### PR TITLE
Add final output path generation in base file manager

### DIFF
--- a/env_setup/environment_setup.py
+++ b/env_setup/environment_setup.py
@@ -3,6 +3,7 @@ import os
 
 import config
 from env_setup.global_config import (
+    final_outputs,
     scale_n50,
     scale_n100,
     scale_n250,
@@ -129,6 +130,7 @@ class ProjectDirectorySetup:
             scale_n500,
         ]
         self.gdb_names = [
+            final_outputs,
             object_admin,
             object_arealdekke_flate,
             object_bygning,

--- a/env_setup/global_config.py
+++ b/env_setup/global_config.py
@@ -1,3 +1,4 @@
+final_outputs = "final_outputs"
 scale_n50 = "n50"
 scale_n100 = "n100"
 scale_n250 = "n250"

--- a/file_manager/base_file_manager.py
+++ b/file_manager/base_file_manager.py
@@ -59,6 +59,7 @@ class BaseFileManager:
         self.relative_path_gdb = rf"{self.local_root_directory}\{self.project_root_directory}\{self.scale}\{self.object}.gdb"
         self.relative_path_general_files = rf"{self.local_root_directory}\{self.project_root_directory}\{self.scale}\{self.general_files_directory_name}"
         self.relative_path_lyrx = rf"{self.local_root_directory}\{self.project_root_directory}\{self.scale}\{self.lyrx_directory_name}"
+        self.relative_path_final_outputs = rf"{self.local_root_directory}\{self.project_root_directory}\{self.scale}\{env_setup.global_config.final_outputs}"
 
     @property
     def script_source_name(self):
@@ -165,3 +166,19 @@ class BaseFileManager:
         """
         self.validate_name_and_description(script_source_name, description)
         return rf"{self.relative_path_lyrx}\{script_source_name}___{description}___{self.scale}_{self.object}.lyrx"
+
+    def generate_final_outputs(
+        self,
+        file_name: str,
+    ):
+        """
+        Generates a file path for geodatabase (.gdb) files for the final output files. After validating the input.
+
+        Args:
+            file_name (str): The name of the file name for the final output file.
+
+        Returns:
+            str: The absolute path for the .gdb file.
+        """
+        self.validate_name_and_description(file_name)
+        return rf"{self.relative_path_final_outputs}\{file_name}"


### PR DESCRIPTION
A new method, `generate_final_outputs(),` was added to the base file manager to create paths for final output .gdb files. The `relative_path_final_outputs` attribute was also integrated, and `final_outputs` was added to the environment setup and global config files. This ensures efficient and structured management of final output file paths.