### PR TITLE
552 systematize repair geometry

### DIFF
--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -51,8 +51,8 @@ def remove_polygon_islands(output_feature_class):
 class GeometryValidator:
     def __init__(
         self,
-        input_features: Union[Dict[str, str], str],
-        output_table_path: str,
+        input_features: Union[Dict[str, str], str] = None,
+        output_table_path: str = None,
     ):
         self.input_features = input_features
         self.output_table_path = output_table_path
@@ -125,9 +125,13 @@ class GeometryValidator:
         input_param_names=["input_features"],
         output_param_names=None,
     )
-    def check_repair_sequence(self, max_iterations=2):
+    def check_repair_sequence(self, input_fc: str = None, max_iterations=2):
         """Run the check-repair-check sequence until no issues remain or max iterations reached."""
         self.iteration = 0
+
+        if input_fc:
+            self.input_features = input_fc
+
         while self.iteration < max_iterations:
             print(f"--- Iteration {self.iteration + 1} ---")
             self.check_geometry()

--- a/generalization/n10/arealdekke/orchestrator/arealdekke_class.py
+++ b/generalization/n10/arealdekke/orchestrator/arealdekke_class.py
@@ -4,7 +4,6 @@ import yaml
 from composition_configs import core_config
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
-from input_data import input_n10, input_test_data
 from generalization.n10.arealdekke.orchestrator.category_class import Category
 from custom_tools.decorators.timing_decorator import timing_decorator
 
@@ -37,7 +36,7 @@ arcpy.env.overwriteOutput = True
 
 class Arealdekke:
 
-    def __init__(self, map_scale) -> None:
+    def __init__(self, input_data: str, map_scale: str) -> None:
 
         # Setting up file manager w. dictionary for easy file access
         self.working_fc = (
@@ -69,7 +68,7 @@ class Arealdekke:
 
         # Extracts the data and saves it in the object
         arcpy.management.CopyFeatures(
-            in_features=input_test_data.arealdekke,  # input_n10.Arealdekke_Buskerud,
+            in_features=input_data,
             out_feature_class=self.files["arealdekke_fc"],
         )
 

--- a/generalization/n10/arealdekke/orchestrator/orchestrator_copy.py
+++ b/generalization/n10/arealdekke/orchestrator/orchestrator_copy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from arealdekke_class import Arealdekke
 from env_setup import environment_setup
 from custom_tools.decorators.timing_decorator import timing_decorator
+from input_data import input_n10, input_test_data
 
 
 @timing_decorator
@@ -10,7 +11,8 @@ def main():
     environment_setup.main()
 
     # Creates an instance of the arealdekke object.
-    arealdekke = Arealdekke("N10")
+    input_data = input_test_data.arealdekke_1
+    arealdekke = Arealdekke(input_data=input_data, map_scale="N10")
 
     arealdekke.preprocess()
 

--- a/generalization/n10/arealdekke/overall_tools/arealdekke_dissolver.py
+++ b/generalization/n10/arealdekke/overall_tools/arealdekke_dissolver.py
@@ -9,6 +9,7 @@ from input_data import input_n10
 from env_setup import environment_setup
 
 from custom_tools.general_tools.partition_iterator import PartitionIterator
+from custom_tools.general_tools.geometry_tools import GeometryValidator
 
 from collections import defaultdict
 
@@ -33,6 +34,8 @@ class ArealdekkeDissolver:
         self.output_feature = areal_dekke_dissolver_config.output_feature
 
         self.index_col = areal_dekke_dissolver_config.index_column_name
+
+        self.geometry_validator = GeometryValidator()
 
         self.wfm = WorkFileManager(
             config=areal_dekke_dissolver_config.work_file_manager_config
@@ -339,20 +342,14 @@ class ArealdekkeDissolver:
                 arcpy.management.DeleteField(without_data, field)
 
     @timing_decorator
-    def repair_geom(self):
-        arcpy.management.RepairGeometry(
-            in_features=self.output_feature,
-            delete_null="DELETE_NULL",
-            validation_method="ESRI",
-        )
-
-    @timing_decorator
     def run(self) -> None:
         environment_setup.main()
         self.fetch_divide_data()
         self.dissolve()
         self.restore_data()
-        self.repair_geom()
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.output_feature, max_iterations=5
+        )
         self.wfm.delete_created_files()
 
 

--- a/generalization/n10/arealdekke/overall_tools/eliminate_small_polygons.py
+++ b/generalization/n10/arealdekke/overall_tools/eliminate_small_polygons.py
@@ -4,6 +4,7 @@ from custom_tools.decorators.timing_decorator import timing_decorator
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 from env_setup import environment_setup
+from custom_tools.general_tools.geometry_tools import GeometryValidator
 from custom_tools.general_tools.partition_iterator import PartitionIterator
 from composition_configs import core_config, logic_config
 from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
@@ -40,6 +41,8 @@ class EliminateSmallPolygons:
         )
 
         self.files = self._create_wfm_gdbs(self.wfm)
+
+        self.geometry_validator = GeometryValidator()
 
     def _create_wfm_gdbs(self, wfm: WorkFileManager) -> dict:
         eliminate_input = wfm.build_file_path(
@@ -221,6 +224,10 @@ class EliminateSmallPolygons:
             selection="LENGTH",
         )
 
+        self.geometry_validator.check_repair_sequence(
+            input_fc=output_fc, max_iterations=5
+        )
+
     @timing_decorator
     def _buffer_potential_spikes(self):
         """Buffer all polygons except water and samferdsel to remove spikes"""
