### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,5 +1,5 @@
-version: 2.0
+version: 3.0
 organization: Land
-product : automatisk-generalisering
+product: Automatisk generalisering
 repo_types: [Tool]
 platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "automatisk-generalisering"
+  tags:
+  - "private"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "n50"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_automatisk-generalisering"
+  title: "Security Champion automatisk-generalisering"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "EllingOftedalKV"
+  children:
+  - "resource:automatisk-generalisering"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "automatisk-generalisering"
+  links:
+  - url: "https://github.com/kartverket/automatisk-generalisering"
+    title: "automatisk-generalisering på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_automatisk-generalisering"
+  dependencyOf:
+  - "component:automatisk-generalisering"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Land`
- `product: Automatisk generalisering`
- `repo_types: [Tool]`
- `platforms: [LOKALT]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.