@@ -257,15 +264,11 @@ class EliminateSmallPolygons:
             erase_features=self.files["eliminate_selected_positive_buffers"],
             out_feature_class=self.files["eliminate_erased"],
         )
-        arcpy.management.RepairGeometry(
-            in_features=self.files["eliminate_erased"],
-            delete_null="DELETE_NULL",
-            validation_method="ESRI",
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.files["eliminate_clipped"], max_iterations=5
         )
-        arcpy.management.RepairGeometry(
-            in_features=self.files["eliminate_clipped"],
-            delete_null="DELETE_NULL",
-            validation_method="ESRI",
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.files["eliminate_erased"], max_iterations=5
         )
 
         arcpy.management.MultipartToSinglepart(
@@ -287,10 +290,8 @@ class EliminateSmallPolygons:
 
         self.add_fields(self.files["eliminate_merged_clipped_erased"])
 
-        arcpy.management.RepairGeometry(
-            in_features=self.files["eliminate_merged_clipped_erased"],
-            delete_null="DELETE_NULL",
-            validation_method="ESRI",
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.files["eliminate_merged_clipped_erased"], max_iterations=5
         )
 
         quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.dont_remove_spikes)
@@ -452,10 +453,8 @@ class EliminateSmallPolygons:
             in_features=self.files["eliminate_final_elim_merged"],
             out_feature_class=self.output_feature,
         )
-        arcpy.management.RepairGeometry(
-            in_features=self.output_feature,
-            delete_null="DELETE_NULL",
-            validation_method="ESRI",
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.output_feature, max_iterations=5
         )
 
         self.wfm.delete_created_files()

--- a/generalization/n10/arealdekke/overall_tools/gangsykkel_dissolver.py
+++ b/generalization/n10/arealdekke/overall_tools/gangsykkel_dissolver.py
@@ -14,6 +14,7 @@ from generalization.n10.arealdekke.overall_tools.eliminate_small_polygons import
 )
 from collections import defaultdict
 from pathlib import Path
+from custom_tools.general_tools.geometry_tools import GeometryValidator
 from custom_tools.general_tools.param_utils import initialize_params
 from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
     GangSykkelDissolverParameters,
@@ -48,6 +49,8 @@ class GangSykkelDissolver:
             map_scale=self.map_scale,
             dataclass=GangSykkelDissolverParameters,
         )
+
+        self.geometry_validator = GeometryValidator()
 
     def _create_wfm_gdbs(self, wfm: WorkFileManager) -> dict:
         gangsykkel_input = wfm.build_file_path(
@@ -260,14 +263,18 @@ class GangSykkelDissolver:
             output=self.files["gangsykkel_final_merge"],
         )
 
-        arcpy.management.RepairGeometry(self.files["gangsykkel_final_merge"])
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.files["gangsykkel_final_merge"], max_iterations=5
+        )
 
         arcpy.management.MultipartToSinglepart(
             in_features=self.files["gangsykkel_final_merge"],
             out_feature_class=self.files["gangsykkel_final_merge_singlepart"],
         )
 
-        arcpy.management.RepairGeometry(self.files["gangsykkel_final_merge_singlepart"])
+        self.geometry_validator.check_repair_sequence(
+            input_fc=self.files["gangsykkel_final_merge_singlepart"], max_iterations=5
+        )
 
         gangsykkel_final_merge_singlepart_lyr = (
             "layer_gangsykkel_final_merge_singlepart_lyr"
@@ -356,14 +363,18 @@ class GangSykkelDissolver:
             out_feature_class=paths["clip_path"],
         )
 
-        arcpy.management.RepairGeometry(in_features=paths["clip_path"])
+        self.geometry_validator.check_repair_sequence(
+            input_fc=paths["clip_path"], max_iterations=5
+        )
 
         arcpy.management.MultipartToSinglepart(
             in_features=paths["clip_path"],
             out_feature_class=paths["singlepart_clipped_path"],
         )
 
-        arcpy.management.RepairGeometry(in_features=paths["singlepart_clipped_path"])
+        self.geometry_validator.check_repair_sequence(
+            input_fc=paths["singlepart_clipped_path"], max_iterations=5
+        )
 
         arcpy.analysis.Erase(
             in_features=current_gangsykkel,
@@ -371,14 +382,18 @@ class GangSykkelDissolver:
             out_feature_class=paths["erased_path"],
         )
 
-        arcpy.management.RepairGeometry(in_features=paths["erased_path"])
+        self.geometry_validator.check_repair_sequence(
+            input_fc=paths["erased_path"], max_iterations=5
+        )
 
         arcpy.management.MultipartToSinglepart(
             in_features=paths["erased_path"],
             out_feature_class=paths["singlepart_erased_path"],
         )
 
-        arcpy.management.RepairGeometry(in_features=paths["singlepart_erased_path"])
+        self.geometry_validator.check_repair_sequence(
+            input_fc=paths["singlepart_erased_path"], max_iterations=5
+        )
 
         return (
             paths["buf_path"],


### PR DESCRIPTION
Rewritten GeometryValidation class to not necessary need input, but possible to initialize without in- and output data.
The iterative function call to check and repair geometry is rewritten to have a possible input instead of the data stored in the element itself.

Functionality relevant for the land use pipeline has implemented this class as a geometry controller during the generalization process.