### PR TITLE
Line Gap Topology Tool

### DIFF
--- a/composition_configs/__init__.py
+++ b/composition_configs/__init__.py
@@ -1,8 +1,10 @@
 from importlib import import_module
 
+# Order matters: logic_config imports type_defs and io_types from this package
+# at module load time, so they must be bound as package attributes first.
 core_config = import_module(".core_config", __name__)
-logic_config = import_module(".logic_config", __name__)
 type_defs = import_module(".type_defs", __name__)
 io_types = import_module(".io_types", __name__)
+logic_config = import_module(".logic_config", __name__)
 
 __all__ = ["core_config", "logic_config", "type_defs", "io_types"]

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -193,11 +193,6 @@ class EditMethod(str, Enum):
     FORCED_EXTEND = "forced_extend"
 
 
-class EditOp(str, Enum):
-    SNAP = "snap"
-    EXTEND = "extend"
-
-
 class ConnectivityScope(str, Enum):
     NONE = "none"
     DIRECT_CONNECTION = "direct"

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -340,11 +340,13 @@ class FillLineGapsAngleConfig:
         (flow runs start to end). Angle comparisons use directional difference (0 to 180
         degrees) and src_target_diff as the primary metric for line-to-line pairs.
         Requires best_fit_weights.angle > 0 on FillLineGapsConfig (enforced at init).
-    dangle_pair_apply_connector_diff: when True and lines_are_directed is also True,
-        the angle metric for a valid end-to-start dangle pair uses
-        max(src_target_diff, src_connector_diff) instead of src_target_diff alone.
-        This penalises candidates whose connector direction is poor even when target
-        alignment is good. Has no effect when lines_are_directed is False.
+    connector_angle_diff_required_above_meters: when set, the angle metric for a
+        valid end-to-start dangle pair uses max(src_target_diff, src_connector_diff)
+        instead of src_target_diff alone, but only when the source dangle is farther
+        than this many metres from the target dangle's parent line. Below the
+        threshold src_target_diff alone is used. Set to 0 to always apply the
+        penalty for any dangle pair. None (default) disables the penalty entirely.
+        Has no effect when lines_are_directed is False.
     """
 
     angle_block_threshold_degrees: Optional[float] = None
@@ -360,7 +362,7 @@ class FillLineGapsAngleConfig:
     angle_local_half_window_m: float = 2.0
     connect_to_features_angle_mode: Optional[dict[str, AngleTargetMode]] = None
     lines_are_directed: bool = False
-    dangle_pair_apply_connector_diff: bool = False
+    connector_angle_diff_required_above_meters: Optional[float] = None
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -302,6 +302,36 @@ class BestFitWeightsConfig:
     z: float = 0.0
 
 
+class SourceDirectionMode(str, Enum):
+    """
+    Controls how FillLineGaps interprets the digitization direction of source lines
+    when computing angle metrics for candidate scoring and blocking.
+
+    UNDIRECTED
+        Default. Lines have no guaranteed direction. Angle comparisons use
+        orientation-diff (0–90°) and src_connector_diff as the metric.
+        This is the original behavior.
+
+    PRE_ORIENTED
+        The user guarantees that all input lines (and any line-like
+        connect_to_features) are already oriented correctly (e.g. flow goes
+        from start to end). No orientation step is run. Angle comparisons use
+        directional-diff (0–180°) and src_target_diff as the metric for all
+        line-to-line pairs.
+
+    RASTER_DERIVED
+        FillLineGaps orients the working copy of input lines (and any line-like
+        connect_to_features copies) using LineZOrientTool before building the
+        gap-fill plan. Requires raster_paths to be set. After orientation,
+        directional semantics apply as in PRE_ORIENTED.
+        Requires min_z_drop_meters to be set in FillLineGapsAdvancedConfig.
+    """
+
+    UNDIRECTED = "undirected"
+    PRE_ORIENTED = "pre_oriented"
+    RASTER_DERIVED = "raster_derived"
+
+
 @dataclass(frozen=True)
 class FillLineGapsAdvancedConfig:
     fill_gaps_on_self: bool = True
@@ -334,6 +364,21 @@ class FillLineGapsAdvancedConfig:
     # Keying recommendation:
     # - support keys by original connect_to_features path OR by dataset_key(path)
     connect_to_features_angle_mode: Optional[dict[str, AngleTargetMode]] = None
+
+    # ----------------------------
+    # Source line direction
+    # ----------------------------
+
+    # Controls whether lines are treated as undirected, assumed already oriented,
+    # or oriented by raster elevation before gap-filling.
+    # See SourceDirectionMode for full semantics.
+    # When RASTER_DERIVED: raster_paths must be set and min_z_drop_meters applies.
+    # When not UNDIRECTED: best_fit_weights.angle must be > 0 (enforced at init).
+    source_direction_mode: SourceDirectionMode = SourceDirectionMode.UNDIRECTED
+
+    # Minimum elevation drop (metres) required for LineZOrientTool to commit a flip.
+    # Only used when source_direction_mode == RASTER_DERIVED.
+    min_z_drop_meters: float = 0.5
 
     # ----------------------------
     # Z / elevation layer

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -276,6 +276,27 @@ class LandUseInitKwargs:
 
 
 @dataclass(frozen=True)
+class BestFitWeightsConfig:
+    """
+    Normalized weights for composite best-fit candidate scoring.
+
+    Each weight is a non-negative scalar. The composite score for a candidate is:
+
+        score = distance * norm_dist + angle * norm_angle + z * norm_z
+
+    where norm_* are each normalized to [0, 1] relative to their natural range
+    (distance: gap_tolerance_meters; angle: 90 degrees; z: reserved).
+
+    Default (distance=1.0, angle=0.0, z=0.0) produces pure nearest-distance ranking,
+    identical to the behavior before angle weighting was introduced.
+    """
+
+    distance: float = 1.0
+    angle: float = 0.0
+    z: float = 0.0
+
+
+@dataclass(frozen=True)
 class FillLineGapsAdvancedConfig:
     fill_gaps_on_self: bool = True
     line_changes_output: Optional[str] = None
@@ -292,10 +313,11 @@ class FillLineGapsAdvancedConfig:
     # ----------------------------
     angle_block_threshold_degrees: Optional[float] = None
     angle_extra_dangle_threshold_degrees: Optional[float] = None
-    angle_penalty_max_meters: Optional[float] = None
 
     # 0..1, prefer line alignment a bit more than connector transition
     line_alignment_weight: float = 0.6
+
+    best_fit_weights: BestFitWeightsConfig = field(default_factory=BestFitWeightsConfig)
 
     # Passed to local_line_angle_at_xy(desired_half_window_m=...)
     angle_local_half_window_m: float = 2.0

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -187,25 +187,6 @@ class DissolveInitKwargs:
     sql_expressions: Optional[List[str]] = None
 
 
-class EditMethod(str, Enum):
-    AUTO = "auto"
-    FORCED_SNAP = "forced_snap"
-    FORCED_EXTEND = "forced_extend"
-
-
-class ConnectivityScope(str, Enum):
-    NONE = "none"
-    DIRECT_CONNECTION = "direct"
-    INPUT_LINES = "input_lines"
-    ONE_DEGREE = "one_degree"
-    TRANSITIVE = "transitive"
-
-
-class LineConnectivityMode(str, Enum):
-    ENDPOINTS = "endpoints"
-    INTERSECT = "intersect"
-
-
 @dataclass(frozen=True)
 class ArealDekkeDissolverInitKwargs:
     input_feature: str
@@ -252,6 +233,25 @@ class RiverStrahlerKwargs:
     work_file_manager_config: core_config.WorkFileConfig
     output_processed_feature: io_types.GdbIOArg
     havflate_feature: io_types.GdbIOArg
+
+
+class EditMethod(str, Enum):
+    AUTO = "auto"
+    FORCED_SNAP = "forced_snap"
+    FORCED_EXTEND = "forced_extend"
+
+
+class ConnectivityScope(str, Enum):
+    NONE = "none"
+    DIRECT_CONNECTION = "direct"
+    INPUT_LINES = "input_lines"
+    ONE_DEGREE = "one_degree"
+    TRANSITIVE = "transitive"
+
+
+class LineConnectivityMode(str, Enum):
+    ENDPOINTS = "endpoints"
+    INTERSECT = "intersect"
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -325,6 +325,7 @@ class FillLineGapsAdvancedConfig:
     line_alignment_weight: float = 0.6
 
     best_fit_weights: BestFitWeightsConfig = field(default_factory=BestFitWeightsConfig)
+    best_fit_weights: BestFitWeightsConfig = field(default_factory=BestFitWeightsConfig)
 
     # Passed to local_line_angle_at_xy(desired_half_window_m=...)
     angle_local_half_window_m: float = 2.0

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -318,3 +318,29 @@ class AngleToolConfig:
     field_name_by_mode: Optional[dict[LineAngleMode, str]] = None
     return_results: bool = True
     write_fields: bool = False
+
+
+class LineEndpointMode(str, Enum):
+    START_POINT = "start_point"
+    END_POINT = "end_point"
+    BOTH_ENDPOINTS = "both_endpoints"
+
+
+@dataclass(frozen=True)
+class LineEndpointFieldNameConfig:
+    start_x: str = "start_x"
+    start_y: str = "start_y"
+    end_x: str = "end_x"
+    end_y: str = "end_y"
+
+
+@dataclass(frozen=True)
+class LineEndpointToolConfig:
+    input_lines: str
+    endpoint_modes: tuple[LineEndpointMode, ...]
+    output_lines: Optional[str] = None
+    field_names: LineEndpointFieldNameConfig = field(
+        default_factory=LineEndpointFieldNameConfig
+    )
+    return_results: bool = True
+    write_fields: bool = False

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -386,3 +386,28 @@ class LineEndpointToolConfig:
     )
     return_results: bool = True
     write_fields: bool = False
+
+
+class LineZValueMode(str, Enum):
+    START_POINT = "start_point"
+    END_POINT = "end_point"
+    BOTH_ENDPOINTS = "both_endpoints"
+
+
+@dataclass(frozen=True)
+class LineZValueFieldNameConfig:
+    start_z: str = "start_z"
+    end_z: str = "end_z"
+
+
+@dataclass(frozen=True)
+class LineZValueToolConfig:
+    input_lines: str
+    input_rasters: tuple[str, ...]
+    endpoint_modes: tuple[LineZValueMode, ...]
+    output_lines: Optional[str] = None
+    field_names_per_raster: Optional[tuple[LineZValueFieldNameConfig, ...]] = None
+    # If None and one raster: defaults ("start_z", "end_z").
+    # If None and multiple rasters: auto "start_z_1", "end_z_1", "start_z_2", "end_z_2" …
+    return_results: bool = True
+    write_fields: bool = False

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -400,6 +400,33 @@ class FillLineGapsAdvancedConfig:
     #  -10  → candidate must drop more than 10 m
     z_drop_threshold: Optional[float] = None
 
+    # ----------------------------
+    # Connector crossing check
+    # ----------------------------
+
+    # When True, candidates whose connector geometry crosses an existing feature
+    # (self-lines or connect_to_features) are rejected at Step 1a.  Accepted
+    # connectors are also checked against each other during Kruskal's selection,
+    # and resnap captures are re-checked after their final geometry is resolved.
+    # crossing_check_spatial_reference is required when this is True.
+    reject_crossing_connectors: bool = True
+
+    # Spatial reference used to construct temporary connector geometries for
+    # the crossing check.  Accepts an integer WKID or a .prj file path
+    # (passed directly to arcpy.SpatialReference()).  Only required when
+    # reject_crossing_connectors is True.
+    crossing_check_spatial_reference: "int | str | None" = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.reject_crossing_connectors
+            and self.crossing_check_spatial_reference is None
+        ):
+            raise ValueError(
+                "crossing_check_spatial_reference is required when "
+                "reject_crossing_connectors is True"
+            )
+
 
 @dataclass(frozen=True)
 class FillLineGapsConfig:

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -187,6 +187,17 @@ class DissolveInitKwargs:
     sql_expressions: Optional[List[str]] = None
 
 
+class EditMethod(str, Enum):
+    AUTO = "auto"
+    FORCED_SNAP = "forced_snap"
+    FORCED_EXTEND = "forced_extend"
+
+
+class EditOp(str, Enum):
+    SNAP = "snap"
+    EXTEND = "extend"
+
+
 @dataclass(frozen=True)
 class ArealDekkeDissolverInitKwargs:
     input_feature: str
@@ -259,7 +270,12 @@ class FillLineGapsAdvancedConfig:
     # Effective dangle→dangle cap = gap_tolerance_meters + extra.
     # Use 0 to disable expanded dangle pairing.
     increased_tolerance_edge_case_distance_meters: int = 0
+<<<<<<< HEAD
 >>>>>>> 5aa8c33 (WIP line topolgy gap fix)
+=======
+    # Auto uses snap on dangle pairs and extend for all others
+    edit_method: EditMethod = EditMethod.AUTO
+>>>>>>> c2a0cf4 (Added edit method as param)
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -297,3 +297,22 @@ class FillLineGapsConfig:
     advanced_config: FillLineGapsAdvancedConfig = field(
         default_factory=FillLineGapsAdvancedConfig
     )
+
+
+class LineAngleMode(str, Enum):
+    WHOLE_LINE = "whole_line"
+    START_SEGMENT = "start_segment"
+    END_SEGMENT = "end_segment"
+    BOTH_ENDPOINT_SEGMENTS = "both_endpoint_segments"
+    START_TO_MIDPOINT = "start_to_midpoint"
+    END_TO_MIDPOINT = "end_to_midpoint"
+
+
+@dataclass(frozen=True)
+class AngleToolConfig:
+    input_lines: str
+    angle_modes: tuple[LineAngleMode, ...]
+    output_lines: Optional[str] = None
+    field_name_by_mode: Optional[dict[LineAngleMode, str]] = None
+    return_results: bool = True
+    write_fields: bool = False

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -422,6 +422,11 @@ class LineZOrientMode(str, Enum):
     NETWORK = "network"
 
 
+class LineZOrientOutletMode(str, Enum):
+    DANGLE_ENDPOINTS = "dangle_endpoints"
+    ANY_ENDPOINT = "any_endpoint"
+
+
 @dataclass(frozen=True)
 class LineZValueFieldNameConfig:
     start_z: str = "start_z"
@@ -446,4 +451,5 @@ class LineZOrientConfig:
     input_lines: str
     raster_paths: RasterPathList
     orientation_mode: LineZOrientMode = LineZOrientMode.INDIVIDUAL
+    outlet_mode: LineZOrientOutletMode = LineZOrientOutletMode.DANGLE_ENDPOINTS
     connectivity_tolerance_meters: float = 0.02

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -342,17 +342,18 @@ class FillLineGapsAngleConfig:
         Requires best_fit_weights.angle > 0 on FillLineGapsConfig (enforced at init).
     connector_angle_diff_required_above_meters: when set, the angle metric at a
         valid end-to-start dangle endpoint snap uses
-        max(src_target_diff, src_connector_diff) instead of src_target_diff
-        alone, but only when the source dangle is farther than this many metres
-        from the target's parent line. The endpoint snap covers both dangle-pair
-        targets (target is another dangle) and dangle-parent-line targets
-        (target is a line whose snap point coincides with one of its own dangle
-        endpoints), since both expose the same end-to-start geometry. Within the
-        threshold src_target_diff alone is used. Set to 0 to always apply the
-        penalty. None (default) disables the penalty entirely. Has no effect
-        when lines_are_directed is False, and is independent of the default
-        max(src_target_diff, src_connector_diff) metric used for line-like
-        targets that are not endpoint snaps.
+        max(src_target_diff, src_connector_diff, connector_target_diff) instead
+        of src_target_diff alone, but only when the source dangle is farther
+        than this many metres from the target's parent line. The endpoint snap
+        covers both dangle-pair targets (target is another dangle) and
+        dangle-parent-line targets (target is a line whose snap point coincides
+        with one of its own dangle endpoints), since both expose the same
+        end-to-start geometry. Within the threshold src_target_diff alone is
+        used. Set to 0 to always apply the penalty. None (default) disables the
+        penalty entirely. Has no effect when lines_are_directed is False, and
+        is independent of the default
+        max(src_target_diff, src_connector_diff, connector_target_diff) metric
+        used for line-like targets that are not endpoint snaps.
     """
 
     angle_block_threshold_degrees: Optional[float] = None

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -340,6 +340,10 @@ class FillLineGapsAdvancedConfig:
     candidate_connections_output: Optional[str] = None
 
     increased_tolerance_edge_case_distance_meters: int = 0
+    # When True, the edge-case distance bonus is only applied when both source and target
+    # dangles mutually prefer each other's parent line. Defaults to False — the angle gate
+    # (angle_extra_dangle_threshold_degrees) is the primary guard.
+    require_mutual_dangle_preference_for_bonus: bool = False
     edit_method: EditMethod = EditMethod.AUTO
     connectivity_scope: ConnectivityScope = ConnectivityScope.DIRECT_CONNECTION
     connectivity_tolerance_meters: float = 0.02

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -303,6 +303,21 @@ class BestFitWeightsConfig:
     z: float = 0.0
 
 
+class DiagnosticDetail(Enum):
+    """Fidelity tier for the candidate diagnostics output.
+
+    OFF: skip per-candidate diagnostic collection entirely. Equivalent in
+        effect to setting candidate_connections_output=None, but lets a
+        caller keep the output path configured (e.g. wired via the file
+        manager) while disabling diagnostics for a specific run.
+    FULL: current behavior — one record per evaluated dangle/target pair,
+        with scoring detail.
+    """
+
+    OFF = "off"
+    FULL = "full"
+
+
 @dataclass(frozen=True)
 class FillLineGapsOutputConfig:
     """
@@ -315,11 +330,16 @@ class FillLineGapsOutputConfig:
     candidate_connections_output: path to write the full candidate diagnostics feature
         class (one POLYLINE row per evaluated dangle/target pair, with scoring detail).
         None disables candidate collection entirely, skipping all diagnostic assembly.
+    diagnostic_detail: fidelity tier when candidate_connections_output is set. Default
+        FULL preserves prior behavior. OFF skips collection entirely even if an output
+        path is configured, useful for callers that want to keep the path wired but
+        disable diagnostics for a specific run.
     """
 
     line_changes_output: Optional[str] = None
     write_output_metadata: bool = False
     candidate_connections_output: Optional[str] = None
+    diagnostic_detail: DiagnosticDetail = DiagnosticDetail.FULL
 
 
 @dataclass(frozen=True)
@@ -469,11 +489,64 @@ class FillLineGapsAdvancedConfig:
         is only applied when both source and target dangles mutually prefer each other's
         parent line. When False (default) the angle gate
         (angle_extra_dangle_threshold_degrees) is the sole guard.
+    candidate_closest_count: caps the number of near targets retained per source
+        dangle when generating the candidate near table (and the resnap near table,
+        which is conceptually the same kind of query against forced-parent line
+        segments). Default 100. Under heavy segmentation at a large search radius
+        the cap is often saturated; raise to capture more candidates at memory cost,
+        lower to bound near-table size on memory-constrained systems.
+    connectivity_closest_count: caps adjacencies per endpoint for the connectivity
+        near table. The connectivity tolerance is typically tiny (xy_tolerance), so
+        the cap is rarely hit; included for symmetry with candidate_closest_count and
+        for future-proofing. Default 100.
     """
 
     edit_method: EditMethod = EditMethod.AUTO
     increased_tolerance_edge_case_distance_meters: int = 0
     require_mutual_dangle_preference_for_bonus: bool = False
+    candidate_closest_count: int = 100
+    connectivity_closest_count: int = 100
+
+
+class SegmentationMode(Enum):
+    EVEN = "even"
+    FIXED = "fixed"
+
+
+@dataclass(frozen=True)
+class SegmentationConfig:
+    """
+    Internal segmentation of input_lines and line-like connect_to_features for
+    use in the candidate near table only. Other phases (TopologyBuilder,
+    connectivity, crossing checks, polyline caches, edits, output) operate on
+    the unsegmented originals.
+
+    The candidate near table benefits from short segments because GenerateNearTable
+    measures distance to the closest segment; on long target features the closest
+    point on the whole feature can be far from the actual best connection point.
+    Segmenting only the targets used by that table preserves the precision win
+    without paying the segmentation cost in every other phase.
+
+    Polygon connect_to_features are NOT supported when segmentation is enabled.
+    Convert polygons to polylines (e.g. via PolygonToLine) before passing them
+    to FillLineGaps in that case. Polyline and other geometry types pass through;
+    only polylines are actually segmented.
+
+    Setting segmentation=None on FillLineGapsConfig disables internal segmentation
+    entirely; FillLineGaps then uses caller-provided feature classes as today.
+
+    interval_meters: maximum segment length in the input's linear units. Must be > 0.
+    mode: EVEN divides each long line into ceil(L / interval) equal-length pieces.
+        FIXED cuts at fixed interval and emits the remainder as a final segment
+        (subject to tail_tolerance_meters).
+    tail_tolerance_meters: FIXED mode only. When the remainder of a fixed split
+        is <= this value, it is absorbed into the preceding segment instead of
+        emitted on its own. Default 0.0 disables absorption.
+    """
+
+    interval_meters: float
+    mode: SegmentationMode = SegmentationMode.EVEN
+    tail_tolerance_meters: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -503,6 +576,13 @@ class FillLineGapsConfig:
     crossing_config: optional connector crossing rejection and barrier layer settings.
     connectivity_config: optional connectivity detection settings.
     advanced_config: residual tuning parameters (edit method and edge-case bonus).
+    segmentation: optional internal segmentation of input_lines and line-like
+        connect_to_features for use in the candidate near table only. When set,
+        the engine builds segmented copies internally; the caller passes the
+        original (unsegmented) inputs. Polygon connect_to_features are not
+        supported when segmentation is set — convert polygons to polylines
+        externally first. None (default) disables this and uses caller-provided
+        feature classes for all phases.
     """
 
     input_lines: str
@@ -528,6 +608,7 @@ class FillLineGapsConfig:
     advanced_config: FillLineGapsAdvancedConfig = field(
         default_factory=FillLineGapsAdvancedConfig
     )
+    segmentation: Optional[SegmentationConfig] = None
 
 
 class LineAngleMode(str, Enum):

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -242,6 +242,7 @@ class EditMethod(str, Enum):
     AUTO = "auto"
     FORCED_SNAP = "forced_snap"
     FORCED_EXTEND = "forced_extend"
+    NEW_LINE = "new_line"
 
 
 class ConnectivityScope(str, Enum):
@@ -455,7 +456,12 @@ class FillLineGapsAdvancedConfig:
 
     edit_method: controls how connectors are applied to input lines. AUTO selects snap
         or extend based on geometry; FORCED_SNAP always snaps; FORCED_EXTEND always
-        extends.
+        extends. NEW_LINE leaves all parent geometries untouched and instead inserts
+        each connector as a new 2-vertex feature in the output, copying the parent
+        line's attributes (except geometry/OID) and setting fill_line_gap_generated=1.
+        Original (non-generated) rows carry fill_line_gap_generated=0. The field is
+        preserved across re-runs: when the input already has it, existing values are
+        not overwritten.
     increased_tolerance_edge_case_distance_meters: additional distance added to
         gap_tolerance_meters when searching for dangle-pair candidates that qualify for
         the edge-case bonus. Zero disables the expanded search radius.

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -247,7 +247,6 @@ class RiverStrahlerKwargs:
 
 
 @dataclass(frozen=True)
-<<<<<<< HEAD
 class AttributeChangerInitKwargs:
     input_feature: str
     output_feature: str
@@ -261,7 +260,9 @@ class LandUseInitKwargs:
     input_feature: str
     output_feature: str
     map_scale: str
-=======
+
+
+@dataclass(frozen=True)
 class FillLineGapsAdvancedConfig:
     fill_gaps_on_self: bool = True
     line_changes_output: Optional[str] = None
@@ -270,12 +271,10 @@ class FillLineGapsAdvancedConfig:
     # Effective dangle→dangle cap = gap_tolerance_meters + extra.
     # Use 0 to disable expanded dangle pairing.
     increased_tolerance_edge_case_distance_meters: int = 0
-<<<<<<< HEAD
->>>>>>> 5aa8c33 (WIP line topolgy gap fix)
-=======
     # Auto uses snap on dangle pairs and extend for all others
     edit_method: EditMethod = EditMethod.AUTO
->>>>>>> c2a0cf4 (Added edit method as param)
+    # decide if lines inherit illegal targets of connected lines
+    propagating_illigal_targets = (True,)
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -302,34 +302,6 @@ class BestFitWeightsConfig:
     z: float = 0.0
 
 
-class SourceDirectionMode(str, Enum):
-    """
-    Controls how FillLineGaps interprets the digitization direction of source lines
-    when computing angle metrics for candidate scoring and blocking.
-
-    UNDIRECTED
-        Default. Lines have no guaranteed direction. Angle comparisons use
-        orientation-diff (0–90°) and src_connector_diff as the metric.
-        This is the original behavior.
-
-    PRE_ORIENTED
-        The user guarantees that all input lines (and any line-like
-        connect_to_features) are already oriented correctly (e.g. flow goes
-        from start to end). No orientation step is run. Angle comparisons use
-        directional-diff (0–180°) and src_target_diff as the metric for all
-        line-to-line pairs.
-
-    RASTER_DERIVED
-        FillLineGaps orients the working copy of input lines (and any line-like
-        connect_to_features copies) using LineZOrientTool before building the
-        gap-fill plan. Requires raster_paths to be set. After orientation,
-        directional semantics apply as in PRE_ORIENTED.
-        Requires min_anchor_z_drop_meters to be set in FillLineGapsAdvancedConfig.
-    """
-
-    UNDIRECTED = "undirected"
-    PRE_ORIENTED = "pre_oriented"
-    RASTER_DERIVED = "raster_derived"
 
 
 @dataclass(frozen=True)
@@ -373,30 +345,21 @@ class FillLineGapsAdvancedConfig:
     # Source line direction
     # ----------------------------
 
-    # Controls whether lines are treated as undirected, assumed already oriented,
-    # or oriented by raster elevation before gap-filling.
-    # See SourceDirectionMode for full semantics.
-    # When RASTER_DERIVED: raster_paths must be set and min_anchor_z_drop_meters applies.
-    # When not UNDIRECTED: best_fit_weights.angle must be > 0 (enforced at init).
-    source_direction_mode: SourceDirectionMode = SourceDirectionMode.UNDIRECTED
+    # When True the caller guarantees that all input lines (and any line-like
+    # connect_to_features) are already oriented correctly (e.g. flow runs from
+    # start to end).  Angle comparisons use directional-diff (0–180°) and
+    # src_target_diff as the metric for all line-to-line pairs.
+    # When True, best_fit_weights.angle must be > 0 (enforced at init).
+    # When False (default), lines are treated as undirected.
+    lines_are_directed: bool = False
 
-    # When True and source_direction_mode is directional, the angle metric for a
-    # valid end→start dangle-to-dangle candidate uses max(src_target_diff,
-    # src_connector_diff) instead of src_target_diff alone.  This penalises
-    # candidates whose connector direction is poor even when target alignment is
-    # good, affecting blocking, extra-dangle eligibility, and score weighting.
-    # Has no effect in UNDIRECTED mode.
+    # When True and lines_are_directed, the angle metric for a valid end→start
+    # dangle-to-dangle candidate uses max(src_target_diff, src_connector_diff)
+    # instead of src_target_diff alone.  This penalises candidates whose connector
+    # direction is poor even when target alignment is good, affecting blocking,
+    # extra-dangle eligibility, and score weighting.
+    # Has no effect when lines_are_directed is False.
     dangle_pair_apply_connector_diff: bool = False
-
-    # Minimum elevation drop (metres) required to classify a line as a network anchor.
-    # Only used when source_direction_mode == RASTER_DERIVED.
-    min_anchor_z_drop_meters: float = 0.5
-
-    # When set, a line will only be flipped if it is NOT backed by a confident network
-    # context AND its own Z drop is below this value.  Lines in components that have at
-    # least one anchor are still flipped freely via network propagation.
-    # Defaults to None (no extra guard — behaves identically to the old min_z_drop_meters).
-    min_confident_flip_meters: Optional[float] = None
 
     # ----------------------------
     # Z / elevation layer

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -254,6 +254,11 @@ class LineConnectivityMode(str, Enum):
     INTERSECT = "intersect"
 
 
+class AngleTargetMode(str, Enum):
+    AUTO = "auto"
+    FORCE_NON_LINE = "force_non_line"
+
+
 @dataclass(frozen=True)
 class AttributeChangerInitKwargs:
     input_feature: str
@@ -275,16 +280,29 @@ class FillLineGapsAdvancedConfig:
     fill_gaps_on_self: bool = True
     line_changes_output: Optional[str] = None
 
-    # Extra meters added ONLY when considering dangle→dangle candidates.
-    # Effective dangle→dangle cap = gap_tolerance_meters + extra.
-    # Use 0 to disable expanded dangle pairing.
     increased_tolerance_edge_case_distance_meters: int = 0
-    # Auto uses snap on dangle pairs and extend for all others
     edit_method: EditMethod = EditMethod.AUTO
-    # decide if lines inherit illegal targets of connected lines
     connectivity_scope: ConnectivityScope = ConnectivityScope.DIRECT_CONNECTION
     connectivity_tolerance_meters: float = 0.02
     line_connectivity_mode: LineConnectivityMode = LineConnectivityMode.ENDPOINTS
+
+    # ----------------------------
+    # Angle layer
+    # ----------------------------
+    angle_block_threshold_degrees: Optional[float] = None
+    angle_extra_dangle_threshold_degrees: Optional[float] = None
+    angle_penalty_max_meters: Optional[float] = None
+
+    # 0..1, prefer line alignment a bit more than connector transition
+    line_alignment_weight: float = 0.6
+
+    # Passed to local_line_angle_at_xy(desired_half_window_m=...)
+    angle_local_half_window_m: float = 2.0
+
+    # Optional overrides per external target (connect_to_features)
+    # Keying recommendation:
+    # - support keys by original connect_to_features path OR by dataset_key(path)
+    connect_to_features_angle_mode: Optional[dict[str, AngleTargetMode]] = None
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import (
     Any,
     Dict,
@@ -9,7 +10,7 @@ from typing import (
     Union,
 )
 
-from composition_configs import core_config, io_types
+from composition_configs import core_config, io_types, type_defs
 
 RasterPathList: TypeAlias = tuple[type_defs.RasterFilePath, ...]
 
@@ -383,7 +384,6 @@ class FillLineGapsAngleConfig:
     # 0..1, prefer line alignment a bit more than connector transition
     line_alignment_weight: float = 0.6
 
-    best_fit_weights: BestFitWeightsConfig = field(default_factory=BestFitWeightsConfig)
     best_fit_weights: BestFitWeightsConfig = field(default_factory=BestFitWeightsConfig)
 
     # Passed to local_line_angle_at_xy(desired_half_window_m=...)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -279,6 +279,7 @@ class LandUseInitKwargs:
 class FillLineGapsAdvancedConfig:
     fill_gaps_on_self: bool = True
     line_changes_output: Optional[str] = None
+    write_output_metadata: bool = False
 
     increased_tolerance_edge_case_distance_meters: int = 0
     edit_method: EditMethod = EditMethod.AUTO

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -301,6 +301,7 @@ class FillLineGapsAdvancedConfig:
     fill_gaps_on_self: bool = True
     line_changes_output: Optional[str] = None
     write_output_metadata: bool = False
+    candidate_connections_output: Optional[str] = None
 
     increased_tolerance_edge_case_distance_meters: int = 0
     edit_method: EditMethod = EditMethod.AUTO

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -198,6 +198,19 @@ class EditOp(str, Enum):
     EXTEND = "extend"
 
 
+class ConnectivityScope(str, Enum):
+    NONE = "none"
+    DIRECT_CONNECTION = "direct"
+    INPUT_LINES = "input_lines"
+    ONE_DEGREE = "one_degree"
+    TRANSITIVE = "transitive"
+
+
+class LineConnectivityMode(str, Enum):
+    ENDPOINTS = "endpoints"
+    INTERSECT = "intersect"
+
+
 @dataclass(frozen=True)
 class ArealDekkeDissolverInitKwargs:
     input_feature: str
@@ -274,7 +287,9 @@ class FillLineGapsAdvancedConfig:
     # Auto uses snap on dangle pairs and extend for all others
     edit_method: EditMethod = EditMethod.AUTO
     # decide if lines inherit illegal targets of connected lines
-    propagating_illigal_targets = (True,)
+    connectivity_scope: ConnectivityScope = ConnectivityScope.DIRECT_CONNECTION
+    connectivity_tolerance_meters: float = 0.02
+    line_connectivity_mode: LineConnectivityMode = LineConnectivityMode.ENDPOINTS
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -11,9 +11,6 @@ from typing import (
 
 from composition_configs import core_config, io_types
 
-# Ordered collection of pre-scoped raster tile paths.
-# Produced by find_rasters_for_vector_extent; consumed by FillLineGapsAdvancedConfig
-# and LineZValueToolConfig.
 RasterPathList: TypeAlias = tuple[type_defs.RasterFilePath, ...]
 
 
@@ -293,8 +290,11 @@ class BestFitWeightsConfig:
     where norm_* are each normalized to [0, 1] relative to their natural range
     (distance: gap_tolerance_meters; angle: 90 degrees; z: reserved).
 
-    Default (distance=1.0, angle=0.0, z=0.0) produces pure nearest-distance ranking,
-    identical to the behavior before angle weighting was introduced.
+    distance: weight applied to normalized distance. Default 1.0.
+    angle: weight applied to normalized angle difference. Has no scoring effect unless
+        FillLineGapsAngleConfig is active. Default 0.0.
+    z: weight applied to normalized Z difference. Has no scoring effect unless
+        FillLineGapsZConfig is active. Default 0.0.
     """
 
     distance: float = 1.0
@@ -302,28 +302,51 @@ class BestFitWeightsConfig:
     z: float = 0.0
 
 
-
-
 @dataclass(frozen=True)
-class FillLineGapsAdvancedConfig:
-    fill_gaps_on_self: bool = True
+class FillLineGapsOutputConfig:
+    """
+    Optional diagnostic and metadata outputs produced alongside the main result.
+
+    line_changes_output: path to write a feature class recording each connector added.
+        Each row carries gap_dist_m and gap_source fields. None disables this output.
+    write_output_metadata: when True, appends a metadata summary record to the output
+        feature class after the run completes.
+    candidate_connections_output: path to write the full candidate diagnostics feature
+        class (one POLYLINE row per evaluated dangle/target pair, with scoring detail).
+        None disables candidate collection entirely, skipping all diagnostic assembly.
+    """
+
     line_changes_output: Optional[str] = None
     write_output_metadata: bool = False
     candidate_connections_output: Optional[str] = None
 
-    increased_tolerance_edge_case_distance_meters: int = 0
-    # When True, the edge-case distance bonus is only applied when both source and target
-    # dangles mutually prefer each other's parent line. Defaults to False — the angle gate
-    # (angle_extra_dangle_threshold_degrees) is the primary guard.
-    require_mutual_dangle_preference_for_bonus: bool = False
-    edit_method: EditMethod = EditMethod.AUTO
-    connectivity_scope: ConnectivityScope = ConnectivityScope.DIRECT_CONNECTION
-    connectivity_tolerance_meters: float = 0.02
-    line_connectivity_mode: LineConnectivityMode = LineConnectivityMode.ENDPOINTS
 
-    # ----------------------------
-    # Angle layer
-    # ----------------------------
+@dataclass(frozen=True)
+class FillLineGapsAngleConfig:
+    """
+    Angle-based candidate filtering, scoring, and directional behaviour.
+
+    angle_block_threshold_degrees: candidates whose connector-to-source angle exceeds
+        this threshold are rejected at Step 1b as illegal. None disables the angle gate.
+    angle_extra_dangle_threshold_degrees: relaxed angle threshold applied to dangle-pair
+        candidates that qualify for the edge-case distance bonus. None falls back to
+        angle_block_threshold_degrees.
+    angle_local_half_window_m: half-window in metres passed to local_line_angle_at_xy
+        when computing the source angle at a dangle endpoint.
+    connect_to_features_angle_mode: optional per-dataset override controlling how angles
+        are measured for external target features. Keys are the original
+        connect_to_features path or its dataset_key. Values are AngleTargetMode members.
+    lines_are_directed: when True the caller guarantees all input lines are pre-oriented
+        (flow runs start to end). Angle comparisons use directional difference (0 to 180
+        degrees) and src_target_diff as the primary metric for line-to-line pairs.
+        Requires best_fit_weights.angle > 0 on FillLineGapsConfig (enforced at init).
+    dangle_pair_apply_connector_diff: when True and lines_are_directed is also True,
+        the angle metric for a valid end-to-start dangle pair uses
+        max(src_target_diff, src_connector_diff) instead of src_target_diff alone.
+        This penalises candidates whose connector direction is poor even when target
+        alignment is good. Has no effect when lines_are_directed is False.
+    """
+
     angle_block_threshold_degrees: Optional[float] = None
     angle_extra_dangle_threshold_degrees: Optional[float] = None
 
@@ -335,70 +358,51 @@ class FillLineGapsAdvancedConfig:
 
     # Passed to local_line_angle_at_xy(desired_half_window_m=...)
     angle_local_half_window_m: float = 2.0
-
-    # Optional overrides per external target (connect_to_features)
-    # Keying recommendation:
-    # - support keys by original connect_to_features path OR by dataset_key(path)
     connect_to_features_angle_mode: Optional[dict[str, AngleTargetMode]] = None
-
-    # ----------------------------
-    # Source line direction
-    # ----------------------------
-
-    # When True the caller guarantees that all input lines (and any line-like
-    # connect_to_features) are already oriented correctly (e.g. flow runs from
-    # start to end).  Angle comparisons use directional-diff (0–180°) and
-    # src_target_diff as the metric for all line-to-line pairs.
-    # When True, best_fit_weights.angle must be > 0 (enforced at init).
-    # When False (default), lines are treated as undirected.
     lines_are_directed: bool = False
-
-    # When True and lines_are_directed, the angle metric for a valid end→start
-    # dangle-to-dangle candidate uses max(src_target_diff, src_connector_diff)
-    # instead of src_target_diff alone.  This penalises candidates whose connector
-    # direction is poor even when target alignment is good, affecting blocking,
-    # extra-dangle eligibility, and score weighting.
-    # Has no effect when lines_are_directed is False.
     dangle_pair_apply_connector_diff: bool = False
 
-    # ----------------------------
-    # Z / elevation layer
-    # ----------------------------
 
-    # Pre-scoped raster tile paths (e.g. from find_rasters_for_vector_extent).
-    # FillLineGaps builds RasterHandle objects from these at run() start.
-    # None disables all Z-based logic.
+@dataclass(frozen=True)
+class FillLineGapsZConfig:
+    """
+    Z/elevation-based candidate filtering and scoring.
+
+    raster_paths: ordered tuple of pre-scoped raster tile paths (e.g. from
+        find_rasters_for_vector_extent). FillLineGaps builds RasterHandle objects from
+        these at run() start. None disables all Z-based logic including z_drop_threshold.
+    z_drop_threshold: legality gate on Z drop along a candidate connector. A candidate is
+        rejected when (end_z - start_z) > z_drop_threshold. None disables the gate.
+        Set to 0 to reject any uphill candidate; set to -10 to require a drop of at
+        least 10 m.
+    """
+
     raster_paths: Optional[RasterPathList] = None
-
-    # Legality gate on Z drop along a candidate connector.
-    # A candidate is illegal when (end_z - start_z) > z_drop_threshold.
-    # None disables the gate.
-    #   0   → candidate must run downhill or flat
-    #  -10  → candidate must drop more than 10 m
     z_drop_threshold: Optional[float] = None
 
-    # ----------------------------
-    # Connector crossing check
-    # ----------------------------
 
-    # When True, candidates whose connector geometry crosses an existing feature
-    # (self-lines or connect_to_features) are rejected at Step 1a.  Accepted
-    # connectors are also checked against each other during Kruskal's selection,
-    # and resnap captures are re-checked after their final geometry is resolved.
-    # crossing_check_spatial_reference is required when this is True.
-    reject_crossing_connectors: bool = True
+@dataclass(frozen=True)
+class FillLineGapsCrossingConfig:
+    """
+    Connector crossing rejection and impassable barrier layer settings.
 
-    # Spatial reference used to construct temporary connector geometries for
-    # the crossing check.  Accepts an integer WKID or a .prj file path
-    # (passed directly to arcpy.SpatialReference()).  Required when
-    # reject_crossing_connectors is True or barrier_layers is set.
+    reject_crossing_connectors: when True, candidates whose connector geometry crosses
+        an existing feature (self-lines or connect_to_features) are rejected at Step 1a.
+        Accepted connectors are also checked against each other during Kruskal selection,
+        and resnap captures are re-checked after their final geometry is resolved.
+        Requires crossing_check_spatial_reference.
+    crossing_check_spatial_reference: spatial reference used to construct temporary
+        connector geometries for crossing checks. Accepts an integer WKID or a .prj
+        file path (passed directly to arcpy.SpatialReference()). Required when
+        reject_crossing_connectors is True or barrier_layers is set.
+    barrier_layers: feature layers that act as impassable barriers. Any candidate whose
+        trimmed connector crosses one of these layers is rejected at Step 1a regardless
+        of the reject_crossing_connectors setting. These layers are never used as snap
+        targets. Requires crossing_check_spatial_reference.
+    """
+
+    reject_crossing_connectors: bool = False
     crossing_check_spatial_reference: "int | str | None" = None
-
-    # Feature layers that act as impassable barriers.  Any candidate whose
-    # trimmed connector crosses one of these layers is rejected at Step 1a,
-    # regardless of the reject_crossing_connectors setting.  These layers are
-    # never used as snap targets.  crossing_check_spatial_reference is required
-    # when this is set.
     barrier_layers: "list[str] | None" = None
 
     def __post_init__(self) -> None:
@@ -412,12 +416,100 @@ class FillLineGapsAdvancedConfig:
 
 
 @dataclass(frozen=True)
+class FillLineGapsConnectivityConfig:
+    """
+    Controls how the tool detects existing connections between line endpoints.
+
+    An existing connection between two endpoints means they should not receive a new
+    connector, even if their distance is within gap_tolerance_meters.
+
+    connectivity_scope: determines how far the tool traverses the endpoint graph when
+        deciding whether two endpoints are already connected. NONE skips the check;
+        DIRECT_CONNECTION considers only the immediate pair; INPUT_LINES, ONE_DEGREE,
+        and TRANSITIVE widen the traversal progressively.
+    connectivity_tolerance_meters: snapping tolerance used when building the endpoint
+        connectivity graph.
+    line_connectivity_mode: controls which part of each line participates in connectivity
+        detection. ENDPOINTS checks only start/end vertices; INTERSECT includes any
+        geometric intersection along the line.
+    """
+
+    connectivity_scope: ConnectivityScope = ConnectivityScope.DIRECT_CONNECTION
+    connectivity_tolerance_meters: float = 0.02
+    line_connectivity_mode: LineConnectivityMode = LineConnectivityMode.ENDPOINTS
+
+
+@dataclass(frozen=True)
+class FillLineGapsAdvancedConfig:
+    """
+    Residual tuning parameters that do not belong to a specific themed sub-config.
+
+    edit_method: controls how connectors are applied to input lines. AUTO selects snap
+        or extend based on geometry; FORCED_SNAP always snaps; FORCED_EXTEND always
+        extends.
+    increased_tolerance_edge_case_distance_meters: additional distance added to
+        gap_tolerance_meters when searching for dangle-pair candidates that qualify for
+        the edge-case bonus. Zero disables the expanded search radius.
+    require_mutual_dangle_preference_for_bonus: when True the edge-case distance bonus
+        is only applied when both source and target dangles mutually prefer each other's
+        parent line. When False (default) the angle gate
+        (angle_extra_dangle_threshold_degrees) is the sole guard.
+    """
+
+    edit_method: EditMethod = EditMethod.AUTO
+    increased_tolerance_edge_case_distance_meters: int = 0
+    require_mutual_dangle_preference_for_bonus: bool = False
+
+
+@dataclass(frozen=True)
 class FillLineGapsConfig:
+    """
+    Top-level configuration for FillLineGaps.
+
+    input_lines: path to the input line feature class.
+    output_lines: path where the edited gap-filled line feature class will be written.
+    work_file_manager_config: controls scratch/work file behaviour (root_file,
+        write_to_memory, keep_files).
+    gap_tolerance_meters: maximum connector length in metres; candidates beyond this
+        distance are never considered.
+    connect_to_features: optional list of external feature class paths that act as
+        additional snap targets. When provided, dangles on input_lines may connect to
+        these features as well as to other input_lines dangles.
+    fill_gaps_on_self: when True (default) dangles on input_lines are allowed to connect
+        to other dangles on input_lines. Set to False only when connect_to_features
+        provides all intended targets.
+    best_fit_weights: composite scoring weights controlling how distance, angle, and Z
+        contribute to candidate ranking. The default (distance=1.0, angle=0.0, z=0.0)
+        ranks purely by nearest distance. Angle and Z weights have no scoring effect
+        unless the corresponding sub-configs are also provided.
+    output_config: optional diagnostic and metadata output settings.
+    angle_config: optional angle filtering, scoring, and directional behaviour.
+    z_config: optional Z/elevation filtering and scoring.
+    crossing_config: optional connector crossing rejection and barrier layer settings.
+    connectivity_config: optional connectivity detection settings.
+    advanced_config: residual tuning parameters (edit method and edge-case bonus).
+    """
+
     input_lines: str
     output_lines: str
     work_file_manager_config: core_config.WorkFileConfig
     gap_tolerance_meters: int
     connect_to_features: Optional[list[str]] = None
+    fill_gaps_on_self: bool = True
+    best_fit_weights: BestFitWeightsConfig = field(default_factory=BestFitWeightsConfig)
+    output_config: FillLineGapsOutputConfig = field(
+        default_factory=FillLineGapsOutputConfig
+    )
+    angle_config: FillLineGapsAngleConfig = field(
+        default_factory=FillLineGapsAngleConfig
+    )
+    z_config: FillLineGapsZConfig = field(default_factory=FillLineGapsZConfig)
+    crossing_config: FillLineGapsCrossingConfig = field(
+        default_factory=FillLineGapsCrossingConfig
+    )
+    connectivity_config: FillLineGapsConnectivityConfig = field(
+        default_factory=FillLineGapsConnectivityConfig
+    )
     advanced_config: FillLineGapsAdvancedConfig = field(
         default_factory=FillLineGapsAdvancedConfig
     )

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -340,13 +340,19 @@ class FillLineGapsAngleConfig:
         (flow runs start to end). Angle comparisons use directional difference (0 to 180
         degrees) and src_target_diff as the primary metric for line-to-line pairs.
         Requires best_fit_weights.angle > 0 on FillLineGapsConfig (enforced at init).
-    connector_angle_diff_required_above_meters: when set, the angle metric for a
-        valid end-to-start dangle pair uses max(src_target_diff, src_connector_diff)
-        instead of src_target_diff alone, but only when the source dangle is farther
-        than this many metres from the target dangle's parent line. Below the
+    connector_angle_diff_required_above_meters: when set, the angle metric at a
+        valid end-to-start dangle endpoint snap uses
+        max(src_target_diff, src_connector_diff) instead of src_target_diff
+        alone, but only when the source dangle is farther than this many metres
+        from the target's parent line. The endpoint snap covers both dangle-pair
+        targets (target is another dangle) and dangle-parent-line targets
+        (target is a line whose snap point coincides with one of its own dangle
+        endpoints), since both expose the same end-to-start geometry. Within the
         threshold src_target_diff alone is used. Set to 0 to always apply the
-        penalty for any dangle pair. None (default) disables the penalty entirely.
-        Has no effect when lines_are_directed is False.
+        penalty. None (default) disables the penalty entirely. Has no effect
+        when lines_are_directed is False, and is independent of the default
+        max(src_target_diff, src_connector_diff) metric used for line-like
+        targets that are not endpoint snaps.
     """
 
     angle_block_threshold_degrees: Optional[float] = None

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -422,11 +422,6 @@ class LineZOrientMode(str, Enum):
     NETWORK = "network"
 
 
-class LineZOrientOutletMode(str, Enum):
-    DANGLE_ENDPOINTS = "dangle_endpoints"
-    ANY_ENDPOINT = "any_endpoint"
-
-
 @dataclass(frozen=True)
 class LineZValueFieldNameConfig:
     start_z: str = "start_z"
@@ -451,5 +446,5 @@ class LineZOrientConfig:
     input_lines: str
     raster_paths: RasterPathList
     orientation_mode: LineZOrientMode = LineZOrientMode.INDIVIDUAL
-    outlet_mode: LineZOrientOutletMode = LineZOrientOutletMode.DANGLE_ENDPOINTS
+    min_z_drop_meters: float = 0.5
     connectivity_tolerance_meters: float = 0.02

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -306,6 +306,8 @@ class LineAngleMode(str, Enum):
     BOTH_ENDPOINT_SEGMENTS = "both_endpoint_segments"
     START_TO_MIDPOINT = "start_to_midpoint"
     END_TO_MIDPOINT = "end_to_midpoint"
+    BOTH_ENDPOINT_TO_MIDPOINT = "both_endpoint_to_midpoint"
+    ALL_ANGLES = "all_angles"
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -324,7 +324,7 @@ class SourceDirectionMode(str, Enum):
         connect_to_features copies) using LineZOrientTool before building the
         gap-fill plan. Requires raster_paths to be set. After orientation,
         directional semantics apply as in PRE_ORIENTED.
-        Requires min_z_drop_meters to be set in FillLineGapsAdvancedConfig.
+        Requires min_anchor_z_drop_meters to be set in FillLineGapsAdvancedConfig.
     """
 
     UNDIRECTED = "undirected"
@@ -376,7 +376,7 @@ class FillLineGapsAdvancedConfig:
     # Controls whether lines are treated as undirected, assumed already oriented,
     # or oriented by raster elevation before gap-filling.
     # See SourceDirectionMode for full semantics.
-    # When RASTER_DERIVED: raster_paths must be set and min_z_drop_meters applies.
+    # When RASTER_DERIVED: raster_paths must be set and min_anchor_z_drop_meters applies.
     # When not UNDIRECTED: best_fit_weights.angle must be > 0 (enforced at init).
     source_direction_mode: SourceDirectionMode = SourceDirectionMode.UNDIRECTED
 
@@ -388,9 +388,15 @@ class FillLineGapsAdvancedConfig:
     # Has no effect in UNDIRECTED mode.
     dangle_pair_apply_connector_diff: bool = False
 
-    # Minimum elevation drop (metres) required for LineZOrientTool to commit a flip.
+    # Minimum elevation drop (metres) required to classify a line as a network anchor.
     # Only used when source_direction_mode == RASTER_DERIVED.
-    min_z_drop_meters: float = 0.5
+    min_anchor_z_drop_meters: float = 0.5
+
+    # When set, a line will only be flipped if it is NOT backed by a confident network
+    # context AND its own Z drop is below this value.  Lines in components that have at
+    # least one anchor are still flipped freely via network propagation.
+    # Defaults to None (no extra guard — behaves identically to the old min_z_drop_meters).
+    min_confident_flip_meters: Optional[float] = None
 
     # ----------------------------
     # Z / elevation layer
@@ -434,9 +440,8 @@ class FillLineGapsAdvancedConfig:
 
     def __post_init__(self) -> None:
         if (
-            (self.reject_crossing_connectors or self.barrier_layers is not None)
-            and self.crossing_check_spatial_reference is None
-        ):
+            self.reject_crossing_connectors or self.barrier_layers is not None
+        ) and self.crossing_check_spatial_reference is None:
             raise ValueError(
                 "crossing_check_spatial_reference is required when "
                 "reject_crossing_connectors is True or barrier_layers is set"
@@ -537,5 +542,6 @@ class LineZOrientConfig:
     input_lines: str
     raster_paths: RasterPathList
     orientation_mode: LineZOrientMode = LineZOrientMode.INDIVIDUAL
-    min_z_drop_meters: float = 0.5
+    min_anchor_z_drop_meters: float = 0.5
+    min_confident_flip_meters: Optional[float] = None
     connectivity_tolerance_meters: float = 0.02

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -249,3 +249,14 @@ class LandUseInitKwargs:
     input_feature: str
     output_feature: str
     map_scale: str
+
+
+@dataclass(frozen=True)
+class FillLineGapsConfig:
+    input_lines: str
+    output_lines: str
+    work_file_manager_config: core_config.WorkFileConfig
+    gap_tolerance_meters: int
+    fill_gaps_on_self: bool = True
+    connect_to_features: Optional[list[str]] = None
+    line_changes_output: Optional[str] = None

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -5,10 +5,16 @@ from typing import (
     List,
     Optional,
     Tuple,
+    TypeAlias,
     Union,
 )
 
 from composition_configs import core_config, io_types
+
+# Ordered collection of pre-scoped raster tile paths.
+# Produced by find_rasters_for_vector_extent; consumed by FillLineGapsAdvancedConfig
+# and LineZValueToolConfig.
+RasterPathList: TypeAlias = tuple[type_defs.RasterFilePath, ...]
 
 
 @dataclass(frozen=True)
@@ -327,6 +333,22 @@ class FillLineGapsAdvancedConfig:
     # Keying recommendation:
     # - support keys by original connect_to_features path OR by dataset_key(path)
     connect_to_features_angle_mode: Optional[dict[str, AngleTargetMode]] = None
+
+    # ----------------------------
+    # Z / elevation layer
+    # ----------------------------
+
+    # Pre-scoped raster tile paths (e.g. from find_rasters_for_vector_extent).
+    # FillLineGaps builds RasterHandle objects from these at run() start.
+    # None disables all Z-based logic.
+    raster_paths: Optional[RasterPathList] = None
+
+    # Legality gate on Z drop along a candidate connector.
+    # A candidate is illegal when (end_z - start_z) > z_drop_threshold.
+    # None disables the gate.
+    #   0   → candidate must run downhill or flat
+    #  -10  → candidate must drop more than 10 m
+    z_drop_threshold: Optional[float] = None
 
 
 @dataclass(frozen=True)

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -417,6 +417,11 @@ class LineZValueMode(str, Enum):
     BOTH_ENDPOINTS = "both_endpoints"
 
 
+class LineZOrientMode(str, Enum):
+    INDIVIDUAL = "individual"
+    NETWORK = "network"
+
+
 @dataclass(frozen=True)
 class LineZValueFieldNameConfig:
     start_z: str = "start_z"
@@ -434,3 +439,11 @@ class LineZValueToolConfig:
     # If None and multiple rasters: auto "start_z_1", "end_z_1", "start_z_2", "end_z_2" …
     return_results: bool = True
     write_fields: bool = False
+
+
+@dataclass(frozen=True)
+class LineZOrientConfig:
+    input_lines: str
+    raster_paths: RasterPathList
+    orientation_mode: LineZOrientMode = LineZOrientMode.INDIVIDUAL
+    connectivity_tolerance_meters: float = 0.02

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -380,6 +380,14 @@ class FillLineGapsAdvancedConfig:
     # When not UNDIRECTED: best_fit_weights.angle must be > 0 (enforced at init).
     source_direction_mode: SourceDirectionMode = SourceDirectionMode.UNDIRECTED
 
+    # When True and source_direction_mode is directional, the angle metric for a
+    # valid end→start dangle-to-dangle candidate uses max(src_target_diff,
+    # src_connector_diff) instead of src_target_diff alone.  This penalises
+    # candidates whose connector direction is poor even when target alignment is
+    # good, affecting blocking, extra-dangle eligibility, and score weighting.
+    # Has no effect in UNDIRECTED mode.
+    dangle_pair_apply_connector_diff: bool = False
+
     # Minimum elevation drop (metres) required for LineZOrientTool to commit a flip.
     # Only used when source_direction_mode == RASTER_DERIVED.
     min_z_drop_meters: float = 0.5

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -413,18 +413,25 @@ class FillLineGapsAdvancedConfig:
 
     # Spatial reference used to construct temporary connector geometries for
     # the crossing check.  Accepts an integer WKID or a .prj file path
-    # (passed directly to arcpy.SpatialReference()).  Only required when
-    # reject_crossing_connectors is True.
+    # (passed directly to arcpy.SpatialReference()).  Required when
+    # reject_crossing_connectors is True or barrier_layers is set.
     crossing_check_spatial_reference: "int | str | None" = None
+
+    # Feature layers that act as impassable barriers.  Any candidate whose
+    # trimmed connector crosses one of these layers is rejected at Step 1a,
+    # regardless of the reject_crossing_connectors setting.  These layers are
+    # never used as snap targets.  crossing_check_spatial_reference is required
+    # when this is set.
+    barrier_layers: "list[str] | None" = None
 
     def __post_init__(self) -> None:
         if (
-            self.reject_crossing_connectors
+            (self.reject_crossing_connectors or self.barrier_layers is not None)
             and self.crossing_check_spatial_reference is None
         ):
             raise ValueError(
                 "crossing_check_spatial_reference is required when "
-                "reject_crossing_connectors is True"
+                "reject_crossing_connectors is True or barrier_layers is set"
             )
 
 

--- a/composition_configs/logic_config.py
+++ b/composition_configs/logic_config.py
@@ -236,6 +236,7 @@ class RiverStrahlerKwargs:
 
 
 @dataclass(frozen=True)
+<<<<<<< HEAD
 class AttributeChangerInitKwargs:
     input_feature: str
     output_feature: str
@@ -249,6 +250,16 @@ class LandUseInitKwargs:
     input_feature: str
     output_feature: str
     map_scale: str
+=======
+class FillLineGapsAdvancedConfig:
+    fill_gaps_on_self: bool = True
+    line_changes_output: Optional[str] = None
+
+    # Extra meters added ONLY when considering dangle→dangle candidates.
+    # Effective dangle→dangle cap = gap_tolerance_meters + extra.
+    # Use 0 to disable expanded dangle pairing.
+    increased_tolerance_edge_case_distance_meters: int = 0
+>>>>>>> 5aa8c33 (WIP line topolgy gap fix)
 
 
 @dataclass(frozen=True)
@@ -257,6 +268,7 @@ class FillLineGapsConfig:
     output_lines: str
     work_file_manager_config: core_config.WorkFileConfig
     gap_tolerance_meters: int
-    fill_gaps_on_self: bool = True
     connect_to_features: Optional[list[str]] = None
-    line_changes_output: Optional[str] = None
+    advanced_config: FillLineGapsAdvancedConfig = field(
+        default_factory=FillLineGapsAdvancedConfig
+    )

--- a/composition_configs/type_defs.py
+++ b/composition_configs/type_defs.py
@@ -20,3 +20,9 @@ class SubdirectoryPath(str):
     """Absolute path to a directory we control (safe to delete/reset)."""
 
     pass
+
+
+class RasterFilePath(str):
+    """Absolute or relative path to a raster file (e.g. a .tif tile)."""
+
+    pass

--- a/custom_tools/development_tools/scan_arcpy_usage.py
+++ b/custom_tools/development_tools/scan_arcpy_usage.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+EXCLUDE_DIRS = {
+    ".git",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    "env",
+    "build",
+    "dist",
+    "site-packages",
+}
+
+
+@dataclass(frozen=True)
+class Occurrence:
+    file: str
+    line: int
+
+
+def _is_git_repo(root: Path) -> bool:
+    try:
+        subprocess.check_output(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return True
+    except Exception:
+        return False
+
+
+def iter_python_files(root: Path, use_git: bool) -> Iterable[Path]:
+    if use_git and _is_git_repo(root):
+        out = subprocess.check_output(["git", "ls-files", "*.py"], cwd=root, text=True)
+        for rel in out.splitlines():
+            path = (root / rel).resolve()
+            if path.is_file():
+                yield path
+        return
+
+    for path in root.rglob("*.py"):
+        if any(part in EXCLUDE_DIRS for part in path.parts):
+            continue
+        if path.is_file():
+            yield path
+
+
+def _attr_chain(node: ast.AST) -> list[str] | None:
+    """
+    Convert an Attribute/Name tree like a.b.c into ["a","b","c"].
+    """
+    parts: list[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        parts.reverse()
+        return parts
+    return None
+
+
+def _build_local_to_arcpy_aliases(tree: ast.AST) -> dict[str, str]:
+    """
+    Map local names to fully-qualified arcpy paths based on imports.
+
+    Examples:
+      import arcpy as ap                 => ap -> arcpy
+      import arcpy.management as mgmt    => mgmt -> arcpy.management
+      from arcpy import management as m  => m -> arcpy.management
+      from arcpy.management import Buffer as Buf => Buf -> arcpy.management.Buffer
+    """
+    local_to = {"arcpy": "arcpy"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "arcpy":
+                    local_to[alias.asname or "arcpy"] = "arcpy"
+                elif alias.name.startswith("arcpy."):
+                    # import arcpy.management as mgmt
+                    local_to[alias.asname or alias.name.split(".")[-1]] = alias.name
+
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "arcpy":
+                for alias in node.names:
+                    local_to[alias.asname or alias.name] = f"arcpy.{alias.name}"
+            elif node.module and node.module.startswith("arcpy."):
+                for alias in node.names:
+                    local_to[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+
+    return local_to
+
+
+def _split_toolbox_and_tool(full: str) -> tuple[str, str]:
+    """
+    Turn a resolved call name into (toolbox, tool).
+
+    Examples:
+      arcpy.management.Buffer                  -> ("management", "Buffer")
+      arcpy.cartography.ResolveBuildingConflicts -> ("cartography", "ResolveBuildingConflicts")
+      arcpy.da.SearchCursor                    -> ("da", "SearchCursor")
+      arcpy.FeatureVerticesToPoints_management -> ("management", "FeatureVerticesToPoints")  (legacy style)
+      arcpy.Exists                             -> ("core", "Exists")
+    """
+    parts = full.split(".")
+    if not parts or parts[0] != "arcpy":
+        return ("unknown", full)
+
+    # arcpy.<toolbox>.<tool>[.<more>]
+    if len(parts) >= 3:
+        toolbox = parts[1]
+        tool = ".".join(parts[2:])  # keep deeper names if any
+        return (toolbox, tool)
+
+    # arcpy.<something>
+    name = parts[1] if len(parts) == 2 else "unknown"
+    # legacy GP style: ToolName_management, ToolName_analysis, ...
+    if "_" in name:
+        prefix, suffix = name.rsplit("_", 1)
+        if suffix.isalpha() and suffix.islower():
+            return (suffix, prefix)
+    return ("core", name)
+
+
+def scan_file(path: Path) -> list[tuple[str, Occurrence]]:
+    src = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError:
+        return []
+
+    local_to = _build_local_to_arcpy_aliases(tree)
+    hits: list[tuple[str, Occurrence]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        func = node.func
+
+        # Case: Buf(...) where Buf was imported from arcpy.*
+        if isinstance(func, ast.Name) and func.id in local_to:
+            resolved = local_to[func.id]
+            if resolved.startswith("arcpy."):
+                hits.append((resolved, Occurrence(str(path), node.lineno)))
+            continue
+
+        # Case: arcpy.management.Buffer(...) or ap.management.Buffer(...)
+        chain = _attr_chain(func)
+        if not chain:
+            continue
+
+        head = chain[0]
+        if head not in local_to:
+            continue
+
+        resolved_head = local_to[head]  # "arcpy" or "arcpy.management" etc.
+        resolved_parts = resolved_head.split(".") + chain[1:]
+        if resolved_parts and resolved_parts[0] == "arcpy":
+            resolved = ".".join(resolved_parts)
+            hits.append((resolved, Occurrence(str(path), node.lineno)))
+
+    return hits
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find real ArcPy call sites, then summarize toolboxes/tools used."
+    )
+    parser.add_argument("--root", default=".", help="Project root (default: .)")
+    parser.add_argument(
+        "--no-git", action="store_true", help="Walk filesystem instead of git ls-files"
+    )
+    parser.add_argument(
+        "--min-count", type=int, default=1, help="Only show tools used at least N times"
+    )
+    parser.add_argument(
+        "--list-tools", action="store_true", help="Print tools per toolbox"
+    )
+    parser.add_argument(
+        "--with-locations",
+        action="store_true",
+        help="Show file:line locations for each tool",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    files = list(iter_python_files(root, use_git=not args.no_git))
+
+    occurrences_by_full: dict[str, list[Occurrence]] = defaultdict(list)
+    for file_path in files:
+        for full, occ in scan_file(file_path):
+            occurrences_by_full[full].append(occ)
+
+    toolbox_tool_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    for full, occs in occurrences_by_full.items():
+        toolbox, tool = _split_toolbox_and_tool(full)
+        toolbox_tool_counts[toolbox][tool] += len(occs)
+
+    # Print summary
+    unique_tools_per_toolbox = {
+        tb: len(counter) for tb, counter in toolbox_tool_counts.items()
+    }
+    sorted_toolboxes = sorted(
+        toolbox_tool_counts.keys(),
+        key=lambda tb: (-(unique_tools_per_toolbox[tb]), tb),
+    )
+
+    print(f"Scanned: {len(files)} Python files")
+    total_unique = sum(unique_tools_per_toolbox.values())
+    print(f"Found:   {total_unique} unique ArcPy tools\n")
+
+    print("Toolboxes (unique tools):")
+    for tb in sorted_toolboxes:
+        print(f"  {tb}: {unique_tools_per_toolbox[tb]}")
+
+    if args.list_tools:
+        print("\nTools:")
+        for tb in sorted_toolboxes:
+            tools_sorted = sorted(
+                toolbox_tool_counts[tb].items(),
+                key=lambda kv: (-kv[1], kv[0]),
+            )
+            # apply min-count
+            tools_sorted = [(t, c) for t, c in tools_sorted if c >= args.min_count]
+            if not tools_sorted:
+                continue
+
+            print(f"\n[{tb}]")
+            for tool, count in tools_sorted:
+                print(f"  {tool} ({count})")
+                if args.with_locations:
+                    # locations are keyed by fully resolved name; reconstruct candidate full names
+                    # for printing locations, match any resolved full that maps to this (tb, tool)
+                    for full, occs in occurrences_by_full.items():
+                        tb2, tool2 = _split_toolbox_and_tool(full)
+                        if tb2 == tb and tool2 == tool:
+                            for occ in occs:
+                                rel = str(Path(occ.file).resolve().relative_to(root))
+                                print(f"    - {rel}:{occ.line}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/custom_tools/development_tools/scan_arcpy_usage.py
+++ b/custom_tools/development_tools/scan_arcpy_usage.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-
 EXCLUDE_DIRS = {
     ".git",
     "__pycache__",

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -183,13 +183,15 @@ class LineAngleTool:
 
     Important:
         - WHOLE_LINE always means canonical start -> end direction.
-        - BOTH_ENDPOINT_SEGMENTS is a request convenience selector only.
-          It expands to START_SEGMENT and END_SEGMENT and is never stored
-          as its own output value.
+        - Selector modes are request conveniences only.
+        - Selector modes expand internally and are never stored as their
+          own output values.
     """
 
     def __init__(self, config: AngleToolConfig):
         self.config = config
+        self._validate_config()
+
         self.resolved_modes = self._resolve_requested_modes()
         self.field_name_by_mode = self._build_field_name_by_mode()
         self.issue_counts: dict[str, int] = {}
@@ -205,8 +207,6 @@ class LineAngleTool:
 
             Or None when return_results=False.
         """
-        self._validate_config()
-
         lines_fc = self._prepare_processing_feature_class()
 
         if self.config.write_fields:
@@ -215,6 +215,7 @@ class LineAngleTool:
         results_by_oid: dict[int, dict] = {}
 
         field_names = ["OID@", "SHAPE@"]
+
         if self.config.write_fields:
             ordered_angle_fields = [
                 self.field_name_by_mode[mode] for mode in self.resolved_modes
@@ -272,11 +273,17 @@ class LineAngleTool:
         if self.config.field_name_by_mode is None:
             return
 
+        selector_only_modes = {
+            LineAngleMode.BOTH_ENDPOINT_SEGMENTS,
+            LineAngleMode.BOTH_ENDPOINT_TO_MIDPOINT,
+            LineAngleMode.ALL_ANGLES,
+        }
+
         for mode in self.config.field_name_by_mode:
-            if mode == LineAngleMode.BOTH_ENDPOINT_SEGMENTS:
+            if mode in selector_only_modes:
                 raise ValueError(
-                    "BOTH_ENDPOINT_SEGMENTS cannot be used in field_name_by_mode. "
-                    "It is a convenience selector only."
+                    f"{mode.value} cannot be used in field_name_by_mode. "
+                    "It is a selector-only mode."
                 )
 
     def _resolve_requested_modes(self) -> tuple[_ConcreteLineAngleMode, ...]:
@@ -285,17 +292,34 @@ class LineAngleTool:
         for mode in self.config.angle_modes:
             if mode == LineAngleMode.WHOLE_LINE:
                 requested.add(_ConcreteLineAngleMode.WHOLE_LINE)
+
             elif mode == LineAngleMode.START_SEGMENT:
                 requested.add(_ConcreteLineAngleMode.START_SEGMENT)
+
             elif mode == LineAngleMode.END_SEGMENT:
                 requested.add(_ConcreteLineAngleMode.END_SEGMENT)
+
             elif mode == LineAngleMode.BOTH_ENDPOINT_SEGMENTS:
                 requested.add(_ConcreteLineAngleMode.START_SEGMENT)
                 requested.add(_ConcreteLineAngleMode.END_SEGMENT)
+
             elif mode == LineAngleMode.START_TO_MIDPOINT:
                 requested.add(_ConcreteLineAngleMode.START_TO_MIDPOINT)
+
             elif mode == LineAngleMode.END_TO_MIDPOINT:
                 requested.add(_ConcreteLineAngleMode.END_TO_MIDPOINT)
+
+            elif mode == LineAngleMode.BOTH_ENDPOINT_TO_MIDPOINT:
+                requested.add(_ConcreteLineAngleMode.START_TO_MIDPOINT)
+                requested.add(_ConcreteLineAngleMode.END_TO_MIDPOINT)
+
+            elif mode == LineAngleMode.ALL_ANGLES:
+                requested.add(_ConcreteLineAngleMode.WHOLE_LINE)
+                requested.add(_ConcreteLineAngleMode.START_SEGMENT)
+                requested.add(_ConcreteLineAngleMode.END_SEGMENT)
+                requested.add(_ConcreteLineAngleMode.START_TO_MIDPOINT)
+                requested.add(_ConcreteLineAngleMode.END_TO_MIDPOINT)
+
             else:
                 raise ValueError(f"Unsupported angle mode: {mode}")
 
@@ -372,6 +396,7 @@ class LineAngleTool:
             return self._unsupported_result(issue="multipart_not_supported")
 
         vertices = self._extract_vertices(polyline=polyline)
+
         if len(vertices) < 2:
             return self._unsupported_result(issue="too_few_vertices")
 
@@ -408,6 +433,7 @@ class LineAngleTool:
             reversed_angle = self._reverse_angle(base_angle)
 
         angles_by_mode = {}
+
         for mode in self.resolved_modes:
             if mode == _ConcreteLineAngleMode.WHOLE_LINE:
                 angles_by_mode[mode] = base_angle
@@ -434,7 +460,9 @@ class LineAngleTool:
         )
 
     def _calculate_multivertex_result(
-        self, polyline, vertices: list
+        self,
+        polyline,
+        vertices: list,
     ) -> _RowAngleResult:
         start_point = vertices[0]
         second_point = vertices[1]
@@ -450,21 +478,25 @@ class LineAngleTool:
                     from_point=start_point,
                     to_point=end_point,
                 )
+
             elif mode == _ConcreteLineAngleMode.START_SEGMENT:
                 angles_by_mode[mode] = self._calculate_direction_angle(
                     from_point=start_point,
                     to_point=second_point,
                 )
+
             elif mode == _ConcreteLineAngleMode.END_SEGMENT:
                 angles_by_mode[mode] = self._calculate_direction_angle(
                     from_point=end_point,
                     to_point=previous_to_end_point,
                 )
+
             elif mode == _ConcreteLineAngleMode.START_TO_MIDPOINT:
                 angles_by_mode[mode] = self._calculate_direction_angle(
                     from_point=start_point,
                     to_point=midpoint,
                 )
+
             elif mode == _ConcreteLineAngleMode.END_TO_MIDPOINT:
                 angles_by_mode[mode] = self._calculate_direction_angle(
                     from_point=end_point,
@@ -472,6 +504,7 @@ class LineAngleTool:
                 )
 
         issues = []
+
         if all(value is None for value in angles_by_mode.values()):
             issues.append("no_requested_angles_available")
 
@@ -483,8 +516,10 @@ class LineAngleTool:
 
     def _get_line_midpoint(self, polyline):
         midpoint_geometry = polyline.positionAlongLine(0.5, use_percentage=True)
+
         if midpoint_geometry is None:
             return None
+
         return midpoint_geometry.firstPoint
 
     @staticmethod

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -1992,13 +1992,45 @@ class LineZOrientTool:
                     far_z = u_start_z if u_end_key == non_dangle_ep else u_end_z
 
                     if far_z is not None and abs(far_z - dangle_z) >= threshold:
-                        certain.add(oid)
                         # Orientation from extended direction, not own Z.
                         if far_z > dangle_z:
-                            # Dangle is outlet (lower) — end should be at dangle.
+                            # Dangle is a potential outlet (lower Z).
+                            # Confirm by checking that no other line at the junction
+                            # leads to a point more than threshold lower than dangle_z.
+                            # If one does, the dangle is a side branch and that other
+                            # line is the true downstream continuation.
+                            competing_oids = [
+                                o for o in ep_to_oids.get(non_dangle_ep, [])
+                                if o != oid and o != longest_up and o in component
+                            ]
+                            true_outlet = True
+                            for comp_oid in competing_oids:
+                                c_start_z, c_end_z = z_by_oid.get(
+                                    comp_oid, (None, None)
+                                )
+                                c_start_key, _ = oid_to_eps[comp_oid]
+                                comp_far_z = (
+                                    c_end_z
+                                    if c_start_key == non_dangle_ep
+                                    else c_start_z
+                                )
+                                if (
+                                    comp_far_z is not None
+                                    and (dangle_z - comp_far_z) >= threshold
+                                ):
+                                    true_outlet = False
+                                    break
+
+                            if not true_outlet:
+                                uncertain.add(oid)
+                                continue
+
+                            # Confirmed outlet — end should be at dangle.
+                            certain.add(oid)
                             extension_flip[oid] = end_key != dangle_ep
                         else:
                             # Dangle is source (higher) — start should be at dangle.
+                            certain.add(oid)
                             extension_flip[oid] = start_key != dangle_ep
                         continue
 
@@ -2041,20 +2073,26 @@ class LineZOrientTool:
         uncertain_oids: set[int],
         certain_oids: set[int],
         oriented_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
+        oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
         ep_to_oids: dict[_EndpointKey, list[int]],
         z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
+        dangle_eps: set[_EndpointKey],
     ) -> tuple[set[int], int, int]:
         """
-        Phase 2: orient uncertain lines using network context and raw Z fallback.
+        Phase 2: orient uncertain lines using competing-outlet-aware Z logic,
+        with a network-context fallback for lines that lack Z data.
 
-        For each uncertain line:
-          - Count head-to-tail signals from certain neighbors (N ends at X's start,
-            or X ends at N's start).  A head-to-tail match confirms the current
-            orientation is consistent with the network; the line is kept as-is.
-          - If no head-to-tail signal and Z data is available: orient by raw Z
-            (best guess, counted in raw_z_fallback).
-          - If no head-to-tail signal and no Z data: keep original orientation
-            (counted in unresolved).
+        For lines with Z data:
+          - raw_flip = (start_z < end_z).
+          - If raw_flip: suppress if any neighbor at end_key has far_z < start_z —
+            that neighbor is the true downstream continuation, so start_key is the
+            inlet (keep original orientation, or no flip).
+          - If not raw_flip and end_key is a dangle: force flip if any neighbor at
+            start_key has far_z < end_z — the junction (start_key) connects to
+            something lower than the dangle, so the dangle must be the inlet.
+        For lines without Z data:
+          - Use head-to-tail signal from certain neighbors if available.
+          - Otherwise leave original orientation (unresolved).
 
         Returns (flips_phase2, raw_z_fallback_count, unresolved_count).
         """
@@ -2062,8 +2100,6 @@ class LineZOrientTool:
         raw_z_fallback_count = 0
         unresolved_count = 0
 
-        # Process lines with more certain neighbors first so that the most
-        # constrained uncertain lines are resolved with better context.
         def certain_neighbor_count(oid: int) -> int:
             s, e = oriented_eps[oid]
             return sum(
@@ -2073,39 +2109,80 @@ class LineZOrientTool:
                 if nb in certain_oids
             )
 
+        def z_at_ep(nb: int, ep_key: _EndpointKey) -> Optional[float]:
+            """Z at a specific endpoint of nb, using original geometry Z values."""
+            orig_start, orig_end = oid_to_eps[nb]
+            zs, ze = z_by_oid.get(nb, (None, None))
+            if ep_key == orig_start:
+                return zs
+            if ep_key == orig_end:
+                return ze
+            return None
+
+        def far_z_of(nb: int, junction_key: _EndpointKey) -> Optional[float]:
+            """Z at the far end of neighbor nb from junction_key."""
+            n_start, n_end = oriented_eps[nb]
+            far_ep = n_end if n_start == junction_key else n_start
+            return z_at_ep(nb, far_ep)
+
         for oid in sorted(uncertain_oids, key=certain_neighbor_count, reverse=True):
             start_key, end_key = oriented_eps[oid]
             start_z, end_z = z_by_oid.get(oid, (None, None))
 
-            # Look for a clear head-to-tail relationship with any certain neighbor.
-            # N.end == X.start  →  N→junction→X  (N feeds X, through-flow)
-            # N.start == X.end  →  X→junction→N  (X feeds N, through-flow)
-            has_consistent_signal = False
-            for junction_key, is_x_start in ((start_key, True), (end_key, False)):
-                for neighbor in ep_to_oids.get(junction_key, []):
-                    if neighbor not in certain_oids:
-                        continue
-                    n_start, n_end = oriented_eps[neighbor]
-                    if is_x_start and n_end == junction_key:
-                        has_consistent_signal = True
-                        break
-                    if not is_x_start and n_start == junction_key:
-                        has_consistent_signal = True
-                        break
-                if has_consistent_signal:
-                    break
-
-            if has_consistent_signal:
-                # Current orientation is consistent with certain network; keep it.
-                continue
-
-            # No network signal — fall back to raw Z.
             if start_z is not None and end_z is not None:
-                if start_z < end_z:
-                    flips.add(oid)
+                # Competing-outlet-aware Z orientation.
+                raw_flip = start_z < end_z
+
+                if raw_flip:
+                    # Proposed flip: end_key becomes start (upstream junction),
+                    # start_key becomes end (dangle outlet).
+                    # Suppress if any neighbor at end_key leads to even lower Z
+                    # than start_z — that line is the true downstream continuation.
+                    blocked = False
+                    for nb in ep_to_oids.get(end_key, []):
+                        if nb == oid:
+                            continue
+                        fz = far_z_of(nb, end_key)
+                        if fz is not None and fz < start_z:
+                            blocked = True
+                            break
+                    if not blocked:
+                        flips.add(oid)
+                else:
+                    # Raw Z says keep (start already higher than or equal to end).
+                    # But if end_key is a dangle and start_key (junction) leads to
+                    # something lower than end_z, the dangle is the inlet — flip.
+                    if end_key in dangle_eps:
+                        for nb in ep_to_oids.get(start_key, []):
+                            if nb == oid:
+                                continue
+                            fz = far_z_of(nb, start_key)
+                            if fz is not None and fz < end_z:
+                                flips.add(oid)
+                                break
+
                 raw_z_fallback_count += 1
+
             else:
-                unresolved_count += 1
+                # No Z — fall back to head-to-tail network signal from certain
+                # neighbors.  N.end == X.start or X.end == N.start.
+                has_signal = False
+                for junction_key, is_x_start in ((start_key, True), (end_key, False)):
+                    for nb in ep_to_oids.get(junction_key, []):
+                        if nb not in certain_oids:
+                            continue
+                        n_start, n_end = oriented_eps[nb]
+                        if is_x_start and n_end == junction_key:
+                            has_signal = True
+                            break
+                        if not is_x_start and n_start == junction_key:
+                            has_signal = True
+                            break
+                    if has_signal:
+                        break
+
+                if not has_signal:
+                    unresolved_count += 1
 
         return flips, raw_z_fallback_count, unresolved_count
 
@@ -2145,8 +2222,10 @@ class LineZOrientTool:
                 continue
 
             # Phase 2 — uncertain lines.
+            dangle_eps = self._find_dangle_endpoints(component, oid_to_eps, ep_to_oids)
             flips_p2, raw_z, unresolved = self._propagate_to_uncertain(
-                uncertain, certain, oriented_eps, ep_to_oids, z_by_oid
+                uncertain, certain, oriented_eps, oid_to_eps, ep_to_oids, z_by_oid,
+                dangle_eps,
             )
             all_flips.update(flips_p2)
             total_raw_z += raw_z

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -1792,7 +1792,12 @@ class LineZOrientTool:
         self,
         z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
     ) -> set[int]:
-        threshold = self.config.min_z_drop_meters
+        anchor_threshold = self.config.min_anchor_z_drop_meters
+        flip_threshold = (
+            self.config.min_confident_flip_meters
+            if self.config.min_confident_flip_meters is not None
+            else anchor_threshold
+        )
         oids_to_flip: set[int] = set()
         uncertain_count = 0
 
@@ -1800,7 +1805,11 @@ class LineZOrientTool:
             if start_z is None or end_z is None:
                 uncertain_count += 1
                 continue
-            if abs(start_z - end_z) < threshold:
+            drop = abs(start_z - end_z)
+            if drop < anchor_threshold:
+                uncertain_count += 1
+                continue
+            if drop < flip_threshold:
                 uncertain_count += 1
                 continue
             if start_z < end_z:
@@ -1809,7 +1818,7 @@ class LineZOrientTool:
         if uncertain_count:
             arcpy.AddWarning(
                 f"LineZOrientTool (INDIVIDUAL): {uncertain_count} line(s) had no Z data "
-                f"or a Z drop below {threshold} m; original orientation preserved."
+                f"or a Z drop below {flip_threshold} m; original orientation preserved."
             )
 
         return oids_to_flip
@@ -1932,7 +1941,7 @@ class LineZOrientTool:
         """
         Partition component into certain and uncertain lines.
 
-        A line is certain if its own |start_z - end_z| >= min_z_drop_meters,
+        A line is certain if its own |start_z - end_z| >= min_anchor_z_drop_meters,
         or if it is a short dangle-adjacent segment that can be promoted via
         the extended Z diff: the Z at the far end of the longest upstream
         neighbor vs the Z at the dangle endpoint.
@@ -1945,7 +1954,7 @@ class LineZOrientTool:
                                   certain_oids that are absent from this dict
                                   are oriented by their own Z in Phase 1.
         """
-        threshold = self.config.min_z_drop_meters
+        threshold = self.config.min_anchor_z_drop_meters
         certain: set[int] = set()
         uncertain: set[int] = set()
         extension_flip: dict[int, bool] = {}
@@ -2204,11 +2213,22 @@ class LineZOrientTool:
             )
 
             if not certain:
-                # No lines meet the threshold; orient everything by raw Z and warn.
+                # No lines meet the anchor threshold; orient everything by raw Z and warn.
+                # min_confident_flip_meters guards flips here — no network context to rely on.
+                flip_guard = (
+                    self.config.min_confident_flip_meters
+                    if self.config.min_confident_flip_meters is not None
+                    else 0.0
+                )
                 no_certain_components += 1
                 for oid in component:
                     s, e = z_by_oid.get(oid, (None, None))
-                    if s is not None and e is not None and s < e:
+                    if (
+                        s is not None
+                        and e is not None
+                        and s < e
+                        and abs(s - e) >= flip_guard
+                    ):
                         all_flips.add(oid)
                 continue
 
@@ -2234,13 +2254,13 @@ class LineZOrientTool:
         if no_certain_components:
             arcpy.AddWarning(
                 f"LineZOrientTool (NETWORK): {no_certain_components} connected "
-                f"component(s) had no line meeting the {self.config.min_z_drop_meters} m "
-                "Z drop threshold; all lines in those components oriented by raw Z."
+                f"component(s) had no line meeting the {self.config.min_anchor_z_drop_meters} m "
+                "Z drop anchor threshold; all lines in those components oriented by raw Z."
             )
         if total_raw_z:
             arcpy.AddWarning(
                 f"LineZOrientTool (NETWORK): {total_raw_z} uncertain line(s) had a Z drop "
-                f"below {self.config.min_z_drop_meters} m and were oriented by raw Z as "
+                f"below {self.config.min_anchor_z_drop_meters} m and were oriented by raw Z as "
                 "best guess."
             )
         if total_unresolved:

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -19,7 +19,6 @@ from composition_configs.logic_config import (
     LineEndpointToolConfig,
     LineZOrientConfig,
     LineZOrientMode,
-    LineZOrientOutletMode,
     LineZValueFieldNameConfig,
     LineZValueMode,
     LineZValueToolConfig,
@@ -1793,20 +1792,24 @@ class LineZOrientTool:
         self,
         z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
     ) -> set[int]:
+        threshold = self.config.min_z_drop_meters
         oids_to_flip: set[int] = set()
-        no_data_count = 0
+        uncertain_count = 0
 
         for oid, (start_z, end_z) in z_by_oid.items():
             if start_z is None or end_z is None:
-                no_data_count += 1
+                uncertain_count += 1
+                continue
+            if abs(start_z - end_z) < threshold:
+                uncertain_count += 1
                 continue
             if start_z < end_z:
                 oids_to_flip.add(oid)
 
-        if no_data_count:
+        if uncertain_count:
             arcpy.AddWarning(
-                f"LineZOrientTool (INDIVIDUAL): {no_data_count} line(s) had no raster "
-                "coverage at one or both endpoints and were left unchanged."
+                f"LineZOrientTool (INDIVIDUAL): {uncertain_count} line(s) had no Z data "
+                f"or a Z drop below {threshold} m; original orientation preserved."
             )
 
         return oids_to_flip
@@ -1820,12 +1823,14 @@ class LineZOrientTool:
     ) -> tuple[
         dict[int, tuple[_EndpointKey, _EndpointKey]],
         dict[_EndpointKey, list[int]],
+        dict[int, float],
     ]:
         """
-        Read all line geometries and return two complementary dicts:
+        Read all line geometries and return three complementary dicts:
 
-        oid_to_eps   : {oid: (start_key, end_key)}
-        ep_to_oids   : {endpoint_key: [oid, ...]}
+        oid_to_eps    : {oid: (start_key, end_key)}
+        ep_to_oids    : {endpoint_key: [oid, ...]}
+        oid_to_length : {oid: length_in_map_units}
 
         Endpoint keys are integer grid coordinates snapped to
         connectivity_tolerance_meters so that nearby endpoints are
@@ -1836,11 +1841,12 @@ class LineZOrientTool:
 
         oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]] = {}
         ep_to_oids: dict[_EndpointKey, list[int]] = {}
+        oid_to_length: dict[int, float] = {}
 
         with arcpy.da.SearchCursor(
-            self.config.input_lines, [oid_field, "SHAPE@"]
+            self.config.input_lines, [oid_field, "SHAPE@", "SHAPE@LENGTH"]
         ) as cursor:
-            for oid, polyline in cursor:
+            for oid, polyline, length in cursor:
                 if polyline is None or polyline.partCount == 0:
                     continue
                 first = polyline.firstPoint
@@ -1861,8 +1867,9 @@ class LineZOrientTool:
                 oid_to_eps[oid] = (start_key, end_key)
                 ep_to_oids.setdefault(start_key, []).append(oid)
                 ep_to_oids.setdefault(end_key, []).append(oid)
+                oid_to_length[oid] = float(length) if length is not None else 0.0
 
-        return oid_to_eps, ep_to_oids
+        return oid_to_eps, ep_to_oids, oid_to_length
 
     def _find_components(
         self,
@@ -1914,107 +1921,256 @@ class LineZOrientTool:
                     dangle_eps.add(ep_key)
         return dangle_eps
 
-    def _orient_component(
+    def _classify_lines(
         self,
         component: set[int],
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
         oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
         ep_to_oids: dict[_EndpointKey, list[int]],
-        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
-    ) -> set[int]:
+        oid_to_length: dict[int, float],
+    ) -> tuple[set[int], set[int], dict[int, bool]]:
         """
-        BFS from the outlet endpoint in the component.  Returns the set of
-        OIDs within this component that need to be flipped.
+        Partition component into certain and uncertain lines.
 
-        The outlet is selected according to outlet_mode:
-          DANGLE_ENDPOINTS  — lowest-Z endpoint among free ends (dangles) of the
-                              local network.  Falls back to any endpoint if no
-                              dangle has raster coverage.
-          ANY_ENDPOINT      — lowest-Z endpoint regardless of connectivity.
+        A line is certain if its own |start_z - end_z| >= min_z_drop_meters,
+        or if it is a short dangle-adjacent segment that can be promoted via
+        the extended Z diff: the Z at the far end of the longest upstream
+        neighbor vs the Z at the dangle endpoint.
+
+        Returns:
+            certain_oids        : lines with strong Z evidence.
+            uncertain_oids      : lines with weak or absent Z evidence.
+            extension_flip      : for extension-promoted lines, the pre-computed
+                                  flip decision (True = needs flip).  Lines in
+                                  certain_oids that are absent from this dict
+                                  are oriented by their own Z in Phase 1.
         """
-        # Collect all endpoint keys and their sampled Z values for this component.
-        ep_z: dict[_EndpointKey, float] = {}
+        threshold = self.config.min_z_drop_meters
+        certain: set[int] = set()
+        uncertain: set[int] = set()
+        extension_flip: dict[int, bool] = {}
+
+        dangle_eps = self._find_dangle_endpoints(component, oid_to_eps, ep_to_oids)
+
         for oid in component:
-            if oid not in z_by_oid:
-                continue
-            start_z, end_z = z_by_oid[oid]
+            start_z, end_z = z_by_oid.get(oid, (None, None))
             start_key, end_key = oid_to_eps[oid]
-            if start_z is not None:
-                if start_key not in ep_z or start_z < ep_z[start_key]:
-                    ep_z[start_key] = start_z
-            if end_z is not None:
-                if end_key not in ep_z or end_z < ep_z[end_key]:
-                    ep_z[end_key] = end_z
 
-        if not ep_z:
-            return set()
-
-        if self.config.outlet_mode == LineZOrientOutletMode.DANGLE_ENDPOINTS:
-            dangle_eps = self._find_dangle_endpoints(component, oid_to_eps, ep_to_oids)
-            dangle_ep_z = {ep: z for ep, z in ep_z.items() if ep in dangle_eps}
-            candidate_ep_z = dangle_ep_z if dangle_ep_z else ep_z
-        else:
-            candidate_ep_z = ep_z
-
-        outlet_ep = min(candidate_ep_z, key=lambda k: candidate_ep_z[k])
-
-        # BFS from outlet endpoint, orienting lines so their END is toward the outlet.
-        oids_to_flip: set[int] = set()
-        visited_eps: set[_EndpointKey] = {outlet_ep}
-        visited_oids: set[int] = set()
-        queue: list[_EndpointKey] = [outlet_ep]
-
-        while queue:
-            current_ep = queue.pop(0)
-
-            for oid in ep_to_oids.get(current_ep, []):
-                if oid not in component or oid in visited_oids:
+            # Own Z check.
+            if start_z is not None and end_z is not None:
+                if abs(start_z - end_z) >= threshold:
+                    certain.add(oid)
                     continue
-                visited_oids.add(oid)
 
+            # Below threshold or no Z — try dangle extension for short outlet/inlet
+            # segments that border the edge of the network.
+            dangle_ep: Optional[_EndpointKey] = None
+            non_dangle_ep: Optional[_EndpointKey] = None
+
+            if end_key in dangle_eps:
+                dangle_ep = end_key
+                non_dangle_ep = start_key
+            elif start_key in dangle_eps:
+                dangle_ep = start_key
+                non_dangle_ep = end_key
+
+            if dangle_ep is not None and non_dangle_ep is not None:
+                dangle_z = end_z if dangle_ep == end_key else start_z
+
+                upstream_oids = [
+                    o for o in ep_to_oids.get(non_dangle_ep, [])
+                    if o != oid and o in component
+                ]
+
+                if upstream_oids and dangle_z is not None:
+                    longest_up = max(
+                        upstream_oids, key=lambda o: oid_to_length.get(o, 0.0)
+                    )
+                    u_start_z, u_end_z = z_by_oid.get(longest_up, (None, None))
+                    u_start_key, u_end_key = oid_to_eps[longest_up]
+
+                    far_z = u_start_z if u_end_key == non_dangle_ep else u_end_z
+
+                    if far_z is not None and abs(far_z - dangle_z) >= threshold:
+                        certain.add(oid)
+                        # Orientation from extended direction, not own Z.
+                        if far_z > dangle_z:
+                            # Dangle is outlet (lower) — end should be at dangle.
+                            extension_flip[oid] = end_key != dangle_ep
+                        else:
+                            # Dangle is source (higher) — start should be at dangle.
+                            extension_flip[oid] = start_key != dangle_ep
+                        continue
+
+            uncertain.add(oid)
+
+        return certain, uncertain, extension_flip
+
+    def _orient_certain_lines(
+        self,
+        certain_oids: set[int],
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
+        oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
+        extension_flip: dict[int, bool],
+    ) -> tuple[set[int], dict[int, tuple[_EndpointKey, _EndpointKey]]]:
+        """
+        Phase 1: orient all certain lines by Z and return the flip set plus
+        an oriented_eps dict that reflects the post-Phase-1 start/end state.
+        Extension-promoted lines use the pre-computed flip decision from
+        _classify_lines; all others use their own start_z vs end_z.
+        """
+        flips: set[int] = set()
+        oriented_eps: dict[int, tuple[_EndpointKey, _EndpointKey]] = dict(oid_to_eps)
+
+        for oid in certain_oids:
+            if oid in extension_flip:
+                needs_flip = extension_flip[oid]
+            else:
+                start_z, end_z = z_by_oid[oid]
+                needs_flip = start_z < end_z
+
+            if needs_flip:
+                flips.add(oid)
                 start_key, end_key = oid_to_eps[oid]
+                oriented_eps[oid] = (end_key, start_key)
 
-                if end_key == current_ep:
-                    # END is on the outlet side — correctly oriented.
-                    other_ep = start_key
-                else:
-                    # START is on the outlet side — needs flipping.
-                    oids_to_flip.add(oid)
-                    other_ep = end_key
+        return flips, oriented_eps
 
-                if other_ep not in visited_eps:
-                    visited_eps.add(other_ep)
-                    queue.append(other_ep)
+    def _propagate_to_uncertain(
+        self,
+        uncertain_oids: set[int],
+        certain_oids: set[int],
+        oriented_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
+        ep_to_oids: dict[_EndpointKey, list[int]],
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
+    ) -> tuple[set[int], int, int]:
+        """
+        Phase 2: orient uncertain lines using network context and raw Z fallback.
 
-        return oids_to_flip
+        For each uncertain line:
+          - Count head-to-tail signals from certain neighbors (N ends at X's start,
+            or X ends at N's start).  A head-to-tail match confirms the current
+            orientation is consistent with the network; the line is kept as-is.
+          - If no head-to-tail signal and Z data is available: orient by raw Z
+            (best guess, counted in raw_z_fallback).
+          - If no head-to-tail signal and no Z data: keep original orientation
+            (counted in unresolved).
+
+        Returns (flips_phase2, raw_z_fallback_count, unresolved_count).
+        """
+        flips: set[int] = set()
+        raw_z_fallback_count = 0
+        unresolved_count = 0
+
+        # Process lines with more certain neighbors first so that the most
+        # constrained uncertain lines are resolved with better context.
+        def certain_neighbor_count(oid: int) -> int:
+            s, e = oriented_eps[oid]
+            return sum(
+                1
+                for ep in (s, e)
+                for nb in ep_to_oids.get(ep, [])
+                if nb in certain_oids
+            )
+
+        for oid in sorted(uncertain_oids, key=certain_neighbor_count, reverse=True):
+            start_key, end_key = oriented_eps[oid]
+            start_z, end_z = z_by_oid.get(oid, (None, None))
+
+            # Look for a clear head-to-tail relationship with any certain neighbor.
+            # N.end == X.start  →  N→junction→X  (N feeds X, through-flow)
+            # N.start == X.end  →  X→junction→N  (X feeds N, through-flow)
+            has_consistent_signal = False
+            for junction_key, is_x_start in ((start_key, True), (end_key, False)):
+                for neighbor in ep_to_oids.get(junction_key, []):
+                    if neighbor not in certain_oids:
+                        continue
+                    n_start, n_end = oriented_eps[neighbor]
+                    if is_x_start and n_end == junction_key:
+                        has_consistent_signal = True
+                        break
+                    if not is_x_start and n_start == junction_key:
+                        has_consistent_signal = True
+                        break
+                if has_consistent_signal:
+                    break
+
+            if has_consistent_signal:
+                # Current orientation is consistent with certain network; keep it.
+                continue
+
+            # No network signal — fall back to raw Z.
+            if start_z is not None and end_z is not None:
+                if start_z < end_z:
+                    flips.add(oid)
+                raw_z_fallback_count += 1
+            else:
+                unresolved_count += 1
+
+        return flips, raw_z_fallback_count, unresolved_count
 
     def _compute_network_flips(
         self,
         z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
     ) -> set[int]:
-        oid_to_eps, ep_to_oids = self._build_endpoint_graph()
+        oid_to_eps, ep_to_oids, oid_to_length = self._build_endpoint_graph()
         components = self._find_components(oid_to_eps, ep_to_oids)
 
-        oids_to_flip: set[int] = set()
-        skipped_components = 0
+        all_flips: set[int] = set()
+        no_certain_components = 0
+        total_raw_z = 0
+        total_unresolved = 0
 
         for component in components:
-            flips = self._orient_component(
-                component, oid_to_eps, ep_to_oids, z_by_oid
+            certain, uncertain, extension_flip = self._classify_lines(
+                component, z_by_oid, oid_to_eps, ep_to_oids, oid_to_length
             )
-            if not flips and all(
-                z_by_oid.get(oid, (None, None)) == (None, None) for oid in component
-            ):
-                skipped_components += 1
+
+            if not certain:
+                # No lines meet the threshold; orient everything by raw Z and warn.
+                no_certain_components += 1
+                for oid in component:
+                    s, e = z_by_oid.get(oid, (None, None))
+                    if s is not None and e is not None and s < e:
+                        all_flips.add(oid)
                 continue
-            oids_to_flip.update(flips)
 
-        if skipped_components:
+            # Phase 1 — certain lines.
+            flips_p1, oriented_eps = self._orient_certain_lines(
+                certain, z_by_oid, oid_to_eps, extension_flip
+            )
+            all_flips.update(flips_p1)
+
+            if not uncertain:
+                continue
+
+            # Phase 2 — uncertain lines.
+            flips_p2, raw_z, unresolved = self._propagate_to_uncertain(
+                uncertain, certain, oriented_eps, ep_to_oids, z_by_oid
+            )
+            all_flips.update(flips_p2)
+            total_raw_z += raw_z
+            total_unresolved += unresolved
+
+        if no_certain_components:
             arcpy.AddWarning(
-                f"LineZOrientTool (NETWORK): {skipped_components} connected component(s) "
-                "had no raster coverage and were left unchanged."
+                f"LineZOrientTool (NETWORK): {no_certain_components} connected "
+                f"component(s) had no line meeting the {self.config.min_z_drop_meters} m "
+                "Z drop threshold; all lines in those components oriented by raw Z."
+            )
+        if total_raw_z:
+            arcpy.AddWarning(
+                f"LineZOrientTool (NETWORK): {total_raw_z} uncertain line(s) had a Z drop "
+                f"below {self.config.min_z_drop_meters} m and were oriented by raw Z as "
+                "best guess."
+            )
+        if total_unresolved:
+            arcpy.AddWarning(
+                f"LineZOrientTool (NETWORK): {total_unresolved} line(s) had no Z data "
+                "and could not be resolved by the network; original orientation preserved."
             )
 
-        return oids_to_flip
+        return all_flips
 
     # ------------------------------------------------------------------
     # Shared flip helper

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -1,7 +1,16 @@
 from typing import Dict, Union
 
 import arcpy
+from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
+from math import atan2, degrees
+from typing import Optional, Union, Dict
+
+import arcpy
+
+from composition_configs.logic_config import AngleToolConfig, LineAngleMode
 from custom_tools.decorators.partition_io_decorator import partition_io_decorator
 from custom_tools.general_tools import custom_arcpy
 from file_manager.n100.file_manager_rivers import River_N100
@@ -145,3 +154,396 @@ class GeometryValidator:
             print(
                 f"Maximum iterations ({max_iterations}) reached. Manual inspection may be required for the following features: {problematic_aliases}"
             )
+
+
+class _ConcreteLineAngleMode(str, Enum):
+    WHOLE_LINE = "whole_line"
+    START_SEGMENT = "start_segment"
+    END_SEGMENT = "end_segment"
+    START_TO_MIDPOINT = "start_to_midpoint"
+    END_TO_MIDPOINT = "end_to_midpoint"
+
+
+@dataclass(frozen=True)
+class _RowAngleResult:
+    angles_by_mode: dict[_ConcreteLineAngleMode, Optional[float]]
+    issues: tuple[str, ...]
+    is_supported: bool
+
+
+class LineAngleTool:
+    """
+    Calculate line-angle measurements for requested modes and optionally
+    write them to fields on an output feature class.
+
+    Angle convention:
+        - Range: [0, 360)
+        - Zero direction: positive X axis (east)
+        - Positive rotation: counterclockwise
+
+    Important:
+        - WHOLE_LINE always means canonical start -> end direction.
+        - BOTH_ENDPOINT_SEGMENTS is a request convenience selector only.
+          It expands to START_SEGMENT and END_SEGMENT and is never stored
+          as its own output value.
+    """
+
+    def __init__(self, config: AngleToolConfig):
+        self.config = config
+        self.resolved_modes = self._resolve_requested_modes()
+        self.field_name_by_mode = self._build_field_name_by_mode()
+        self.issue_counts: dict[str, int] = {}
+
+    def run(self) -> Optional[dict[int, dict]]:
+        """
+        Main entrypoint.
+
+        Returns:
+            A dict keyed by object id of the dataset actually processed:
+            - input OID for return-only mode
+            - output OID when write_fields=True and output_lines is used
+
+            Or None when return_results=False.
+        """
+        self._validate_config()
+
+        lines_fc = self._prepare_processing_feature_class()
+
+        if self.config.write_fields:
+            self._ensure_output_fields(lines_fc=lines_fc)
+
+        results_by_oid: dict[int, dict] = {}
+
+        field_names = ["OID@", "SHAPE@"]
+        if self.config.write_fields:
+            ordered_angle_fields = [
+                self.field_name_by_mode[mode] for mode in self.resolved_modes
+            ]
+            field_names.extend(ordered_angle_fields)
+
+            with arcpy.da.UpdateCursor(lines_fc, field_names) as cursor:
+                for row in cursor:
+                    oid = row[0]
+                    polyline = row[1]
+
+                    row_result = self._calculate_row_angles(polyline=polyline)
+                    self._track_issues(row_result.issues)
+
+                    self._write_row_values_to_cursor_row(
+                        row=row,
+                        row_result=row_result,
+                    )
+                    cursor.updateRow(row)
+
+                    if self.config.return_results:
+                        results_by_oid[oid] = self._serialize_row_result(row_result)
+
+        else:
+            with arcpy.da.SearchCursor(lines_fc, field_names) as cursor:
+                for oid, polyline in cursor:
+                    row_result = self._calculate_row_angles(polyline=polyline)
+                    self._track_issues(row_result.issues)
+
+                    if self.config.return_results:
+                        results_by_oid[oid] = self._serialize_row_result(row_result)
+
+        self._emit_summary_warnings()
+
+        if self.config.return_results:
+            return results_by_oid
+
+        return None
+
+    def _validate_config(self) -> None:
+        if not self.config.angle_modes:
+            raise ValueError(
+                "AngleToolConfig.angle_modes must contain at least one mode."
+            )
+
+        if not self.config.return_results and not self.config.write_fields:
+            raise ValueError(
+                "At least one output behavior must be enabled: "
+                "return_results or write_fields."
+            )
+
+        if self.config.write_fields and not self.config.output_lines:
+            raise ValueError("output_lines is required when write_fields=True.")
+
+        if self.config.field_name_by_mode is None:
+            return
+
+        for mode in self.config.field_name_by_mode:
+            if mode == LineAngleMode.BOTH_ENDPOINT_SEGMENTS:
+                raise ValueError(
+                    "BOTH_ENDPOINT_SEGMENTS cannot be used in field_name_by_mode. "
+                    "It is a convenience selector only."
+                )
+
+    def _resolve_requested_modes(self) -> tuple[_ConcreteLineAngleMode, ...]:
+        requested = set()
+
+        for mode in self.config.angle_modes:
+            if mode == LineAngleMode.WHOLE_LINE:
+                requested.add(_ConcreteLineAngleMode.WHOLE_LINE)
+            elif mode == LineAngleMode.START_SEGMENT:
+                requested.add(_ConcreteLineAngleMode.START_SEGMENT)
+            elif mode == LineAngleMode.END_SEGMENT:
+                requested.add(_ConcreteLineAngleMode.END_SEGMENT)
+            elif mode == LineAngleMode.BOTH_ENDPOINT_SEGMENTS:
+                requested.add(_ConcreteLineAngleMode.START_SEGMENT)
+                requested.add(_ConcreteLineAngleMode.END_SEGMENT)
+            elif mode == LineAngleMode.START_TO_MIDPOINT:
+                requested.add(_ConcreteLineAngleMode.START_TO_MIDPOINT)
+            elif mode == LineAngleMode.END_TO_MIDPOINT:
+                requested.add(_ConcreteLineAngleMode.END_TO_MIDPOINT)
+            else:
+                raise ValueError(f"Unsupported angle mode: {mode}")
+
+        ordered_modes = (
+            _ConcreteLineAngleMode.WHOLE_LINE,
+            _ConcreteLineAngleMode.START_SEGMENT,
+            _ConcreteLineAngleMode.END_SEGMENT,
+            _ConcreteLineAngleMode.START_TO_MIDPOINT,
+            _ConcreteLineAngleMode.END_TO_MIDPOINT,
+        )
+
+        return tuple(mode for mode in ordered_modes if mode in requested)
+
+    def _build_field_name_by_mode(self) -> dict[_ConcreteLineAngleMode, str]:
+        default_field_name_by_mode = {
+            _ConcreteLineAngleMode.WHOLE_LINE: "angle_whole",
+            _ConcreteLineAngleMode.START_SEGMENT: "angle_start_seg",
+            _ConcreteLineAngleMode.END_SEGMENT: "angle_end_seg",
+            _ConcreteLineAngleMode.START_TO_MIDPOINT: "angle_start_mid",
+            _ConcreteLineAngleMode.END_TO_MIDPOINT: "angle_end_mid",
+        }
+
+        resolved_field_name_by_mode = {
+            mode: default_field_name_by_mode[mode] for mode in self.resolved_modes
+        }
+
+        if not self.config.field_name_by_mode:
+            return resolved_field_name_by_mode
+
+        public_to_private_mode = {
+            LineAngleMode.WHOLE_LINE: _ConcreteLineAngleMode.WHOLE_LINE,
+            LineAngleMode.START_SEGMENT: _ConcreteLineAngleMode.START_SEGMENT,
+            LineAngleMode.END_SEGMENT: _ConcreteLineAngleMode.END_SEGMENT,
+            LineAngleMode.START_TO_MIDPOINT: _ConcreteLineAngleMode.START_TO_MIDPOINT,
+            LineAngleMode.END_TO_MIDPOINT: _ConcreteLineAngleMode.END_TO_MIDPOINT,
+        }
+
+        for public_mode, field_name in self.config.field_name_by_mode.items():
+            private_mode = public_to_private_mode.get(public_mode)
+            if private_mode in resolved_field_name_by_mode:
+                resolved_field_name_by_mode[private_mode] = field_name
+
+        return resolved_field_name_by_mode
+
+    def _prepare_processing_feature_class(self) -> str:
+        if not self.config.write_fields:
+            return self.config.input_lines
+
+        arcpy.management.CopyFeatures(
+            self.config.input_lines,
+            self.config.output_lines,
+        )
+        return self.config.output_lines
+
+    def _ensure_output_fields(self, lines_fc: str) -> None:
+        existing_fields = {field.name for field in arcpy.ListFields(lines_fc)}
+
+        for mode in self.resolved_modes:
+            field_name = self.field_name_by_mode[mode]
+            if field_name in existing_fields:
+                continue
+
+            arcpy.management.AddField(
+                in_table=lines_fc,
+                field_name=field_name,
+                field_type="DOUBLE",
+            )
+
+    def _calculate_row_angles(self, polyline) -> _RowAngleResult:
+        if polyline is None:
+            return self._unsupported_result(issue="null_geometry")
+
+        if polyline.isMultipart:
+            return self._unsupported_result(issue="multipart_not_supported")
+
+        vertices = self._extract_vertices(polyline=polyline)
+        if len(vertices) < 2:
+            return self._unsupported_result(issue="too_few_vertices")
+
+        if len(vertices) == 2:
+            return self._calculate_two_vertex_result(vertices=vertices)
+
+        return self._calculate_multivertex_result(
+            polyline=polyline,
+            vertices=vertices,
+        )
+
+    def _extract_vertices(self, polyline) -> list:
+        vertices = []
+
+        for part in polyline:
+            for point in part:
+                if point is None:
+                    continue
+                vertices.append(point)
+
+        return vertices
+
+    def _calculate_two_vertex_result(self, vertices: list) -> _RowAngleResult:
+        start_point = vertices[0]
+        end_point = vertices[1]
+
+        base_angle = self._calculate_direction_angle(
+            from_point=start_point,
+            to_point=end_point,
+        )
+
+        reversed_angle = None
+        if base_angle is not None:
+            reversed_angle = self._reverse_angle(base_angle)
+
+        angles_by_mode = {}
+        for mode in self.resolved_modes:
+            if mode == _ConcreteLineAngleMode.WHOLE_LINE:
+                angles_by_mode[mode] = base_angle
+            elif mode == _ConcreteLineAngleMode.START_SEGMENT:
+                angles_by_mode[mode] = base_angle
+            elif mode == _ConcreteLineAngleMode.START_TO_MIDPOINT:
+                angles_by_mode[mode] = base_angle
+            elif mode == _ConcreteLineAngleMode.END_SEGMENT:
+                angles_by_mode[mode] = reversed_angle
+            elif mode == _ConcreteLineAngleMode.END_TO_MIDPOINT:
+                angles_by_mode[mode] = reversed_angle
+
+        if base_angle is None:
+            return _RowAngleResult(
+                angles_by_mode=angles_by_mode,
+                issues=("zero_length_line",),
+                is_supported=False,
+            )
+
+        return _RowAngleResult(
+            angles_by_mode=angles_by_mode,
+            issues=(),
+            is_supported=True,
+        )
+
+    def _calculate_multivertex_result(
+        self, polyline, vertices: list
+    ) -> _RowAngleResult:
+        start_point = vertices[0]
+        second_point = vertices[1]
+        previous_to_end_point = vertices[-2]
+        end_point = vertices[-1]
+        midpoint = self._get_line_midpoint(polyline=polyline)
+
+        angles_by_mode = {}
+
+        for mode in self.resolved_modes:
+            if mode == _ConcreteLineAngleMode.WHOLE_LINE:
+                angles_by_mode[mode] = self._calculate_direction_angle(
+                    from_point=start_point,
+                    to_point=end_point,
+                )
+            elif mode == _ConcreteLineAngleMode.START_SEGMENT:
+                angles_by_mode[mode] = self._calculate_direction_angle(
+                    from_point=start_point,
+                    to_point=second_point,
+                )
+            elif mode == _ConcreteLineAngleMode.END_SEGMENT:
+                angles_by_mode[mode] = self._calculate_direction_angle(
+                    from_point=end_point,
+                    to_point=previous_to_end_point,
+                )
+            elif mode == _ConcreteLineAngleMode.START_TO_MIDPOINT:
+                angles_by_mode[mode] = self._calculate_direction_angle(
+                    from_point=start_point,
+                    to_point=midpoint,
+                )
+            elif mode == _ConcreteLineAngleMode.END_TO_MIDPOINT:
+                angles_by_mode[mode] = self._calculate_direction_angle(
+                    from_point=end_point,
+                    to_point=midpoint,
+                )
+
+        issues = []
+        if all(value is None for value in angles_by_mode.values()):
+            issues.append("no_requested_angles_available")
+
+        return _RowAngleResult(
+            angles_by_mode=angles_by_mode,
+            issues=tuple(issues),
+            is_supported=not issues,
+        )
+
+    def _get_line_midpoint(self, polyline):
+        midpoint_geometry = polyline.positionAlongLine(0.5, use_percentage=True)
+        if midpoint_geometry is None:
+            return None
+        return midpoint_geometry.firstPoint
+
+    @staticmethod
+    def _calculate_direction_angle(from_point, to_point) -> Optional[float]:
+        if from_point is None or to_point is None:
+            return None
+
+        dx = to_point.X - from_point.X
+        dy = to_point.Y - from_point.Y
+
+        if dx == 0 and dy == 0:
+            return None
+
+        angle = degrees(atan2(dy, dx))
+        return angle % 360.0
+
+    @staticmethod
+    def _reverse_angle(angle: float) -> float:
+        return (angle + 180.0) % 360.0
+
+    def _unsupported_result(self, issue: str) -> _RowAngleResult:
+        return _RowAngleResult(
+            angles_by_mode={mode: None for mode in self.resolved_modes},
+            issues=(issue,),
+            is_supported=False,
+        )
+
+    def _write_row_values_to_cursor_row(
+        self,
+        row: list,
+        row_result: _RowAngleResult,
+    ) -> None:
+        start_index = 2
+
+        for index, mode in enumerate(self.resolved_modes, start=start_index):
+            row[index] = row_result.angles_by_mode.get(mode)
+
+    def _serialize_row_result(self, row_result: _RowAngleResult) -> dict:
+        public_mode_by_private_mode = {
+            _ConcreteLineAngleMode.WHOLE_LINE: LineAngleMode.WHOLE_LINE,
+            _ConcreteLineAngleMode.START_SEGMENT: LineAngleMode.START_SEGMENT,
+            _ConcreteLineAngleMode.END_SEGMENT: LineAngleMode.END_SEGMENT,
+            _ConcreteLineAngleMode.START_TO_MIDPOINT: LineAngleMode.START_TO_MIDPOINT,
+            _ConcreteLineAngleMode.END_TO_MIDPOINT: LineAngleMode.END_TO_MIDPOINT,
+        }
+
+        return {
+            "angles_by_mode": {
+                public_mode_by_private_mode[mode]: value
+                for mode, value in row_result.angles_by_mode.items()
+            },
+            "issues": row_result.issues,
+            "is_supported": row_result.is_supported,
+        }
+
+    def _track_issues(self, issues: tuple[str, ...]) -> None:
+        for issue in issues:
+            self.issue_counts[issue] = self.issue_counts.get(issue, 0) + 1
+
+    def _emit_summary_warnings(self) -> None:
+        for issue, count in sorted(self.issue_counts.items()):
+            arcpy.AddWarning(f"{count} feature(s) returned issue: {issue}")

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -10,7 +10,16 @@ from typing import Optional, Union, Dict
 
 import arcpy
 
-from composition_configs.logic_config import AngleToolConfig, LineAngleMode
+from composition_configs.logic_config import (
+    AngleToolConfig,
+    LineAngleMode,
+    LineEndpointMode,
+    LineEndpointToolConfig,
+)
+
+from xarray.backends.common import NONE_VAR_NAME
+
+from custom_tools.general_tools import custom_arcpy
 from custom_tools.decorators.partition_io_decorator import partition_io_decorator
 from custom_tools.general_tools import custom_arcpy
 from file_manager.n100.file_manager_rivers import River_N100
@@ -570,6 +579,284 @@ class LineAngleTool:
             "angles_by_mode": {
                 public_mode_by_private_mode[mode]: value
                 for mode, value in row_result.angles_by_mode.items()
+            },
+            "issues": row_result.issues,
+            "is_supported": row_result.is_supported,
+        }
+
+    def _track_issues(self, issues: tuple[str, ...]) -> None:
+        for issue in issues:
+            self.issue_counts[issue] = self.issue_counts.get(issue, 0) + 1
+
+    def _emit_summary_warnings(self) -> None:
+        for issue, count in sorted(self.issue_counts.items()):
+            arcpy.AddWarning(f"{count} feature(s) returned issue: {issue}")
+
+
+class _ConcreteLineEndpointMode(str, Enum):
+    START_POINT = "start_point"
+    END_POINT = "end_point"
+
+
+@dataclass(frozen=True)
+class _RowEndpointResult:
+    coordinates_by_mode: dict[_ConcreteLineEndpointMode, Optional[tuple[float, float]]]
+    issues: tuple[str, ...]
+    is_supported: bool
+
+
+class LineEndpointTool:
+    """
+    Materialize line endpoint coordinates for requested endpoint modes and
+    optionally write them to fields on an output feature class.
+
+    Definitions:
+        - START_POINT = first vertex of the line
+        - END_POINT = last vertex of the line
+
+    Important:
+        - BOTH_ENDPOINTS is a selector-only request mode.
+        - It expands internally to START_POINT and END_POINT.
+        - It is never stored as its own output value.
+    """
+
+    def __init__(self, config: LineEndpointToolConfig):
+        self.config = config
+        self._validate_config()
+
+        self.resolved_modes = self._resolve_requested_modes()
+        self.issue_counts: dict[str, int] = {}
+
+    def run(self) -> Optional[dict[int, dict]]:
+        lines_fc = self._prepare_processing_feature_class()
+
+        if self.config.write_fields:
+            self._ensure_output_fields(lines_fc=lines_fc)
+
+        results_by_oid: dict[int, dict] = {}
+
+        field_names = ["OID@", "SHAPE@"]
+
+        if self.config.write_fields:
+            field_names.extend(self._ordered_output_field_names())
+
+            with arcpy.da.UpdateCursor(lines_fc, field_names) as cursor:
+                for row in cursor:
+                    oid = row[0]
+                    polyline = row[1]
+
+                    row_result = self._calculate_row_endpoints(polyline=polyline)
+                    self._track_issues(row_result.issues)
+
+                    self._write_row_values_to_cursor_row(
+                        row=row,
+                        row_result=row_result,
+                    )
+                    cursor.updateRow(row)
+
+                    if self.config.return_results:
+                        results_by_oid[oid] = self._serialize_row_result(row_result)
+
+        else:
+            with arcpy.da.SearchCursor(lines_fc, field_names) as cursor:
+                for oid, polyline in cursor:
+                    row_result = self._calculate_row_endpoints(polyline=polyline)
+                    self._track_issues(row_result.issues)
+
+                    if self.config.return_results:
+                        results_by_oid[oid] = self._serialize_row_result(row_result)
+
+        self._emit_summary_warnings()
+
+        if self.config.return_results:
+            return results_by_oid
+
+        return None
+
+    def _validate_config(self) -> None:
+        if not self.config.endpoint_modes:
+            raise ValueError(
+                "LineEndpointToolConfig.endpoint_modes must contain at least one mode."
+            )
+
+        if not self.config.return_results and not self.config.write_fields:
+            raise ValueError(
+                "At least one output behavior must be enabled: "
+                "return_results or write_fields."
+            )
+
+        if self.config.write_fields and not self.config.output_lines:
+            raise ValueError("output_lines is required when write_fields=True.")
+
+    def _resolve_requested_modes(self) -> tuple[_ConcreteLineEndpointMode, ...]:
+        requested = set()
+
+        for mode in self.config.endpoint_modes:
+            if mode == LineEndpointMode.START_POINT:
+                requested.add(_ConcreteLineEndpointMode.START_POINT)
+
+            elif mode == LineEndpointMode.END_POINT:
+                requested.add(_ConcreteLineEndpointMode.END_POINT)
+
+            elif mode == LineEndpointMode.BOTH_ENDPOINTS:
+                requested.add(_ConcreteLineEndpointMode.START_POINT)
+                requested.add(_ConcreteLineEndpointMode.END_POINT)
+
+            else:
+                raise ValueError(f"Unsupported endpoint mode: {mode}")
+
+        ordered_modes = (
+            _ConcreteLineEndpointMode.START_POINT,
+            _ConcreteLineEndpointMode.END_POINT,
+        )
+
+        return tuple(mode for mode in ordered_modes if mode in requested)
+
+    def _prepare_processing_feature_class(self) -> str:
+        if not self.config.write_fields:
+            return self.config.input_lines
+
+        arcpy.management.CopyFeatures(
+            self.config.input_lines,
+            self.config.output_lines,
+        )
+        return self.config.output_lines
+
+    def _ensure_output_fields(self, lines_fc: str) -> None:
+        existing_fields = {field.name for field in arcpy.ListFields(lines_fc)}
+
+        for field_name in self._required_field_names():
+            if field_name in existing_fields:
+                continue
+
+            arcpy.management.AddField(
+                in_table=lines_fc,
+                field_name=field_name,
+                field_type="DOUBLE",
+            )
+
+    def _required_field_names(self) -> list[str]:
+        field_names = []
+
+        if _ConcreteLineEndpointMode.START_POINT in self.resolved_modes:
+            field_names.extend(
+                [
+                    self.config.field_names.start_x,
+                    self.config.field_names.start_y,
+                ]
+            )
+
+        if _ConcreteLineEndpointMode.END_POINT in self.resolved_modes:
+            field_names.extend(
+                [
+                    self.config.field_names.end_x,
+                    self.config.field_names.end_y,
+                ]
+            )
+
+        return field_names
+
+    def _ordered_output_field_names(self) -> list[str]:
+        field_names = []
+
+        for mode in self.resolved_modes:
+            if mode == _ConcreteLineEndpointMode.START_POINT:
+                field_names.extend(
+                    [
+                        self.config.field_names.start_x,
+                        self.config.field_names.start_y,
+                    ]
+                )
+            elif mode == _ConcreteLineEndpointMode.END_POINT:
+                field_names.extend(
+                    [
+                        self.config.field_names.end_x,
+                        self.config.field_names.end_y,
+                    ]
+                )
+
+        return field_names
+
+    def _calculate_row_endpoints(self, polyline) -> _RowEndpointResult:
+        if polyline is None:
+            return self._unsupported_result(issue="null_geometry")
+
+        if polyline.isMultipart:
+            return self._unsupported_result(issue="multipart_not_supported")
+
+        vertices = self._extract_vertices(polyline=polyline)
+
+        if len(vertices) < 2:
+            return self._unsupported_result(issue="too_few_vertices")
+
+        start_point = vertices[0]
+        end_point = vertices[-1]
+
+        coordinates_by_mode: dict[
+            _ConcreteLineEndpointMode,
+            Optional[tuple[float, float]],
+        ] = {}
+
+        for mode in self.resolved_modes:
+            if mode == _ConcreteLineEndpointMode.START_POINT:
+                coordinates_by_mode[mode] = (start_point.X, start_point.Y)
+
+            elif mode == _ConcreteLineEndpointMode.END_POINT:
+                coordinates_by_mode[mode] = (end_point.X, end_point.Y)
+
+        return _RowEndpointResult(
+            coordinates_by_mode=coordinates_by_mode,
+            issues=(),
+            is_supported=True,
+        )
+
+    def _extract_vertices(self, polyline) -> list:
+        vertices = []
+
+        for part in polyline:
+            for point in part:
+                if point is None:
+                    continue
+                vertices.append(point)
+
+        return vertices
+
+    def _unsupported_result(self, issue: str) -> _RowEndpointResult:
+        return _RowEndpointResult(
+            coordinates_by_mode={mode: None for mode in self.resolved_modes},
+            issues=(issue,),
+            is_supported=False,
+        )
+
+    def _write_row_values_to_cursor_row(
+        self,
+        row: list,
+        row_result: _RowEndpointResult,
+    ) -> None:
+        write_values = []
+
+        for mode in self.resolved_modes:
+            xy = row_result.coordinates_by_mode.get(mode)
+
+            if xy is None:
+                write_values.extend([None, None])
+            else:
+                write_values.extend([xy[0], xy[1]])
+
+        row[2:] = write_values
+
+    def _serialize_row_result(self, row_result: _RowEndpointResult) -> dict:
+        public_mode_by_private_mode = {
+            _ConcreteLineEndpointMode.START_POINT: LineEndpointMode.START_POINT,
+            _ConcreteLineEndpointMode.END_POINT: LineEndpointMode.END_POINT,
+        }
+
+        return {
+            "coordinates_by_mode": {
+                public_mode_by_private_mode[mode]: (
+                    None if xy is None else {"x": xy[0], "y": xy[1]}
+                )
+                for mode, xy in row_result.coordinates_by_mode.items()
             },
             "issues": row_result.issues,
             "is_supported": row_result.is_supported,

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -19,6 +19,7 @@ from composition_configs.logic_config import (
     LineEndpointToolConfig,
     LineZOrientConfig,
     LineZOrientMode,
+    LineZOrientOutletMode,
     LineZValueFieldNameConfig,
     LineZValueMode,
     LineZValueToolConfig,
@@ -1895,6 +1896,24 @@ class LineZOrientTool:
 
         return components
 
+    def _find_dangle_endpoints(
+        self,
+        component: set[int],
+        oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
+        ep_to_oids: dict[_EndpointKey, list[int]],
+    ) -> set[_EndpointKey]:
+        """
+        Return endpoint keys that are connected to exactly one line within the
+        component.  These are the free ends (dangles) of the local network.
+        """
+        dangle_eps: set[_EndpointKey] = set()
+        for oid in component:
+            for ep_key in oid_to_eps[oid]:
+                count = sum(1 for o in ep_to_oids.get(ep_key, []) if o in component)
+                if count == 1:
+                    dangle_eps.add(ep_key)
+        return dangle_eps
+
     def _orient_component(
         self,
         component: set[int],
@@ -1903,8 +1922,14 @@ class LineZOrientTool:
         z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
     ) -> set[int]:
         """
-        BFS from the lowest-Z endpoint in the component.  Returns the set of
+        BFS from the outlet endpoint in the component.  Returns the set of
         OIDs within this component that need to be flipped.
+
+        The outlet is selected according to outlet_mode:
+          DANGLE_ENDPOINTS  — lowest-Z endpoint among free ends (dangles) of the
+                              local network.  Falls back to any endpoint if no
+                              dangle has raster coverage.
+          ANY_ENDPOINT      — lowest-Z endpoint regardless of connectivity.
         """
         # Collect all endpoint keys and their sampled Z values for this component.
         ep_z: dict[_EndpointKey, float] = {}
@@ -1923,7 +1948,14 @@ class LineZOrientTool:
         if not ep_z:
             return set()
 
-        outlet_ep = min(ep_z, key=lambda k: ep_z[k])
+        if self.config.outlet_mode == LineZOrientOutletMode.DANGLE_ENDPOINTS:
+            dangle_eps = self._find_dangle_endpoints(component, oid_to_eps, ep_to_oids)
+            dangle_ep_z = {ep: z for ep, z in ep_z.items() if ep in dangle_eps}
+            candidate_ep_z = dangle_ep_z if dangle_ep_z else ep_z
+        else:
+            candidate_ep_z = ep_z
+
+        outlet_ep = min(candidate_ep_z, key=lambda k: candidate_ep_z[k])
 
         # BFS from outlet endpoint, orienting lines so their END is toward the outlet.
         oids_to_flip: set[int] = set()

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -869,3 +869,135 @@ class LineEndpointTool:
     def _emit_summary_warnings(self) -> None:
         for issue, count in sorted(self.issue_counts.items()):
             arcpy.AddWarning(f"{count} feature(s) returned issue: {issue}")
+
+
+def local_line_angle_at_xy(
+    *,
+    polyline,
+    x: float,
+    y: float,
+    desired_half_window_m: float,
+    min_half_window_percent: float = 0.01,
+    max_half_window_percent: float = 0.25,
+) -> Optional[float]:
+    """
+    Returns a local direction angle [0, 360) for the polyline near the nearest point
+    to (x, y), using a small window around that measure.
+
+    Pure geometry helper (no IO). Returns None if unsupported.
+    """
+
+    def _direction_angle(p0, p1) -> Optional[float]:
+        if p0 is None or p1 is None:
+            return None
+        dx = p1.X - p0.X
+        dy = p1.Y - p0.Y
+        if dx == 0 and dy == 0:
+            return None
+        return degrees(atan2(dy, dx)) % 360.0
+
+    def _query_measure_percent(polyline, pt_geom) -> Optional[float]:
+        def _extract(q) -> Optional[float]:
+            if not q or len(q) < 2 or q[1] is None:
+                return None
+            try:
+                return float(q[1])
+            except (TypeError, ValueError):
+                return None
+
+        # Prefer percentage along line (0..1)
+        try:
+            q = polyline.queryPointAndDistance(pt_geom, use_percentage=True)
+            m = _extract(q)
+            if m is not None:
+                return m
+        except TypeError:
+            pass
+
+        # Some versions accept positional boolean
+        try:
+            q = polyline.queryPointAndDistance(pt_geom, True)
+            m = _extract(q)
+            if m is not None:
+                return m
+        except TypeError:
+            pass
+
+        # Fallback: distance along line in map units -> convert to percent
+        try:
+            q = polyline.queryPointAndDistance(pt_geom)
+            if not q or len(q) < 2 or q[1] is None:
+                return None
+            dist_along = float(q[1])
+
+            length = float(getattr(polyline, "length", 0.0) or 0.0)
+            if length <= 0.0:
+                return None
+
+            m = dist_along / length
+            # clamp to [0,1]
+            return max(0.0, min(1.0, float(m)))
+        except Exception:
+            return None
+
+    def _position_along_percent(polyline, p: float):
+        # Prefer keyword
+        try:
+            return polyline.positionAlongLine(float(p), use_percentage=True)
+        except TypeError:
+            # Some versions accept positional boolean
+            return polyline.positionAlongLine(float(p), True)
+
+    # 1) Validate geometry
+    if polyline is None:
+        return None
+    if getattr(polyline, "isMultipart", False):
+        return None
+    length = float(getattr(polyline, "length", 0.0) or 0.0)
+    if length <= 0.0:
+        return None
+
+    # 2) Convert length to meters if possible (fallback to dataset units)
+    sr = getattr(polyline, "spatialReference", None)
+    meters_per_unit = getattr(sr, "metersPerUnit", None) if sr is not None else None
+    meters_per_unit = float(meters_per_unit) if meters_per_unit else 1.0
+    length_m = length * meters_per_unit
+    if length_m <= 0.0:
+        return None
+
+    # 3) Find measure (percentage) of nearest point along line
+    pt_geom = arcpy.PointGeometry(arcpy.Point(float(x), float(y)), sr)
+    m = _query_measure_percent(polyline, pt_geom)
+    if m is None:
+        return None
+
+    # 4) Compute window as percent, clamp
+    half_p = float(desired_half_window_m) / float(length_m)
+    half_p = max(
+        float(min_half_window_percent), min(float(max_half_window_percent), half_p)
+    )
+
+    start = max(0.0, m - half_p)
+    end = min(1.0, m + half_p)
+
+    # 5) Sample points and compute local direction; fallback to whole line
+    def _whole_line_angle() -> Optional[float]:
+        a0 = _position_along_percent(polyline, 0.0)
+        a1 = _position_along_percent(polyline, 1.0)
+        if a0 is None or a1 is None:
+            return None
+        return _direction_angle(a0.firstPoint, a1.firstPoint)
+
+    if (end - start) < 1e-9:
+        return _whole_line_angle()
+
+    s0 = _position_along_percent(polyline, start)
+    s1 = _position_along_percent(polyline, end)
+    if s0 is None or s1 is None:
+        return _whole_line_angle()
+
+    angle = _direction_angle(s0.firstPoint, s1.firstPoint)
+    if angle is None:
+        angle = _whole_line_angle()
+
+    return angle

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -17,6 +17,8 @@ from composition_configs.logic_config import (
     LineAngleMode,
     LineEndpointMode,
     LineEndpointToolConfig,
+    LineZOrientConfig,
+    LineZOrientMode,
     LineZValueFieldNameConfig,
     LineZValueMode,
     LineZValueToolConfig,
@@ -1669,3 +1671,344 @@ def find_rasters_for_vector_extent(
             arcpy.AddWarning(f"Could not read extent of raster: {tif_path}. Skipping.")
 
     return matched
+
+
+# ---------------------------------------------------------------------------
+# Endpoint key type used throughout LineZOrientTool.
+# A snapped integer grid coordinate pair — two endpoints that fall on the
+# same cell are treated as connected.
+# ---------------------------------------------------------------------------
+_EndpointKey = tuple[int, int]
+
+
+class LineZOrientTool:
+    """
+    Orient line features so that the start vertex is upstream (higher Z) and
+    the end vertex is downstream (lower Z).
+
+    Two modes are supported, controlled by LineZOrientConfig.orientation_mode:
+
+    INDIVIDUAL
+        Each line is oriented in isolation.  If start_z < end_z the line is
+        flipped.  Lines where either endpoint has no raster coverage are left
+        unchanged and produce a warning.
+
+    NETWORK
+        Lines that share endpoints are treated as a connected network.  Within
+        each connected component the endpoint with the lowest sampled Z is
+        identified as the outlet.  All lines in the component are then
+        oriented so that flow runs toward the outlet, regardless of each
+        individual line's Z drop.  This corrects single outlier segments that
+        would otherwise point against the network's predominant direction.
+        Components where no Z values can be sampled are skipped with a warning.
+
+    The method modifies input_lines in-place (no output feature class is
+    created).  It is designed to be called on a working copy inside
+    FillLineGaps.
+    """
+
+    def __init__(self, config: LineZOrientConfig) -> None:
+        self.config = config
+        self._tol_grid = max(1e-9, float(config.connectivity_tolerance_meters))
+
+    def run(self) -> None:
+        handles = self._build_raster_handles()
+        z_by_oid = self._sample_z_values(handles)
+
+        if self.config.orientation_mode == LineZOrientMode.INDIVIDUAL:
+            oids_to_flip = self._compute_individual_flips(z_by_oid)
+        else:
+            oids_to_flip = self._compute_network_flips(z_by_oid)
+
+        if oids_to_flip:
+            self._flip_lines(oids_to_flip)
+
+    # ------------------------------------------------------------------
+    # Raster handles
+    # ------------------------------------------------------------------
+
+    def _build_raster_handles(self) -> list[RasterHandle]:
+        desc = arcpy.Describe(self.config.input_lines)
+        ext = desc.extent
+        handles: list[RasterHandle] = []
+        for raster_path in self.config.raster_paths:
+            try:
+                handle = build_raster_handle(
+                    raster_path,
+                    clip_xmin=ext.XMin,
+                    clip_ymin=ext.YMin,
+                    clip_xmax=ext.XMax,
+                    clip_ymax=ext.YMax,
+                )
+                handles.append(handle)
+            except Exception as exc:
+                arcpy.AddWarning(
+                    f"LineZOrientTool: could not load raster {raster_path}: {exc}"
+                )
+        return handles
+
+    # ------------------------------------------------------------------
+    # Z sampling
+    # ------------------------------------------------------------------
+
+    def _sample_z_values(
+        self,
+        handles: list[RasterHandle],
+    ) -> dict[int, tuple[Optional[float], Optional[float]]]:
+        """Return {oid: (start_z, end_z)} for every line in input_lines."""
+        oid_field = arcpy.Describe(self.config.input_lines).OIDFieldName
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]] = {}
+
+        with arcpy.da.SearchCursor(
+            self.config.input_lines, [oid_field, "SHAPE@"]
+        ) as cursor:
+            for oid, polyline in cursor:
+                if polyline is None or polyline.partCount == 0:
+                    arcpy.AddWarning(
+                        f"LineZOrientTool: OID {oid} has null or empty geometry. Skipping."
+                    )
+                    continue
+
+                first = polyline.firstPoint
+                last = polyline.lastPoint
+
+                if first is None or last is None:
+                    arcpy.AddWarning(
+                        f"LineZOrientTool: OID {oid} has no first/last point. Skipping."
+                    )
+                    continue
+
+                start_z = local_z_at_xy(handles, first.X, first.Y)
+                end_z = local_z_at_xy(handles, last.X, last.Y)
+                z_by_oid[int(oid)] = (start_z, end_z)
+
+        return z_by_oid
+
+    # ------------------------------------------------------------------
+    # INDIVIDUAL mode
+    # ------------------------------------------------------------------
+
+    def _compute_individual_flips(
+        self,
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
+    ) -> set[int]:
+        oids_to_flip: set[int] = set()
+        no_data_count = 0
+
+        for oid, (start_z, end_z) in z_by_oid.items():
+            if start_z is None or end_z is None:
+                no_data_count += 1
+                continue
+            if start_z < end_z:
+                oids_to_flip.add(oid)
+
+        if no_data_count:
+            arcpy.AddWarning(
+                f"LineZOrientTool (INDIVIDUAL): {no_data_count} line(s) had no raster "
+                "coverage at one or both endpoints and were left unchanged."
+            )
+
+        return oids_to_flip
+
+    # ------------------------------------------------------------------
+    # NETWORK mode
+    # ------------------------------------------------------------------
+
+    def _build_endpoint_graph(
+        self,
+    ) -> tuple[
+        dict[int, tuple[_EndpointKey, _EndpointKey]],
+        dict[_EndpointKey, list[int]],
+    ]:
+        """
+        Read all line geometries and return two complementary dicts:
+
+        oid_to_eps   : {oid: (start_key, end_key)}
+        ep_to_oids   : {endpoint_key: [oid, ...]}
+
+        Endpoint keys are integer grid coordinates snapped to
+        connectivity_tolerance_meters so that nearby endpoints are
+        treated as shared.
+        """
+        scale = 1.0 / self._tol_grid
+        oid_field = arcpy.Describe(self.config.input_lines).OIDFieldName
+
+        oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]] = {}
+        ep_to_oids: dict[_EndpointKey, list[int]] = {}
+
+        with arcpy.da.SearchCursor(
+            self.config.input_lines, [oid_field, "SHAPE@"]
+        ) as cursor:
+            for oid, polyline in cursor:
+                if polyline is None or polyline.partCount == 0:
+                    continue
+                first = polyline.firstPoint
+                last = polyline.lastPoint
+                if first is None or last is None:
+                    continue
+
+                oid = int(oid)
+                start_key: _EndpointKey = (
+                    int(round(first.X * scale)),
+                    int(round(first.Y * scale)),
+                )
+                end_key: _EndpointKey = (
+                    int(round(last.X * scale)),
+                    int(round(last.Y * scale)),
+                )
+
+                oid_to_eps[oid] = (start_key, end_key)
+                ep_to_oids.setdefault(start_key, []).append(oid)
+                ep_to_oids.setdefault(end_key, []).append(oid)
+
+        return oid_to_eps, ep_to_oids
+
+    def _find_components(
+        self,
+        oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
+        ep_to_oids: dict[_EndpointKey, list[int]],
+    ) -> list[set[int]]:
+        """Return a list of connected components as sets of OIDs."""
+        visited_oids: set[int] = set()
+        components: list[set[int]] = []
+
+        for seed_oid in oid_to_eps:
+            if seed_oid in visited_oids:
+                continue
+
+            component: set[int] = set()
+            queue = [seed_oid]
+
+            while queue:
+                oid = queue.pop()
+                if oid in visited_oids:
+                    continue
+                visited_oids.add(oid)
+                component.add(oid)
+
+                for ep_key in oid_to_eps[oid]:
+                    for neighbor_oid in ep_to_oids.get(ep_key, []):
+                        if neighbor_oid not in visited_oids:
+                            queue.append(neighbor_oid)
+
+            components.append(component)
+
+        return components
+
+    def _orient_component(
+        self,
+        component: set[int],
+        oid_to_eps: dict[int, tuple[_EndpointKey, _EndpointKey]],
+        ep_to_oids: dict[_EndpointKey, list[int]],
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
+    ) -> set[int]:
+        """
+        BFS from the lowest-Z endpoint in the component.  Returns the set of
+        OIDs within this component that need to be flipped.
+        """
+        # Collect all endpoint keys and their sampled Z values for this component.
+        ep_z: dict[_EndpointKey, float] = {}
+        for oid in component:
+            if oid not in z_by_oid:
+                continue
+            start_z, end_z = z_by_oid[oid]
+            start_key, end_key = oid_to_eps[oid]
+            if start_z is not None:
+                if start_key not in ep_z or start_z < ep_z[start_key]:
+                    ep_z[start_key] = start_z
+            if end_z is not None:
+                if end_key not in ep_z or end_z < ep_z[end_key]:
+                    ep_z[end_key] = end_z
+
+        if not ep_z:
+            return set()
+
+        outlet_ep = min(ep_z, key=lambda k: ep_z[k])
+
+        # BFS from outlet endpoint, orienting lines so their END is toward the outlet.
+        oids_to_flip: set[int] = set()
+        visited_eps: set[_EndpointKey] = {outlet_ep}
+        visited_oids: set[int] = set()
+        queue: list[_EndpointKey] = [outlet_ep]
+
+        while queue:
+            current_ep = queue.pop(0)
+
+            for oid in ep_to_oids.get(current_ep, []):
+                if oid not in component or oid in visited_oids:
+                    continue
+                visited_oids.add(oid)
+
+                start_key, end_key = oid_to_eps[oid]
+
+                if end_key == current_ep:
+                    # END is on the outlet side — correctly oriented.
+                    other_ep = start_key
+                else:
+                    # START is on the outlet side — needs flipping.
+                    oids_to_flip.add(oid)
+                    other_ep = end_key
+
+                if other_ep not in visited_eps:
+                    visited_eps.add(other_ep)
+                    queue.append(other_ep)
+
+        return oids_to_flip
+
+    def _compute_network_flips(
+        self,
+        z_by_oid: dict[int, tuple[Optional[float], Optional[float]]],
+    ) -> set[int]:
+        oid_to_eps, ep_to_oids = self._build_endpoint_graph()
+        components = self._find_components(oid_to_eps, ep_to_oids)
+
+        oids_to_flip: set[int] = set()
+        skipped_components = 0
+
+        for component in components:
+            flips = self._orient_component(
+                component, oid_to_eps, ep_to_oids, z_by_oid
+            )
+            if not flips and all(
+                z_by_oid.get(oid, (None, None)) == (None, None) for oid in component
+            ):
+                skipped_components += 1
+                continue
+            oids_to_flip.update(flips)
+
+        if skipped_components:
+            arcpy.AddWarning(
+                f"LineZOrientTool (NETWORK): {skipped_components} connected component(s) "
+                "had no raster coverage and were left unchanged."
+            )
+
+        return oids_to_flip
+
+    # ------------------------------------------------------------------
+    # Shared flip helper
+    # ------------------------------------------------------------------
+
+    def _flip_lines(self, oids_to_flip: set[int]) -> None:
+        """Reverse the geometry of every OID in oids_to_flip in-place."""
+        oid_field = arcpy.Describe(self.config.input_lines).OIDFieldName
+
+        with arcpy.da.UpdateCursor(
+            self.config.input_lines, [oid_field, "SHAPE@"]
+        ) as cursor:
+            for row in cursor:
+                if int(row[0]) not in oids_to_flip:
+                    continue
+
+                polyline: arcpy.Polyline = row[1]
+                if polyline is None:
+                    continue
+
+                reversed_parts = arcpy.Array()
+                for part_idx in range(polyline.partCount):
+                    part = polyline.getPart(part_idx)
+                    points = [part.getObject(i) for i in range(part.count)]
+                    reversed_part = arcpy.Array(reversed(points))
+                    reversed_parts.add(reversed_part)
+
+                row[1] = arcpy.Polyline(reversed_parts, polyline.spatialReference)
+                cursor.updateRow(row)

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -3,6 +3,7 @@ from typing import Dict, Union
 import arcpy
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from enum import Enum
 from math import atan2, degrees
@@ -15,6 +16,9 @@ from composition_configs.logic_config import (
     LineAngleMode,
     LineEndpointMode,
     LineEndpointToolConfig,
+    LineZValueFieldNameConfig,
+    LineZValueMode,
+    LineZValueToolConfig,
 )
 
 from xarray.backends.common import NONE_VAR_NAME
@@ -871,6 +875,336 @@ class LineEndpointTool:
             arcpy.AddWarning(f"{count} feature(s) returned issue: {issue}")
 
 
+class _ConcreteLineZValueMode(str, Enum):
+    START_POINT = "start_point"
+    END_POINT = "end_point"
+
+
+@dataclass(frozen=True)
+class _RowZValueResult:
+    z_by_slot: dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]
+    issues: tuple[str, ...]
+    is_supported: bool
+
+
+class LineZValueTool:
+    """
+    Sample raster Z values at line endpoints and optionally write them to
+    fields on an output feature class.
+
+    Definitions:
+        - START_POINT = first vertex of the line
+        - END_POINT   = last vertex of the line
+
+    Important:
+        - BOTH_ENDPOINTS is a selector-only request mode.
+        - It expands internally to START_POINT and END_POINT.
+        - Multiple rasters are supported; each raster produces its own pair
+          of output fields.
+        - Coordinates are passed to GetCellValue in the line feature's own
+          spatial reference. A warning is emitted when that SR differs from
+          a raster's SR, but no reprojection is performed.
+    """
+
+    def __init__(self, config: LineZValueToolConfig):
+        self.config = config
+        self._validate_config()
+
+        self.resolved_modes = self._resolve_requested_modes()
+        self.resolved_field_names = self._resolve_field_names()
+        self.ordered_slots = self._build_ordered_slots()
+        self.issue_counts: dict[str, int] = {}
+
+    def run(self) -> Optional[dict[int, dict]]:
+        """
+        Main entrypoint.
+
+        Returns:
+            A dict keyed by OID with z_by_raster_by_mode, issues, and
+            is_supported entries, or None when return_results=False.
+        """
+        self._check_spatial_reference()
+        lines_fc = self._prepare_processing_feature_class()
+
+        if self.config.write_fields:
+            self._ensure_output_fields(lines_fc=lines_fc)
+
+        results_by_oid: dict[int, dict] = {}
+        field_names = ["OID@", "SHAPE@"]
+
+        if self.config.write_fields:
+            field_names.extend(self._build_output_field_names_ordered())
+
+            with arcpy.da.UpdateCursor(lines_fc, field_names) as cursor:
+                for row in cursor:
+                    oid = row[0]
+                    polyline = row[1]
+
+                    row_result = self._calculate_row_z(polyline=polyline)
+                    self._track_issues(row_result.issues)
+
+                    self._write_row_values_to_cursor_row(row=row, row_result=row_result)
+                    cursor.updateRow(row)
+
+                    if self.config.return_results:
+                        results_by_oid[oid] = self._serialize_row_result(row_result)
+
+        else:
+            with arcpy.da.SearchCursor(lines_fc, field_names) as cursor:
+                for oid, polyline in cursor:
+                    row_result = self._calculate_row_z(polyline=polyline)
+                    self._track_issues(row_result.issues)
+
+                    if self.config.return_results:
+                        results_by_oid[oid] = self._serialize_row_result(row_result)
+
+        self._emit_summary_warnings()
+
+        if self.config.return_results:
+            return results_by_oid
+
+        return None
+
+    def _validate_config(self) -> None:
+        if not self.config.endpoint_modes:
+            raise ValueError(
+                "LineZValueToolConfig.endpoint_modes must contain at least one mode."
+            )
+
+        if not self.config.input_rasters:
+            raise ValueError(
+                "LineZValueToolConfig.input_rasters must contain at least one raster."
+            )
+
+        if not self.config.return_results and not self.config.write_fields:
+            raise ValueError(
+                "At least one output behavior must be enabled: "
+                "return_results or write_fields."
+            )
+
+        if self.config.write_fields and not self.config.output_lines:
+            raise ValueError("output_lines is required when write_fields=True.")
+
+        if self.config.field_names_per_raster is not None:
+            if len(self.config.field_names_per_raster) != len(self.config.input_rasters):
+                raise ValueError(
+                    "field_names_per_raster must have the same length as input_rasters."
+                )
+
+    def _resolve_requested_modes(self) -> tuple[_ConcreteLineZValueMode, ...]:
+        requested = set()
+
+        for mode in self.config.endpoint_modes:
+            if mode == LineZValueMode.START_POINT:
+                requested.add(_ConcreteLineZValueMode.START_POINT)
+
+            elif mode == LineZValueMode.END_POINT:
+                requested.add(_ConcreteLineZValueMode.END_POINT)
+
+            elif mode == LineZValueMode.BOTH_ENDPOINTS:
+                requested.add(_ConcreteLineZValueMode.START_POINT)
+                requested.add(_ConcreteLineZValueMode.END_POINT)
+
+            else:
+                raise ValueError(f"Unsupported endpoint mode: {mode}")
+
+        ordered_modes = (
+            _ConcreteLineZValueMode.START_POINT,
+            _ConcreteLineZValueMode.END_POINT,
+        )
+
+        return tuple(mode for mode in ordered_modes if mode in requested)
+
+    def _resolve_field_names(self) -> tuple[LineZValueFieldNameConfig, ...]:
+        if self.config.field_names_per_raster is not None:
+            return self.config.field_names_per_raster
+
+        n = len(self.config.input_rasters)
+
+        if n == 1:
+            return (LineZValueFieldNameConfig(),)
+
+        return tuple(
+            LineZValueFieldNameConfig(
+                start_z=f"start_z_{i + 1}",
+                end_z=f"end_z_{i + 1}",
+            )
+            for i in range(n)
+        )
+
+    def _build_ordered_slots(self) -> list[tuple[int, _ConcreteLineZValueMode]]:
+        slots = []
+
+        for raster_idx in range(len(self.config.input_rasters)):
+            for mode in self.resolved_modes:
+                slots.append((raster_idx, mode))
+
+        return slots
+
+    def _build_output_field_names_ordered(self) -> list[str]:
+        field_names = []
+
+        for raster_idx, mode in self.ordered_slots:
+            fn_config = self.resolved_field_names[raster_idx]
+
+            if mode == _ConcreteLineZValueMode.START_POINT:
+                field_names.append(fn_config.start_z)
+            else:
+                field_names.append(fn_config.end_z)
+
+        return field_names
+
+    def _prepare_processing_feature_class(self) -> str:
+        if not self.config.write_fields:
+            return self.config.input_lines
+
+        arcpy.management.CopyFeatures(
+            self.config.input_lines,
+            self.config.output_lines,
+        )
+        return self.config.output_lines
+
+    def _ensure_output_fields(self, lines_fc: str) -> None:
+        existing_fields = {field.name for field in arcpy.ListFields(lines_fc)}
+
+        for field_name in self._build_output_field_names_ordered():
+            if field_name in existing_fields:
+                continue
+
+            arcpy.management.AddField(
+                in_table=lines_fc,
+                field_name=field_name,
+                field_type="DOUBLE",
+            )
+
+    def _check_spatial_reference(self) -> None:
+        try:
+            lines_sr = arcpy.Describe(self.config.input_lines).spatialReference
+        except Exception:
+            return
+
+        for raster_path in self.config.input_rasters:
+            try:
+                raster_sr = arcpy.Describe(raster_path).spatialReference
+            except Exception:
+                continue
+
+            if lines_sr.factoryCode == 0 or raster_sr.factoryCode == 0:
+                continue
+
+            if lines_sr.factoryCode != raster_sr.factoryCode:
+                arcpy.AddWarning(
+                    f"Spatial reference mismatch: input lines ({lines_sr.name}) vs "
+                    f"raster ({raster_sr.name}): {raster_path}. "
+                    "Z values are sampled using line coordinates without reprojection."
+                )
+
+    def _calculate_row_z(self, polyline) -> _RowZValueResult:
+        if polyline is None:
+            return self._unsupported_result("null_geometry")
+
+        if polyline.isMultipart:
+            return self._unsupported_result("multipart_not_supported")
+
+        start_point, end_point = self._extract_endpoints(polyline)
+
+        if start_point is None:
+            return self._unsupported_result("too_few_vertices")
+
+        z_by_slot: dict[tuple[int, _ConcreteLineZValueMode], Optional[float]] = {}
+
+        for raster_idx, mode in self.ordered_slots:
+            raster = self.config.input_rasters[raster_idx]
+
+            if mode == _ConcreteLineZValueMode.START_POINT:
+                z = self._sample_raster_at_point(raster, start_point.X, start_point.Y)
+            else:
+                z = self._sample_raster_at_point(raster, end_point.X, end_point.Y)
+
+            z_by_slot[(raster_idx, mode)] = z
+
+        return _RowZValueResult(
+            z_by_slot=z_by_slot,
+            issues=(),
+            is_supported=True,
+        )
+
+    def _extract_endpoints(self, polyline) -> tuple[Optional[object], Optional[object]]:
+        vertices = []
+
+        for part in polyline:
+            for point in part:
+                if point is not None:
+                    vertices.append(point)
+
+        if len(vertices) < 2:
+            return None, None
+
+        return vertices[0], vertices[-1]
+
+    @staticmethod
+    def _sample_raster_at_point(raster: str, x: float, y: float) -> Optional[float]:
+        result = arcpy.management.GetCellValue(
+            in_raster=raster,
+            location_point=f"{x} {y}",
+        )
+        value_str = result.getOutput(0)
+
+        if value_str == "NoData":
+            return None
+
+        try:
+            return float(value_str)
+        except (ValueError, TypeError):
+            return None
+
+    def _unsupported_result(self, issue: str) -> _RowZValueResult:
+        return _RowZValueResult(
+            z_by_slot={slot: None for slot in self.ordered_slots},
+            issues=(issue,),
+            is_supported=False,
+        )
+
+    def _write_row_values_to_cursor_row(
+        self,
+        row: list,
+        row_result: _RowZValueResult,
+    ) -> None:
+        for index, slot in enumerate(self.ordered_slots, start=2):
+            row[index] = row_result.z_by_slot.get(slot)
+
+    def _serialize_row_result(self, row_result: _RowZValueResult) -> dict:
+        public_mode_by_private = {
+            _ConcreteLineZValueMode.START_POINT: LineZValueMode.START_POINT,
+            _ConcreteLineZValueMode.END_POINT: LineZValueMode.END_POINT,
+        }
+
+        z_by_raster_by_mode: dict[str, dict[LineZValueMode, Optional[float]]] = {}
+
+        for (raster_idx, mode), z_value in row_result.z_by_slot.items():
+            raster_path = self.config.input_rasters[raster_idx]
+            public_mode = public_mode_by_private[mode]
+
+            if raster_path not in z_by_raster_by_mode:
+                z_by_raster_by_mode[raster_path] = {}
+
+            z_by_raster_by_mode[raster_path][public_mode] = z_value
+
+        return {
+            "z_by_raster_by_mode": z_by_raster_by_mode,
+            "issues": row_result.issues,
+            "is_supported": row_result.is_supported,
+        }
+
+    def _track_issues(self, issues: tuple[str, ...]) -> None:
+        for issue in issues:
+            self.issue_counts[issue] = self.issue_counts.get(issue, 0) + 1
+
+    def _emit_summary_warnings(self) -> None:
+        for issue, count in sorted(self.issue_counts.items()):
+            arcpy.AddWarning(f"{count} feature(s) returned issue: {issue}")
+
+
 def local_line_angle_at_xy(
     *,
     polyline,
@@ -1001,3 +1335,102 @@ def local_line_angle_at_xy(
         angle = _whole_line_angle()
 
     return angle
+
+
+def find_rasters_for_vector_extent(
+    raster_dir: str,
+    input_features: Union[str, list[str]],
+) -> list[str]:
+    """
+    Return paths of all .tif files in raster_dir whose extents intersect
+    the combined extent of the given input feature classes.
+
+    The directory is treated as flat — subdirectories are not searched.
+    Auxiliary sidecar files (.aux.xml, .ovr, etc.) are ignored.
+
+    Extent comparison is done in each dataset's own coordinate system.
+    A warning is emitted if the vector SR differs from the raster SR, but
+    no reprojection is performed.
+
+    Args:
+        raster_dir: Path to a flat directory containing .tif raster files.
+        input_features: One or more feature class paths whose combined extent
+            defines the area of interest.
+
+    Returns:
+        Sorted list of .tif file paths that intersect the vector extent.
+    """
+    if isinstance(input_features, str):
+        input_features = [input_features]
+
+    tif_paths = sorted(
+        os.path.join(raster_dir, f)
+        for f in os.listdir(raster_dir)
+        if f.lower().endswith(".tif")
+    )
+
+    if not tif_paths:
+        return []
+
+    union_xmin = float("inf")
+    union_ymin = float("inf")
+    union_xmax = float("-inf")
+    union_ymax = float("-inf")
+    vector_sr = None
+
+    for fc in input_features:
+        try:
+            desc = arcpy.Describe(fc)
+            ext = desc.extent
+            union_xmin = min(union_xmin, ext.XMin)
+            union_ymin = min(union_ymin, ext.YMin)
+            union_xmax = max(union_xmax, ext.XMax)
+            union_ymax = max(union_ymax, ext.YMax)
+            if vector_sr is None:
+                vector_sr = desc.spatialReference
+        except Exception:
+            arcpy.AddWarning(
+                f"Could not read extent of feature class: {fc}. Skipping."
+            )
+
+    if union_xmin == float("inf"):
+        return []
+
+    sr_warning_emitted = False
+    matched = []
+
+    for tif_path in tif_paths:
+        try:
+            raster_desc = arcpy.Describe(tif_path)
+            raster_ext = raster_desc.extent
+            raster_sr = raster_desc.spatialReference
+
+            if (
+                not sr_warning_emitted
+                and vector_sr is not None
+                and raster_sr is not None
+                and vector_sr.factoryCode != 0
+                and raster_sr.factoryCode != 0
+                and vector_sr.factoryCode != raster_sr.factoryCode
+            ):
+                arcpy.AddWarning(
+                    f"Spatial reference mismatch: input features ({vector_sr.name}) vs "
+                    f"raster ({raster_sr.name}). "
+                    "Extent intersection is compared without reprojection."
+                )
+                sr_warning_emitted = True
+
+            if (
+                raster_ext.XMax > union_xmin
+                and raster_ext.XMin < union_xmax
+                and raster_ext.YMax > union_ymin
+                and raster_ext.YMin < union_ymax
+            ):
+                matched.append(tif_path)
+
+        except Exception:
+            arcpy.AddWarning(
+                f"Could not read extent of raster: {tif_path}. Skipping."
+            )
+
+    return matched

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from enum import Enum
-from math import atan2, degrees
+from math import atan2, ceil, degrees, floor
 from typing import Optional, Union, Dict
 
 import arcpy
+import numpy as np
 
 from composition_configs.logic_config import (
     AngleToolConfig,
@@ -20,10 +21,11 @@ from composition_configs.logic_config import (
     LineZValueMode,
     LineZValueToolConfig,
 )
+from composition_configs.type_defs import RasterFilePath
 
 from xarray.backends.common import NONE_VAR_NAME
 
-from custom_tools.general_tools import custom_arcpy
+from custom_tools.general_tools import custom_arcpy, file_utilities
 from custom_tools.decorators.partition_io_decorator import partition_io_decorator
 from custom_tools.general_tools import custom_arcpy
 from file_manager.n100.file_manager_rivers import River_N100
@@ -875,6 +877,33 @@ class LineEndpointTool:
             arcpy.AddWarning(f"{count} feature(s) returned issue: {issue}")
 
 
+@dataclass
+class RasterHandle:
+    """
+    An in-memory window of a raster tile with the coordinate metadata needed
+    for O(1) point lookups.
+
+    Built by build_raster_handle; queried by local_z_at_xy.
+
+    Attributes:
+        array: 2-D float array (rows top-to-bottom). NoData cells are nan.
+        xmin:  west edge of the loaded window in map coordinates.
+        ymax:  north edge of the loaded window in map coordinates.
+        xmax:  east edge of the loaded window in map coordinates.
+        ymin:  south edge of the loaded window in map coordinates.
+        cell_w: cell width in map units.
+        cell_h: cell height in map units.
+    """
+
+    array: np.ndarray
+    xmin: float
+    ymax: float
+    xmax: float
+    ymin: float
+    cell_w: float
+    cell_h: float
+
+
 class _ConcreteLineZValueMode(str, Enum):
     START_POINT = "start_point"
     END_POINT = "end_point"
@@ -919,6 +948,14 @@ class LineZValueTool:
         """
         Main entrypoint.
 
+        Two-pass design:
+            Pass 1 (SearchCursor): collect all endpoint coordinates and
+                record any geometry issues.
+            Build: load each raster into a RasterHandle windowed to the
+                bounding box of all collected points (one IO call per raster).
+            Compute: look up Z values via in-memory array indexing.
+            Pass 2 (UpdateCursor, when write_fields=True): write results.
+
         Returns:
             A dict keyed by OID with z_by_raster_by_mode, issues, and
             is_supported entries, or None when return_results=False.
@@ -929,34 +966,34 @@ class LineZValueTool:
         if self.config.write_fields:
             self._ensure_output_fields(lines_fc=lines_fc)
 
+        valid_endpoints, issues_by_oid = self._collect_endpoints(lines_fc)
+
+        for issue in issues_by_oid.values():
+            self._track_issues((issue,))
+
+        raster_handles = self._build_raster_handles_for_endpoints(valid_endpoints)
+        z_by_oid = self._compute_z_values(valid_endpoints, raster_handles)
+
         results_by_oid: dict[int, dict] = {}
-        field_names = ["OID@", "SHAPE@"]
 
         if self.config.write_fields:
-            field_names.extend(self._build_output_field_names_ordered())
+            field_names = ["OID@"] + self._build_output_field_names_ordered()
 
             with arcpy.da.UpdateCursor(lines_fc, field_names) as cursor:
                 for row in cursor:
                     oid = row[0]
-                    polyline = row[1]
-
-                    row_result = self._calculate_row_z(polyline=polyline)
-                    self._track_issues(row_result.issues)
-
+                    row_result = self._make_row_result(oid, z_by_oid, issues_by_oid)
                     self._write_row_values_to_cursor_row(row=row, row_result=row_result)
                     cursor.updateRow(row)
 
                     if self.config.return_results:
                         results_by_oid[oid] = self._serialize_row_result(row_result)
 
-        else:
-            with arcpy.da.SearchCursor(lines_fc, field_names) as cursor:
-                for oid, polyline in cursor:
-                    row_result = self._calculate_row_z(polyline=polyline)
-                    self._track_issues(row_result.issues)
-
-                    if self.config.return_results:
-                        results_by_oid[oid] = self._serialize_row_result(row_result)
+        elif self.config.return_results:
+            all_oids = set(valid_endpoints.keys()) | set(issues_by_oid.keys())
+            for oid in all_oids:
+                row_result = self._make_row_result(oid, z_by_oid, issues_by_oid)
+                results_by_oid[oid] = self._serialize_row_result(row_result)
 
         self._emit_summary_warnings()
 
@@ -986,7 +1023,9 @@ class LineZValueTool:
             raise ValueError("output_lines is required when write_fields=True.")
 
         if self.config.field_names_per_raster is not None:
-            if len(self.config.field_names_per_raster) != len(self.config.input_rasters):
+            if len(self.config.field_names_per_raster) != len(
+                self.config.input_rasters
+            ):
                 raise ValueError(
                     "field_names_per_raster must have the same length as input_rasters."
                 )
@@ -1058,6 +1097,7 @@ class LineZValueTool:
         if not self.config.write_fields:
             return self.config.input_lines
 
+        file_utilities.delete_feature(input_feature=self.config.output_lines)
         arcpy.management.CopyFeatures(
             self.config.input_lines,
             self.config.output_lines,
@@ -1099,32 +1139,119 @@ class LineZValueTool:
                     "Z values are sampled using line coordinates without reprojection."
                 )
 
-    def _calculate_row_z(self, polyline) -> _RowZValueResult:
-        if polyline is None:
-            return self._unsupported_result("null_geometry")
+    def _collect_endpoints(
+        self,
+        lines_fc: str,
+    ) -> tuple[
+        dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]],
+        dict[int, str],
+    ]:
+        valid_endpoints: dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]] = {}
+        issues_by_oid: dict[int, str] = {}
 
-        if polyline.isMultipart:
-            return self._unsupported_result("multipart_not_supported")
+        with arcpy.da.SearchCursor(lines_fc, ["OID@", "SHAPE@"]) as cursor:
+            for oid, polyline in cursor:
+                if polyline is None:
+                    issues_by_oid[oid] = "null_geometry"
+                    continue
 
-        start_point, end_point = self._extract_endpoints(polyline)
+                if polyline.isMultipart:
+                    issues_by_oid[oid] = "multipart_not_supported"
+                    continue
 
-        if start_point is None:
-            return self._unsupported_result("too_few_vertices")
+                start_point, end_point = self._extract_endpoints(polyline)
 
-        z_by_slot: dict[tuple[int, _ConcreteLineZValueMode], Optional[float]] = {}
+                if start_point is None:
+                    issues_by_oid[oid] = "too_few_vertices"
+                    continue
 
-        for raster_idx, mode in self.ordered_slots:
-            raster = self.config.input_rasters[raster_idx]
+                endpoints_for_oid: dict[_ConcreteLineZValueMode, tuple[float, float]] = {}
 
-            if mode == _ConcreteLineZValueMode.START_POINT:
-                z = self._sample_raster_at_point(raster, start_point.X, start_point.Y)
-            else:
-                z = self._sample_raster_at_point(raster, end_point.X, end_point.Y)
+                for mode in self.resolved_modes:
+                    if mode == _ConcreteLineZValueMode.START_POINT:
+                        endpoints_for_oid[mode] = (start_point.X, start_point.Y)
+                    else:
+                        endpoints_for_oid[mode] = (end_point.X, end_point.Y)
 
-            z_by_slot[(raster_idx, mode)] = z
+                valid_endpoints[oid] = endpoints_for_oid
+
+        return valid_endpoints, issues_by_oid
+
+    def _build_raster_handles_for_endpoints(
+        self,
+        valid_endpoints: dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]],
+    ) -> list[Optional[RasterHandle]]:
+        all_xy = [
+            xy
+            for ep in valid_endpoints.values()
+            for xy in ep.values()
+        ]
+
+        if not all_xy:
+            return [None] * len(self.config.input_rasters)
+
+        clip_xmin = min(xy[0] for xy in all_xy)
+        clip_ymin = min(xy[1] for xy in all_xy)
+        clip_xmax = max(xy[0] for xy in all_xy)
+        clip_ymax = max(xy[1] for xy in all_xy)
+
+        handles: list[Optional[RasterHandle]] = []
+
+        for raster_path in self.config.input_rasters:
+            try:
+                handle = build_raster_handle(
+                    raster_path=raster_path,
+                    clip_xmin=clip_xmin,
+                    clip_ymin=clip_ymin,
+                    clip_xmax=clip_xmax,
+                    clip_ymax=clip_ymax,
+                )
+                handles.append(handle)
+            except Exception as exc:
+                arcpy.AddWarning(
+                    f"Could not load raster {raster_path}: {exc}. "
+                    "Z values for this raster will be None."
+                )
+                handles.append(None)
+
+        return handles
+
+    def _compute_z_values(
+        self,
+        valid_endpoints: dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]],
+        raster_handles: list[Optional[RasterHandle]],
+    ) -> dict[int, dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]]:
+        z_by_oid: dict[int, dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]] = {}
+
+        for oid, endpoints_for_oid in valid_endpoints.items():
+            z_by_slot: dict[tuple[int, _ConcreteLineZValueMode], Optional[float]] = {}
+
+            for raster_idx, handle in enumerate(raster_handles):
+                for mode in self.resolved_modes:
+                    xy = endpoints_for_oid[mode]
+
+                    if handle is None:
+                        z_by_slot[(raster_idx, mode)] = None
+                    else:
+                        z_by_slot[(raster_idx, mode)] = local_z_at_xy(
+                            [handle], xy[0], xy[1]
+                        )
+
+            z_by_oid[oid] = z_by_slot
+
+        return z_by_oid
+
+    def _make_row_result(
+        self,
+        oid: int,
+        z_by_oid: dict[int, dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]],
+        issues_by_oid: dict[int, str],
+    ) -> _RowZValueResult:
+        if oid in issues_by_oid:
+            return self._unsupported_result(issues_by_oid[oid])
 
         return _RowZValueResult(
-            z_by_slot=z_by_slot,
+            z_by_slot=z_by_oid.get(oid, {}),
             issues=(),
             is_supported=True,
         )
@@ -1141,22 +1268,6 @@ class LineZValueTool:
             return None, None
 
         return vertices[0], vertices[-1]
-
-    @staticmethod
-    def _sample_raster_at_point(raster: str, x: float, y: float) -> Optional[float]:
-        result = arcpy.management.GetCellValue(
-            in_raster=raster,
-            location_point=f"{x} {y}",
-        )
-        value_str = result.getOutput(0)
-
-        if value_str == "NoData":
-            return None
-
-        try:
-            return float(value_str)
-        except (ValueError, TypeError):
-            return None
 
     def _unsupported_result(self, issue: str) -> _RowZValueResult:
         return _RowZValueResult(
@@ -1337,10 +1448,138 @@ def local_line_angle_at_xy(
     return angle
 
 
+def build_raster_handle(
+    raster_path: str,
+    clip_xmin: Optional[float] = None,
+    clip_ymin: Optional[float] = None,
+    clip_xmax: Optional[float] = None,
+    clip_ymax: Optional[float] = None,
+) -> RasterHandle:
+    """
+    Load a raster tile (or a clipped window of it) into a RasterHandle for
+    fast in-memory point lookups via local_z_at_xy.
+
+    When clip bounds are provided the loaded window is the intersection of
+    those bounds with the tile extent, snapped outward to cell boundaries so
+    that every point within the clip is covered.  When no clip bounds are
+    given the full tile is loaded (use only for small rasters).
+
+    NoData cells are stored as nan; callers receive None from local_z_at_xy
+    for those cells.
+
+    Args:
+        raster_path: Path to the raster file.
+        clip_xmin: West edge of the region of interest in map coordinates.
+        clip_ymin: South edge of the region of interest in map coordinates.
+        clip_xmax: East edge of the region of interest in map coordinates.
+        clip_ymax: North edge of the region of interest in map coordinates.
+
+    Returns:
+        RasterHandle ready for local_z_at_xy queries.
+    """
+    desc = arcpy.Describe(raster_path)
+    tile_xmin = desc.extent.XMin
+    tile_ymin = desc.extent.YMin
+    tile_xmax = desc.extent.XMax
+    tile_ymax = desc.extent.YMax
+    cell_w = desc.meanCellWidth
+    cell_h = desc.meanCellHeight
+    tile_ncols = int(round((tile_xmax - tile_xmin) / cell_w))
+    tile_nrows = int(round((tile_ymax - tile_ymin) / cell_h))
+
+    if all(v is not None for v in [clip_xmin, clip_ymin, clip_xmax, clip_ymax]):
+        # Intersect clip with tile extent then snap outward to cell boundaries.
+        effective_xmin = max(tile_xmin, clip_xmin)
+        effective_ymin = max(tile_ymin, clip_ymin)
+        effective_xmax = min(tile_xmax, clip_xmax)
+        effective_ymax = min(tile_ymax, clip_ymax)
+
+        col_start = max(0, floor((effective_xmin - tile_xmin) / cell_w))
+        row_start = max(0, floor((tile_ymax - effective_ymax) / cell_h))
+        col_end = min(tile_ncols, ceil((effective_xmax - tile_xmin) / cell_w))
+        row_end = min(tile_nrows, ceil((tile_ymax - effective_ymin) / cell_h))
+
+        ncols = max(1, col_end - col_start)
+        nrows = max(1, row_end - row_start)
+
+        window_xmin = tile_xmin + col_start * cell_w
+        window_ymax = tile_ymax - row_start * cell_h
+    else:
+        ncols = tile_ncols
+        nrows = tile_nrows
+        window_xmin = tile_xmin
+        window_ymax = tile_ymax
+
+    window_xmax = window_xmin + ncols * cell_w
+    window_ymin = window_ymax - nrows * cell_h
+
+    array = arcpy.RasterToNumPyArray(
+        in_raster=raster_path,
+        lower_left_corner=arcpy.Point(window_xmin, window_ymin),
+        ncols=ncols,
+        nrows=nrows,
+        nodata_to_value=np.nan,
+    ).astype(float)
+
+    return RasterHandle(
+        array=array,
+        xmin=window_xmin,
+        ymax=window_ymax,
+        xmax=window_xmax,
+        ymin=window_ymin,
+        cell_w=cell_w,
+        cell_h=cell_h,
+    )
+
+
+def local_z_at_xy(
+    raster_handles: list[RasterHandle],
+    x: float,
+    y: float,
+) -> Optional[float]:
+    """
+    Return the raster Z value at (x, y) from the first handle whose window
+    covers the point.
+
+    Pure function — no IO.  Mirrors local_line_angle_at_xy in intent: it is
+    designed to be called on demand inside a processing loop after handles
+    have been built once with build_raster_handle.
+
+    Returns None when the point falls outside all handles, lands on a NoData
+    cell, or the index computation produces an out-of-bounds result.
+
+    Args:
+        raster_handles: Ordered list of RasterHandle objects to search.
+        x: X coordinate in the same spatial reference as the handles.
+        y: Y coordinate in the same spatial reference as the handles.
+
+    Returns:
+        Z value as float, or None.
+    """
+    for handle in raster_handles:
+        if not (handle.xmin <= x < handle.xmax and handle.ymin < y <= handle.ymax):
+            continue
+
+        col = int((x - handle.xmin) / handle.cell_w)
+        row = int((handle.ymax - y) / handle.cell_h)
+
+        nrows, ncols = handle.array.shape
+        if not (0 <= row < nrows and 0 <= col < ncols):
+            continue
+
+        z = handle.array[row, col]
+        if np.isnan(z):
+            return None
+
+        return float(z)
+
+    return None
+
+
 def find_rasters_for_vector_extent(
     raster_dir: str,
     input_features: Union[str, list[str]],
-) -> list[str]:
+) -> list[RasterFilePath]:
     """
     Return paths of all .tif files in raster_dir whose extents intersect
     the combined extent of the given input feature classes.
@@ -1389,9 +1628,7 @@ def find_rasters_for_vector_extent(
             if vector_sr is None:
                 vector_sr = desc.spatialReference
         except Exception:
-            arcpy.AddWarning(
-                f"Could not read extent of feature class: {fc}. Skipping."
-            )
+            arcpy.AddWarning(f"Could not read extent of feature class: {fc}. Skipping.")
 
     if union_xmin == float("inf"):
         return []
@@ -1426,11 +1663,9 @@ def find_rasters_for_vector_extent(
                 and raster_ext.YMax > union_ymin
                 and raster_ext.YMin < union_ymax
             ):
-                matched.append(tif_path)
+                matched.append(RasterFilePath(tif_path))
 
         except Exception:
-            arcpy.AddWarning(
-                f"Could not read extent of raster: {tif_path}. Skipping."
-            )
+            arcpy.AddWarning(f"Could not read extent of raster: {tif_path}. Skipping.")
 
     return matched

--- a/custom_tools/general_tools/geometry_tools.py
+++ b/custom_tools/general_tools/geometry_tools.py
@@ -1,8 +1,3 @@
-from typing import Dict, Union
-
-import arcpy
-from __future__ import annotations
-
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -25,11 +20,8 @@ from composition_configs.logic_config import (
 )
 from composition_configs.type_defs import RasterFilePath
 
-from xarray.backends.common import NONE_VAR_NAME
-
 from custom_tools.general_tools import custom_arcpy, file_utilities
 from custom_tools.decorators.partition_io_decorator import partition_io_decorator
-from custom_tools.general_tools import custom_arcpy
 from file_manager.n100.file_manager_rivers import River_N100
 
 
@@ -1148,7 +1140,9 @@ class LineZValueTool:
         dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]],
         dict[int, str],
     ]:
-        valid_endpoints: dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]] = {}
+        valid_endpoints: dict[
+            int, dict[_ConcreteLineZValueMode, tuple[float, float]]
+        ] = {}
         issues_by_oid: dict[int, str] = {}
 
         with arcpy.da.SearchCursor(lines_fc, ["OID@", "SHAPE@"]) as cursor:
@@ -1167,7 +1161,9 @@ class LineZValueTool:
                     issues_by_oid[oid] = "too_few_vertices"
                     continue
 
-                endpoints_for_oid: dict[_ConcreteLineZValueMode, tuple[float, float]] = {}
+                endpoints_for_oid: dict[
+                    _ConcreteLineZValueMode, tuple[float, float]
+                ] = {}
 
                 for mode in self.resolved_modes:
                     if mode == _ConcreteLineZValueMode.START_POINT:
@@ -1183,11 +1179,7 @@ class LineZValueTool:
         self,
         valid_endpoints: dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]],
     ) -> list[Optional[RasterHandle]]:
-        all_xy = [
-            xy
-            for ep in valid_endpoints.values()
-            for xy in ep.values()
-        ]
+        all_xy = [xy for ep in valid_endpoints.values() for xy in ep.values()]
 
         if not all_xy:
             return [None] * len(self.config.input_rasters)
@@ -1223,7 +1215,9 @@ class LineZValueTool:
         valid_endpoints: dict[int, dict[_ConcreteLineZValueMode, tuple[float, float]]],
         raster_handles: list[Optional[RasterHandle]],
     ) -> dict[int, dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]]:
-        z_by_oid: dict[int, dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]] = {}
+        z_by_oid: dict[
+            int, dict[tuple[int, _ConcreteLineZValueMode], Optional[float]]
+        ] = {}
 
         for oid, endpoints_for_oid in valid_endpoints.items():
             z_by_slot: dict[tuple[int, _ConcreteLineZValueMode], Optional[float]] = {}
@@ -1987,7 +1981,8 @@ class LineZOrientTool:
                 dangle_z = end_z if dangle_ep == end_key else start_z
 
                 upstream_oids = [
-                    o for o in ep_to_oids.get(non_dangle_ep, [])
+                    o
+                    for o in ep_to_oids.get(non_dangle_ep, [])
                     if o != oid and o in component
                 ]
 
@@ -2009,7 +2004,8 @@ class LineZOrientTool:
                             # If one does, the dangle is a side branch and that other
                             # line is the true downstream continuation.
                             competing_oids = [
-                                o for o in ep_to_oids.get(non_dangle_ep, [])
+                                o
+                                for o in ep_to_oids.get(non_dangle_ep, [])
                                 if o != oid and o != longest_up and o in component
                             ]
                             true_outlet = True
@@ -2244,7 +2240,12 @@ class LineZOrientTool:
             # Phase 2 — uncertain lines.
             dangle_eps = self._find_dangle_endpoints(component, oid_to_eps, ep_to_oids)
             flips_p2, raw_z, unresolved = self._propagate_to_uncertain(
-                uncertain, certain, oriented_eps, oid_to_eps, ep_to_oids, z_by_oid,
+                uncertain,
+                certain,
+                oriented_eps,
+                oid_to_eps,
+                ep_to_oids,
+                z_by_oid,
                 dangle_eps,
             )
             all_flips.update(flips_p2)

--- a/custom_tools/general_tools/line_segmenter.py
+++ b/custom_tools/general_tools/line_segmenter.py
@@ -1,0 +1,105 @@
+import math
+import os
+
+import arcpy
+
+
+def segment_line(
+    input_fc: str,
+    output_fc: str,
+    segment_interval: float,
+    even_segments: bool = False,
+    tail_tolerance: float = 0.0,
+) -> None:
+    """Split each polyline in input_fc so no segment exceeds segment_interval.
+
+    Lines with length <= segment_interval pass through unchanged. Longer
+    lines are cut along their natural direction, and the source row's
+    non-functional fields (everything except OID, Shape, and required
+    auto-managed fields) are copied onto every emitted segment.
+
+    Singlepart polyline input only. Multipart input is not supported
+    because segmentAlongLine measures along cumulative length and the
+    resulting cuts may straddle parts in unexpected ways.
+
+    Args:
+        input_fc: Singlepart polyline feature class.
+        output_fc: Path of the feature class to create. Overwritten if it
+            already exists.
+        segment_interval: Maximum segment length in the input's linear
+            units. Must be > 0.
+        even_segments: When True, divide each long line into
+            ceil(L / segment_interval) equal-length pieces. When False,
+            cut at fixed segment_interval and emit the remainder as a
+            final segment (subject to tail_tolerance).
+        tail_tolerance: Fixed-mode only. When the remainder of a fixed
+            split is <= tail_tolerance, it is absorbed into the preceding
+            segment instead of emitted on its own. Default 0.0 disables
+            absorption. Sensible values are well below segment_interval.
+    """
+    if segment_interval <= 0:
+        raise ValueError("segment_interval must be > 0")
+    if tail_tolerance < 0:
+        raise ValueError("tail_tolerance must be >= 0")
+
+    if arcpy.Exists(output_fc):
+        arcpy.management.Delete(output_fc)
+
+    arcpy.management.CreateFeatureclass(
+        out_path=os.path.dirname(output_fc),
+        out_name=os.path.basename(output_fc),
+        geometry_type="POLYLINE",
+        template=input_fc,
+        spatial_reference=input_fc,
+    )
+
+    carried_fields = [
+        f.name for f in arcpy.ListFields(input_fc) if not f.required
+    ]
+    cursor_fields = ["SHAPE@"] + carried_fields
+
+    with arcpy.da.SearchCursor(input_fc, cursor_fields) as src, \
+            arcpy.da.InsertCursor(output_fc, cursor_fields) as dst:
+        for row in src:
+            geom = row[0]
+            if geom is None:
+                continue
+            attrs = list(row)
+            for start, end in _segment_positions(
+                geom.length, segment_interval, even_segments, tail_tolerance
+            ):
+                if start == 0.0 and end >= geom.length:
+                    attrs[0] = geom
+                else:
+                    attrs[0] = geom.segmentAlongLine(start, end, False)
+                dst.insertRow(attrs)
+
+
+def _segment_positions(
+    length: float,
+    interval: float,
+    even: bool,
+    tail_tolerance: float,
+):
+    """Yield (start, end) cut positions along a line of the given length."""
+    if length <= interval:
+        yield (0.0, length)
+        return
+    if even:
+        n = math.ceil(length / interval)
+        step = length / n
+        for i in range(n):
+            end = length if i == n - 1 else (i + 1) * step
+            yield (i * step, end)
+        return
+    n_full = int(length // interval)
+    remainder = length - n_full * interval
+    if 0 < remainder <= tail_tolerance:
+        for i in range(n_full - 1):
+            yield (i * interval, (i + 1) * interval)
+        yield ((n_full - 1) * interval, length)
+    else:
+        for i in range(n_full):
+            yield (i * interval, (i + 1) * interval)
+        if remainder > 0:
+            yield (n_full * interval, length)

--- a/custom_tools/general_tools/line_segmenter.py
+++ b/custom_tools/general_tools/line_segmenter.py
@@ -53,13 +53,12 @@ def segment_line(
         spatial_reference=input_fc,
     )
 
-    carried_fields = [
-        f.name for f in arcpy.ListFields(input_fc) if not f.required
-    ]
+    carried_fields = [f.name for f in arcpy.ListFields(input_fc) if not f.required]
     cursor_fields = ["SHAPE@"] + carried_fields
 
-    with arcpy.da.SearchCursor(input_fc, cursor_fields) as src, \
-            arcpy.da.InsertCursor(output_fc, cursor_fields) as dst:
+    with arcpy.da.SearchCursor(input_fc, cursor_fields) as src, arcpy.da.InsertCursor(
+        output_fc, cursor_fields
+    ) as dst:
         for row in src:
             geom = row[0]
             if geom is None:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 import math
 import os
+import time  # [DBG_LINEGAP]
 
 from typing import Optional, Callable, Iterable, Any, TypeAlias, NamedTuple
 
@@ -10,6 +11,7 @@ import arcpy
 
 from env_setup import environment_setup
 from custom_tools.general_tools import custom_arcpy, file_utilities
+from custom_tools.general_tools.line_segmenter import segment_line
 from file_manager import WorkFileManager
 from composition_configs import logic_config
 from composition_configs.logic_config import ConnectivityScope, LineConnectivityMode
@@ -65,8 +67,11 @@ class NearCandidate:
     """One row from the GenerateNearTable output, already keyed against the canonical
     dataset keys (line-like targets collapsed onto a single ``lines_key``).
 
-    near_fc_key_raw preserves the original dataset key before normalization; kept for
-    debugging only.
+    near_fc_key_raw preserves the original dataset key before normalization;
+    near_fid_raw preserves the original OID before parent-id mapping. Together
+    they let the per-segment angle path reach the segmented twin's polyline
+    geometry when segmentation is enabled. With segmentation off, near_fid_raw
+    equals near_fid and near_fc_key_raw equals the source FC key.
 
     near_fid is polymorphic (DangleOid when near_fc_key == dangles_key, ParentId when
     near_fc_key == lines_key, external-dataset FID otherwise); stays as int.
@@ -78,6 +83,7 @@ class NearCandidate:
     near_x: float
     near_y: float
     near_fc_key_raw: DatasetKey
+    near_fid_raw: int
 
 
 @dataclass(frozen=True)
@@ -1184,10 +1190,18 @@ class _ScoredCandidateItem:
 class _AngleCaches:
     """Polyline and line-type caches consumed by the CANDIDATE scope.
 
-    polyline_by_parent: self-line polylines keyed by parent_id.
+    polyline_by_parent: self-line polylines keyed by parent_id. Used for the
+        SOURCE side of every candidate (the source dangle sits at a parent
+        endpoint) and for dangle-to-dangle target lookups (the other dangle is
+        also at its parent's endpoint).
     polyline_by_external: polylines from external polyline targets, keyed by
-        dataset_key then SOURCE OID. Only populated for targets that survive
-        the line-like classification below.
+        SOURCE dataset_key then SOURCE OID. Used for the target side when
+        segmentation is None. Only populated for targets that survive the
+        line-like classification below.
+    polyline_by_segment: polylines from segmented twin FCs, keyed by raw
+        segmented dataset_key then segmented OID. Empty when segmentation is
+        None. Used for the target side when segmentation is set so each
+        candidate is scored against its own segment's local geometry.
     is_external_line_like: per external dataset_key, whether it is treated as
         a line-like target for scoring. Respects
         connect_to_features_angle_mode overrides.
@@ -1199,6 +1213,7 @@ class _AngleCaches:
 
     polyline_by_parent: dict[ParentId, Any]
     polyline_by_external: dict[DatasetKey, dict[int, Any]]
+    polyline_by_segment: dict[DatasetKey, dict[int, Any]]
     is_external_line_like: dict[DatasetKey, bool]
     line_like_external_ds_keys: set[DatasetKey]
     line_like_ds_keys: set[DatasetKey]
@@ -1344,10 +1359,16 @@ class FillLineGaps:
 
         self.fill_gaps_on_self = bool(line_gap_config.fill_gaps_on_self)
         self.best_fit_weights = line_gap_config.best_fit_weights
+        self.segmentation = line_gap_config.segmentation
 
         self.line_changes_output = out.line_changes_output
         self.write_output_metadata = bool(out.write_output_metadata)
         self.candidate_connections_output = out.candidate_connections_output
+        self.diagnostic_detail = logic_config.DiagnosticDetail(out.diagnostic_detail)
+        self._collect_diags = (
+            self.candidate_connections_output is not None
+            and self.diagnostic_detail is not logic_config.DiagnosticDetail.OFF
+        )
 
         self.increased_tolerance_edge_case_distance_meters = int(
             adv.increased_tolerance_edge_case_distance_meters
@@ -1356,6 +1377,8 @@ class FillLineGaps:
             adv.require_mutual_dangle_preference_for_bonus
         )
         self.edit_method = logic_config.EditMethod(adv.edit_method)
+        self.candidate_closest_count = int(adv.candidate_closest_count)
+        self.connectivity_closest_count = int(adv.connectivity_closest_count)
 
         self.connectivity_scope = logic_config.ConnectivityScope(
             conn.connectivity_scope
@@ -1437,6 +1460,16 @@ class FillLineGaps:
         self.conn_endpoints = "line_endpoints"
         self.conn_table = "connected_table"
 
+        # Segmented twins of lines_copy / target_self / each line-like external
+        # target layer. Built by _setup_segmentation when self.segmentation is
+        # set; used by the candidate near table only. Other phases continue to
+        # read the unsegmented originals. Lookups map a segmented FC's OID
+        # space back to parent ORIGINAL_ID.
+        self.lines_copy_segmented = "lines_copy_segmented"
+        self.target_self_segmented = "target_self_segmented"
+        self.external_target_layers_segmented: list[str] = []
+        self._segmented_oid_to_parent_id: dict[str, dict[int, ParentId]] = {}
+
         self.external_target_layers: list[str] = []
         # FCs to use as against_fcs in the connector-crossing pre-filter.
         # Polyline connect_to_features are reused as-is; polygon
@@ -1456,6 +1489,11 @@ class FillLineGaps:
             self.conn_endpoints,
             self.conn_table,
         ]
+
+        if self.segmentation is not None:
+            self.work_file_list.extend(
+                [self.lines_copy_segmented, self.target_self_segmented]
+            )
 
     # ----------------------------
     # Units & dataset key
@@ -1480,10 +1518,14 @@ class FillLineGaps:
         return text.split("/")[-1]
 
     def _line_dataset_keys(self) -> set[str]:
-        return {
+        keys = {
             self._dataset_key(self.lines_copy),
             self._dataset_key(self.target_self),
         }
+        if self.segmentation is not None:
+            keys.add(self._dataset_key(self.lines_copy_segmented))
+            keys.add(self._dataset_key(self.target_self_segmented))
+        return keys
 
     def _normalize_target_key(
         self, *, near_fc_key: str, lines_key: str, line_keys: set[str]
@@ -1925,6 +1967,7 @@ class FillLineGaps:
         polyline_by_parent = self._build_polyline_by_parent_id()
 
         polyline_by_external: dict[DatasetKey, dict[int, Any]] = {}
+        polyline_by_segment: dict[DatasetKey, dict[int, Any]] = {}
         is_external_line_like: dict[DatasetKey, bool] = {}
 
         line_keys = self._line_dataset_keys()
@@ -1949,6 +1992,34 @@ class FillLineGaps:
             else:
                 is_external_line_like[ds_key] = False
 
+        # Per-segment polyline cache (consumed by _resolve_target_angle_and_snap
+        # when segmentation is enabled). Built only for the candidate-side
+        # segmented twins — the tolerance filter that scopes target_self also
+        # scopes target_self_segmented, so the cache size tracks candidate
+        # volume, not total segment count.
+        if self.segmentation is not None:
+            if self.fill_gaps_on_self:
+                seg_self_key = self._dataset_key(self.target_self_segmented)
+                polyline_by_segment[seg_self_key] = self._build_polyline_by_oid(
+                    self.target_self_segmented
+                )
+            # external_target_layers and external_target_layers_segmented are
+            # appended in lock-step in _setup_segmentation (one entry per
+            # source layer), so zip pairs each segmented twin with its source.
+            for ext_src, ext_seg in zip(
+                self.external_target_layers, self.external_target_layers_segmented
+            ):
+                if not self._is_polyline_fc(ext_seg):
+                    continue
+                src_mode = self._angle_mode_by_external_ds_key.get(
+                    self._dataset_key(ext_src), logic_config.AngleTargetMode.AUTO
+                )
+                if src_mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
+                    continue
+                polyline_by_segment[self._dataset_key(ext_seg)] = (
+                    self._build_polyline_by_oid(ext_seg)
+                )
+
         line_like_external_ds_keys: set[DatasetKey] = {
             ds_key for ds_key, is_line in is_external_line_like.items() if is_line
         }
@@ -1961,6 +2032,7 @@ class FillLineGaps:
         return _AngleCaches(
             polyline_by_parent=polyline_by_parent,
             polyline_by_external=polyline_by_external,
+            polyline_by_segment=polyline_by_segment,
             is_external_line_like=is_external_line_like,
             line_like_external_ds_keys=line_like_external_ds_keys,
             line_like_ds_keys=line_like_ds_keys,
@@ -2113,7 +2185,14 @@ class FillLineGaps:
         for index, feature_path in enumerate(self.connect_to_features):
             output_name = self.wfm.build_file_path(file_name=f"target_feature_{index}")
 
-            if self.write_work_files_to_memory:
+            # Segmentation needs to stamp ORIGINAL_ID on the output FC so the
+            # segmented twin can map back to a stable parent identifier;
+            # that requires a permanent FC rather than a memory-backed layer
+            # view (which would point at the user's source data).
+            use_memory_layer = (
+                self.write_work_files_to_memory and self.segmentation is None
+            )
+            if use_memory_layer:
                 custom_arcpy.select_location_and_make_feature_layer(
                     input_layer=feature_path,
                     overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
@@ -2128,6 +2207,23 @@ class FillLineGaps:
                     select_features=self.dangles,
                     output_name=output_name,
                     search_distance=self._tolerance_linear_unit(),
+                )
+
+            if self.segmentation is not None:
+                # Stamp ORIGINAL_ID = OID on the staged target FC so the
+                # segmented twin's segments can carry their parent's OID
+                # via segment_line's field-preservation, giving a clean
+                # segmented_oid -> parent_id mapping in the candidate near
+                # table reader.
+                existing = {f.name for f in arcpy.ListFields(output_name)}
+                if self.ORIGINAL_ID not in existing:
+                    arcpy.management.AddField(output_name, self.ORIGINAL_ID, "LONG")
+                oid_field = arcpy.Describe(output_name).OIDFieldName
+                arcpy.management.CalculateField(
+                    output_name,
+                    self.ORIGINAL_ID,
+                    expression=f"!{oid_field}!",
+                    expression_type="PYTHON3",
                 )
 
             self.external_target_layers.append(output_name)
@@ -2167,12 +2263,93 @@ class FillLineGaps:
 
             self._angle_mode_by_external_ds_key[str(out_key)] = mode
 
+    def _setup_segmentation(self) -> None:
+        """Build internal segmented twins of ``lines_copy`` and line-like
+        external target layers. Segmented twins are read only by the
+        candidate near table; other phases continue to use the unsegmented
+        originals.
+
+        ``ORIGINAL_ID`` is stamped on ``lines_copy`` by
+        ``_add_original_id_field`` and on each external target layer in
+        ``_build_external_target_layers_once`` (when segmentation is
+        enabled); ``segment_line`` preserves all non-required fields, so
+        each segment carries its parent's ORIGINAL_ID and the OID lookup
+        reduces to the existing ``_oid_to_original_id_lookup`` helper.
+
+        Polygon ``connect_to_features`` are not supported with segmentation
+        enabled — callers should convert polygons to polylines before
+        passing them in. Geometry types other than polygon and polyline
+        (e.g. points) pass through unsegmented; the candidate near table
+        reads them directly.
+
+        No-op when ``self.segmentation`` is None.
+        """
+        if self.segmentation is None:
+            return
+
+        seg_cfg = self.segmentation
+        even = seg_cfg.mode is logic_config.SegmentationMode.EVEN
+
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation lines_copy START")  # [DBG_LINEGAP]
+        segment_line(
+            input_fc=self.lines_copy,
+            output_fc=self.lines_copy_segmented,
+            segment_interval=float(seg_cfg.interval_meters),
+            even_segments=even,
+            tail_tolerance=float(seg_cfg.tail_tolerance_meters),
+        )
+        self._segmented_oid_to_parent_id[
+            self._dataset_key(self.lines_copy_segmented)
+        ] = self._oid_to_original_id_lookup(self.lines_copy_segmented)
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation lines_copy END (rows={int(arcpy.management.GetCount(self.lines_copy_segmented)[0])})")  # [DBG_LINEGAP]
+
+        for index, ext_path in enumerate(self.external_target_layers):
+            if self._is_polygon_fc(ext_path):
+                raise ValueError(
+                    f"connect_to_features[{index}] is a polygon feature class. "
+                    f"Segmentation only supports polyline connect_to_features. "
+                    f"Convert polygons to polylines (e.g. via PolygonToLine) "
+                    f"before passing them to FillLineGaps when segmentation "
+                    f"is enabled."
+                )
+            if not self._is_polyline_fc(ext_path):
+                # Non-line, non-polygon (e.g. point) — segmentation does
+                # not apply. Pass the source path through so the segmented
+                # list aligns with external_target_layers.
+                self.external_target_layers_segmented.append(ext_path)
+                continue
+
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation external[{index}] START")  # [DBG_LINEGAP]
+            seg_path = self.wfm.build_file_path(
+                file_name=f"target_feature_{index}_segmented"
+            )
+            segment_line(
+                input_fc=ext_path,
+                output_fc=seg_path,
+                segment_interval=float(seg_cfg.interval_meters),
+                even_segments=even,
+                tail_tolerance=float(seg_cfg.tail_tolerance_meters),
+            )
+            self.external_target_layers_segmented.append(seg_path)
+            self._segmented_oid_to_parent_id[
+                self._dataset_key(seg_path)
+            ] = self._oid_to_original_id_lookup(seg_path)
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation external[{index}] END (rows={int(arcpy.management.GetCount(seg_path)[0])})")  # [DBG_LINEGAP]
+
     def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
-        """Return the combined target layer list for the near table.
+        """Return the global target layer list for connectivity-side queries.
 
         Includes the tolerance-filtered self-lines layer (``target_self``)
         when ``fill_gaps_on_self`` is enabled, followed by the external
-        target layers built in ``_build_external_target_layers_once``.
+        target layers built in ``_build_external_target_layers_once``. The
+        candidate-side target list is produced separately by
+        ``_candidate_target_layers`` (which routes to segmented twins when
+        ``self.segmentation`` is set).
+
+        When segmentation is enabled and ``fill_gaps_on_self`` is True, also
+        builds ``target_self_segmented`` (a tolerance-filtered slice of
+        ``lines_copy_segmented``) and registers its segmented OID lookup so
+        the candidate near table reader can map back to parent ids.
         """
         targets: list[str] = []
         if self.fill_gaps_on_self:
@@ -2194,8 +2371,53 @@ class FillLineGaps:
                 )
             targets.append(self.target_self)
 
+            if self.segmentation is not None:
+                # target_self_segmented is built from lines_copy_segmented at
+                # the same tolerance filter — candidates reach segments by
+                # their segmented OID, the OID lookup maps back to parent_id.
+                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} target_self_segmented build START")  # [DBG_LINEGAP]
+                if self.write_work_files_to_memory:
+                    custom_arcpy.select_location_and_make_feature_layer(
+                        input_layer=self.lines_copy_segmented,
+                        overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                        select_features=self.dangles,
+                        output_name=self.target_self_segmented,
+                        search_distance=self._tolerance_linear_unit(),
+                    )
+                else:
+                    custom_arcpy.select_location_and_make_permanent_feature(
+                        input_layer=self.lines_copy_segmented,
+                        overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                        select_features=self.dangles,
+                        output_name=self.target_self_segmented,
+                        search_distance=self._tolerance_linear_unit(),
+                    )
+                self._segmented_oid_to_parent_id[
+                    self._dataset_key(self.target_self_segmented)
+                ] = self._oid_to_original_id_lookup(self.target_self_segmented)
+                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} target_self_segmented build END (rows={int(arcpy.management.GetCount(self.target_self_segmented)[0])})")  # [DBG_LINEGAP]
+
         targets.extend(self.external_target_layers)
         return targets
+
+    def _candidate_target_layers(self, global_target_layers: list[str]) -> list[str]:
+        """Translate the global target list to its segmented twins for the
+        candidate near table.
+
+        Returns ``global_target_layers`` unchanged when
+        ``self.segmentation`` is None. Otherwise returns
+        ``[target_self_segmented]`` (when ``fill_gaps_on_self``) followed
+        by ``external_target_layers_segmented`` — the same shape as
+        ``_select_targets_within_tolerance_of_dangles``, but every line-like
+        entry points at its segmented twin.
+        """
+        if self.segmentation is None:
+            return global_target_layers
+        out: list[str] = []
+        if self.fill_gaps_on_self:
+            out.append(self.target_self_segmented)
+        out.extend(self.external_target_layers_segmented)
+        return out
 
     def _filter_true_dangles(self) -> None:
         """
@@ -2667,6 +2889,7 @@ class FillLineGaps:
         connect_tol_m = float(self.connectivity_tolerance_meters)
         connect_tol = f"{connect_tol_m} Meters"
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(connectivity) START (in_endpoints={int(arcpy.management.GetCount(self.conn_endpoints)[0])}, near_features={len(near_features)}, radius={connect_tol})")  # [DBG_LINEGAP]
         arcpy.analysis.GenerateNearTable(
             in_features=self.conn_endpoints,
             near_features=near_features,
@@ -2675,9 +2898,10 @@ class FillLineGaps:
             location="NO_LOCATION",
             angle="NO_ANGLE",
             closest="ALL",
-            closest_count=100,
+            closest_count=self.connectivity_closest_count,
             method="PLANAR",
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(connectivity) END (conn_table_rows={int(arcpy.management.GetCount(self.conn_table)[0])})")  # [DBG_LINEGAP]
 
         lines_key = self._dataset_key(self.lines_copy)
         line_keys = self._line_dataset_keys()
@@ -2814,7 +3038,7 @@ class FillLineGaps:
             location="LOCATION",
             angle="NO_ANGLE",
             closest="ALL",
-            closest_count=100,
+            closest_count=self.candidate_closest_count,
             method="PLANAR",
         )
 
@@ -2850,17 +3074,25 @@ class FillLineGaps:
                     continue
 
                 in_id = int(in_fid)
-                nf_id = int(near_fid)
+                raw_fid = int(near_fid)
                 dist = float(near_dist)
 
                 raw_key = self._dataset_key(near_fc)
-                nf_id = int(near_fid)
 
-                # Convert line-like near_fid into ORIGINAL_ID space
-                if raw_key == lines_copy_key:
-                    nf_id = lines_copy_oid_to_orig.get(nf_id, nf_id)
+                # Convert line-like near_fid into ORIGINAL_ID space. Segmented
+                # twins (when self.segmentation is set) are checked first so
+                # the candidate near table's segmented OID maps to its parent
+                # ORIGINAL_ID; the lines_copy / target_self branches handle
+                # the unsegmented path.
+                seg_lookup = self._segmented_oid_to_parent_id.get(raw_key)
+                if seg_lookup is not None:
+                    nf_id = seg_lookup.get(raw_fid, raw_fid)
+                elif raw_key == lines_copy_key:
+                    nf_id = lines_copy_oid_to_orig.get(raw_fid, raw_fid)
                 elif raw_key == target_self_key:
-                    nf_id = target_self_oid_to_orig.get(nf_id, nf_id)
+                    nf_id = target_self_oid_to_orig.get(raw_fid, raw_fid)
+                else:
+                    nf_id = raw_fid
 
                 near_fc_key = self._normalize_target_key(
                     near_fc_key=raw_key,
@@ -2880,6 +3112,7 @@ class FillLineGaps:
                         near_x=float(near_x),
                         near_y=float(near_y),
                         near_fc_key_raw=raw_key,
+                        near_fid_raw=raw_fid,
                     )
                 )
 
@@ -3126,27 +3359,47 @@ class FillLineGaps:
         dangle_xy: dict[DangleOid, tuple[float, float]],
         polyline_by_parent: dict[ParentId, Any],
         polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        polyline_by_segment: dict[DatasetKey, dict[int, Any]],
     ) -> _TargetAngleResolution:
         """Resolve the target polyline, its local angle, and the snap point.
 
         For dangle-pair targets the snap defaults to the precise dangle XY
         (more accurate than the near-table snap, which is rounded). Other
         targets use the near-table coordinates directly.
+
+        When segmentation is enabled, line-target angle is evaluated against
+        the candidate's segment polyline (looked up via near_fc_key_raw +
+        near_fid_raw in polyline_by_segment) so each segment gets its own
+        local angle. Source-side dangle and other-dangle target lookups stay
+        on parent geometry — those endpoints sit at the parent's true ends.
         """
         near_fid = cand.near_fid
         snap_x = float(cand.near_x)
         snap_y = float(cand.near_y)
+        use_segment = self.segmentation is not None
 
         if ds_key == lines_fc_key:
             tgt_parent = int(near_fid)
-            tgt_poly = polyline_by_parent.get(tgt_parent)
+            if use_segment:
+                seg_lookup = polyline_by_segment.get(cand.near_fc_key_raw)
+                tgt_poly = (
+                    seg_lookup.get(int(cand.near_fid_raw))
+                    if seg_lookup is not None
+                    else None
+                )
+                angle_ds_key = cand.near_fc_key_raw
+                angle_oid = int(cand.near_fid_raw)
+            else:
+                tgt_poly = polyline_by_parent.get(tgt_parent)
+                angle_ds_key = lines_fc_key
+                angle_oid = tgt_parent
             if tgt_poly is None:
                 return _TargetAngleResolution(
                     None, None, snap_x, snap_y, target_parent_id=tgt_parent
                 )
             target_angle = self._local_line_angle_cached(
-                dataset_key=lines_fc_key,
-                oid=tgt_parent,
+                dataset_key=angle_ds_key,
+                oid=angle_oid,
                 polyline=tgt_poly,
                 x=snap_x,
                 y=snap_y,
@@ -3183,13 +3436,25 @@ class FillLineGaps:
                 target_parent_id=int(other_parent),
             )
 
-        ext = polyline_by_external.get(ds_key, {})
-        tgt_poly = ext.get(int(near_fid))
+        if use_segment:
+            seg_lookup = polyline_by_segment.get(cand.near_fc_key_raw)
+            tgt_poly = (
+                seg_lookup.get(int(cand.near_fid_raw))
+                if seg_lookup is not None
+                else None
+            )
+            angle_ds_key = cand.near_fc_key_raw
+            angle_oid = int(cand.near_fid_raw)
+        else:
+            ext = polyline_by_external.get(ds_key, {})
+            tgt_poly = ext.get(int(near_fid))
+            angle_ds_key = ds_key
+            angle_oid = int(near_fid)
         if tgt_poly is None:
             return _TargetAngleResolution(None, None, snap_x, snap_y)
         target_angle = self._local_line_angle_cached(
-            dataset_key=ds_key,
-            oid=int(near_fid),
+            dataset_key=angle_ds_key,
+            oid=angle_oid,
             polyline=tgt_poly,
             x=snap_x,
             y=snap_y,
@@ -3254,6 +3519,7 @@ class FillLineGaps:
         dangle_xy: dict[DangleOid, tuple[float, float]],
         polyline_by_parent: dict[ParentId, Any],
         polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        polyline_by_segment: dict[DatasetKey, dict[int, Any]],
         is_external_line_like: dict[DatasetKey, bool],
         dangle_xys_by_parent: Optional[_DangleXYsByParent] = None,
         dist_to_parent_line_by_id: Optional[dict[ParentId, float]] = None,
@@ -3326,6 +3592,7 @@ class FillLineGaps:
             dangle_xy=dangle_xy,
             polyline_by_parent=polyline_by_parent,
             polyline_by_external=polyline_by_external,
+            polyline_by_segment=polyline_by_segment,
         )
         target_angle = resolved.target_angle
         tgt_poly = resolved.tgt_poly
@@ -3730,6 +3997,7 @@ class FillLineGaps:
         lines_key: DatasetKey,
         polyline_by_parent: dict[ParentId, Any],
         polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        polyline_by_segment: dict[DatasetKey, dict[int, Any]],
         is_external_line_like: dict[DatasetKey, bool],
     ) -> dict[DangleOid, ParentId]:
         """Per dangle, pick the line-target parent that wins the angle-aware
@@ -3775,6 +4043,7 @@ class FillLineGaps:
                     dangle_xy=dangle_xy,
                     polyline_by_parent=polyline_by_parent,
                     polyline_by_external=polyline_by_external,
+                    polyline_by_segment=polyline_by_segment,
                     is_external_line_like=is_external_line_like,
                 )
                 if assess.blocks:
@@ -3855,6 +4124,7 @@ class FillLineGaps:
 
         relevant_parent_ids = set(dangle_parent.values())
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} TopologyBuilder.build START (relevant_parents={len(relevant_parent_ids)})")  # [DBG_LINEGAP]
         topology = TopologyBuilder(
             lines_fc=self.lines_copy,
             original_id_field=self.ORIGINAL_ID,
@@ -3868,17 +4138,24 @@ class FillLineGaps:
             scope=self.connectivity_scope,
             relevant_parent_ids=relevant_parent_ids,
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} TopologyBuilder.build END")  # [DBG_LINEGAP]
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} detect_illegal_targets START")  # [DBG_LINEGAP]
         illegal = self.detect_illegal_targets(
             dangle_parent=dangle_parent,
             target_layers=target_layers,
             topology=topology,
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} detect_illegal_targets END (illegal_dangles={len(illegal)})")  # [DBG_LINEGAP]
 
         dangles_key = self._dataset_key(dangles_fc)
         lines_key = self._dataset_key(self.lines_copy)
 
-        near_features = list(target_layers) + [dangles_fc]
+        # Candidate near table reads from segmented twins when
+        # self.segmentation is set (per-segment closest-point + per-segment
+        # angle); other engine phases continue to use the unsegmented globals.
+        candidate_target_layers = self._candidate_target_layers(target_layers)
+        near_features = list(candidate_target_layers) + [dangles_fc]
 
         base_tol = float(self.gap_tolerance_meters)
         dangle_tol = float(self._expanded_dangle_tolerance_meters())
@@ -3894,13 +4171,16 @@ class FillLineGaps:
         )
 
         # Expanded radius so we can see dangle→dangle candidates, but legality will enforce tol rules.
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(candidate) START (near_features={len(near_features)}, radius={self._expanded_dangle_tolerance_linear_unit()})")  # [DBG_LINEGAP]
         self._generate_near_table(
             in_dangles=dangles_fc,
             near_features=near_features,
             search_radius=self._expanded_dangle_tolerance_linear_unit(),
             out_table=self.near_table,
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(candidate) END (near_table_rows={int(arcpy.management.GetCount(self.near_table)[0])})")  # [DBG_LINEGAP]
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _read_near_table_grouped START")  # [DBG_LINEGAP]
         grouped = self._read_near_table_grouped(
             near_table=self.near_table,
             dangles_fc_key=dangles_key,
@@ -3909,11 +4189,12 @@ class FillLineGaps:
             lines_copy_oid_to_orig=lines_copy_oid_to_orig,
             target_self_oid_to_orig=target_self_oid_to_orig,
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _read_near_table_grouped END (dangles_with_candidates={len(grouped)})")  # [DBG_LINEGAP]
 
         if not grouped:
             return BuildPlanResult.empty(diagnostics=[])
 
-        collect_diags = self.candidate_connections_output is not None
+        collect_diags = self._collect_diags
 
         def _build_diagnostics(
             state: _DiagnosticsState,
@@ -3946,6 +4227,7 @@ class FillLineGaps:
         )
         polyline_by_parent = angle_caches.polyline_by_parent
         polyline_by_external = angle_caches.polyline_by_external
+        polyline_by_segment = angle_caches.polyline_by_segment
         is_external_line_like = angle_caches.is_external_line_like
         line_like_external_ds_keys = angle_caches.line_like_external_ds_keys
         line_like_ds_keys = angle_caches.line_like_ds_keys
@@ -3979,6 +4261,7 @@ class FillLineGaps:
         # Step 2 - Legality gates (distance / network / illegal-target)
         # Collects legal (dangle, target) candidate rows.
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_legal_candidates START (grouped={len(grouped)})")  # [DBG_LINEGAP]
         legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
             self._filter_legal_candidates(
                 grouped=grouped,
@@ -3994,6 +4277,11 @@ class FillLineGaps:
                 directed_source_illegal_oids=directed_start_dangles,
             )
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_legal_candidates END (legal_dangles={len(legal_rows_by_dangle)}, illegal_rows={len(_step1a_illegal)})")  # [DBG_LINEGAP]
+
+        # Eager release: the outer dict's surviving NearCandidate lists are
+        # already referenced by legal_rows_by_dangle; the rest is dead weight.
+        grouped.clear()
 
         # ----------------------------
         # Step 3 - Crossing pre-filters (last legality check)
@@ -4032,6 +4320,7 @@ class FillLineGaps:
                     parent_id_by_dangle.pop(_dangle_oid, None)
 
         if self.barrier_layers and legal_rows_by_dangle and _crossing_sr is not None:
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_barrier_crossing_keys START (legal_dangles={len(legal_rows_by_dangle)})")  # [DBG_LINEGAP]
             _barrier_keys = self._find_barrier_crossing_keys(
                 legal_rows_by_dangle=legal_rows_by_dangle,
                 dangle_xy=dangle_xy,
@@ -4039,6 +4328,7 @@ class FillLineGaps:
                 trim_distance=_crossing_trim,
                 spatial_reference=_crossing_sr,
             )
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_barrier_crossing_keys END (rejected_keys={len(_barrier_keys)})")  # [DBG_LINEGAP]
             if _barrier_keys:
                 _apply_crossing_filter(_barrier_keys, "crosses_barrier_layer")
 
@@ -4057,6 +4347,7 @@ class FillLineGaps:
                 self.lines_copy,
                 *self.external_target_crossing_layers,
             ]
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_crossing_conflict_keys START (legal_dangles={len(legal_rows_by_dangle)}, check_layers={len(_check_layers)})")  # [DBG_LINEGAP]
             crossing_conflict_keys, trimmed_connector_cache = (
                 self._find_crossing_conflict_keys(
                     legal_rows_by_dangle=legal_rows_by_dangle,
@@ -4066,6 +4357,7 @@ class FillLineGaps:
                     spatial_reference=_crossing_sr,
                 )
             )
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_crossing_conflict_keys END (rejected_keys={len(crossing_conflict_keys)}, trimmed_cache={len(trimmed_connector_cache)})")  # [DBG_LINEGAP]
             if crossing_conflict_keys:
                 _apply_crossing_filter(
                     crossing_conflict_keys, "crosses_existing_feature"
@@ -4080,6 +4372,7 @@ class FillLineGaps:
         # Step 4 - Best line parent per dangle (angle-aware)
         # Used by edge-case bonus detection in the scoring step.
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _compute_best_line_parent_by_dangle START (legal_dangles={len(legal_rows_by_dangle)})")  # [DBG_LINEGAP]
         best_line_parent_by_dangle = self._compute_best_line_parent_by_dangle(
             legal_rows_by_dangle=legal_rows_by_dangle,
             parent_id_by_dangle=parent_id_by_dangle,
@@ -4089,12 +4382,15 @@ class FillLineGaps:
             lines_key=lines_key,
             polyline_by_parent=polyline_by_parent,
             polyline_by_external=polyline_by_external,
+            polyline_by_segment=polyline_by_segment,
             is_external_line_like=is_external_line_like,
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _compute_best_line_parent_by_dangle END (best_line_parents={len(best_line_parent_by_dangle)})")  # [DBG_LINEGAP]
 
         # ----------------------------
         # Step 5 - Angle-aware selection: one proposal per dangle
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_dangle_proposals START (legal_dangles={len(legal_rows_by_dangle)})")  # [DBG_LINEGAP]
         _dangle_proposals, dangle_norm_z_by_dangle, _step1b_illegal, _step1b_scored = (
             self._select_dangle_proposals(
                 legal_rows_by_dangle=legal_rows_by_dangle,
@@ -4107,6 +4403,7 @@ class FillLineGaps:
                 base_tol=base_tol,
                 polyline_by_parent=polyline_by_parent,
                 polyline_by_external=polyline_by_external,
+                polyline_by_segment=polyline_by_segment,
                 is_external_line_like=is_external_line_like,
                 best_line_parent_by_dangle=best_line_parent_by_dangle,
                 dangle_parent=dangle_parent,
@@ -4115,6 +4412,7 @@ class FillLineGaps:
                 dist_to_parent_line_by_dangle=dist_to_parent_line_by_dangle,
             )
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_dangle_proposals END (proposals={len(_dangle_proposals)}, illegal_b={len(_step1b_illegal)}, scored_b={len(_step1b_scored)})")  # [DBG_LINEGAP]
 
         if not _dangle_proposals:
             return _empty_result(
@@ -4166,19 +4464,23 @@ class FillLineGaps:
         # ----------------------------
         # Step 2 - Connection normalization: re-normalize Z within each undirected A<->B connection group
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_normalization START (dangle_proposals={len(_dangle_proposals)})")  # [DBG_LINEGAP]
         connection_proposals_by_dangle, connection_norm_z_by_dangle = (
             self._run_connection_normalization(_dangle_proposals)
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_normalization END (proposals={len(connection_proposals_by_dangle)})")  # [DBG_LINEGAP]
 
         # ----------------------------
         # Step 3 - Connection selection: one winner per undirected connection
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_selection START")  # [DBG_LINEGAP]
         _connection_proposals, connection_loser_oids = self._run_connection_selection(
             connection_proposals_by_dangle=connection_proposals_by_dangle,
             directed_edges=directed_network_edges,
             dangle_mutual_oids=dangle_mutual_oids,
             collect_diags=collect_diags,
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_selection END (winners={len(_connection_proposals)}, losers={len(connection_loser_oids)})")  # [DBG_LINEGAP]
 
         # ============================
         # KRUSKAL SCOPE
@@ -4188,13 +4490,16 @@ class FillLineGaps:
         # ----------------------------
         # Step 1 - Global normalization: re-normalize Z across all connection winners
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_global_normalization START (connection_proposals={len(_connection_proposals)})")  # [DBG_LINEGAP]
         _global_winners, global_norm_z_by_dangle = self._run_global_normalization(
             _connection_proposals
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_global_normalization END (global_winners={len(_global_winners)})")  # [DBG_LINEGAP]
 
         # ----------------------------
         # Step 2 - Kruskal cycle prevention across accepted connections
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_kruskal START")  # [DBG_LINEGAP]
         (
             _global_proposals,
             accepted_dangle_oids,
@@ -4214,6 +4519,12 @@ class FillLineGaps:
                 else None
             ),
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_kruskal END (accepted={len(accepted_dangle_oids)}, kruskal_rejected={len(kruskal_rejected_oids)}, crossing_rejected={len(kruskal_crossing_rejected_oids)})")  # [DBG_LINEGAP]
+
+        # Eager release: trimmed_connector_cache is consumed by _run_kruskal
+        # and not referenced by resnap or output phases; release the Polyline
+        # handles before the deferred scope and the diagnostics assembly run.
+        trimmed_connector_cache.clear()
 
         if not _global_proposals:
             return _empty_result(
@@ -4240,12 +4551,16 @@ class FillLineGaps:
         # ----------------------------
         # Step 1 - Resnap candidate identification
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _identify_resnap_captures START (global_proposals={len(_global_proposals)})")  # [DBG_LINEGAP]
         resnap_captures = self._identify_resnap_captures(_global_proposals)
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _identify_resnap_captures END (resnap_captures={len(resnap_captures)})")  # [DBG_LINEGAP]
 
         # ----------------------------
         # Step 2 - Plan entry assembly: parent_id -> list[plan_entry]
         # ----------------------------
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _assemble_plan_entries START")  # [DBG_LINEGAP]
         plan_by_parent = self._assemble_plan_entries(_global_proposals)
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _assemble_plan_entries END (plan_parents={len(plan_by_parent)})")  # [DBG_LINEGAP]
 
         return BuildPlanResult(
             plan_by_parent=plan_by_parent,
@@ -4379,6 +4694,7 @@ class FillLineGaps:
         base_tol: float,
         polyline_by_parent: dict[ParentId, Any],
         polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        polyline_by_segment: dict[DatasetKey, dict[int, Any]],
         is_external_line_like: dict[DatasetKey, bool],
         best_line_parent_by_dangle: dict[DangleOid, ParentId],
         dangle_parent: dict[DangleOid, ParentId],
@@ -4492,6 +4808,7 @@ class FillLineGaps:
                     dangle_xy=dangle_xy,
                     polyline_by_parent=polyline_by_parent,
                     polyline_by_external=polyline_by_external,
+                    polyline_by_segment=polyline_by_segment,
                     is_external_line_like=is_external_line_like,
                     dangle_xys_by_parent=_dangle_xys_by_parent,
                     dist_to_parent_line_by_id=dist_to_parent_line_by_id,
@@ -5252,6 +5569,7 @@ class FillLineGaps:
                 near_x=float(prop.ctx.near_x),
                 near_y=float(prop.ctx.near_y),
                 near_fc_key_raw=str(prop.ctx.near_fc_key),
+                near_fid_raw=int(prop.ctx.near_fid),
             )
             entry = self._make_plan_entry(
                 parent_id=int(prop.ctx.src_parent_id),
@@ -5313,10 +5631,24 @@ class FillLineGaps:
         dangles_key: DatasetKey,
         lines_key: DatasetKey,
     ) -> list[CandidateDiagnostic]:
-        """Assemble CandidateDiagnostic records from all pipeline state collected during _build_plan."""
+        """Stream non-deferrable diagnostic records to the FC; return only the
+        accepted-Kruskal subset that may receive late annotations from
+        ``_update_deferred_diagnostics`` after the resnap pass.
+
+        The returned list contains records with ``kruskal_scope.status ==
+        "accepted"`` only. All other records (step-1A illegals, step-1B
+        illegals, and step-1B scored entries that were outscored, lost the
+        connection selection, or rejected by Kruskal) are written immediately
+        and not retained, dropping the peak in-memory diagnostic footprint
+        from O(rejected candidates) to O(accepted candidates).
+        """
         if not collect_diags:
             return []
-        result: list[CandidateDiagnostic] = []
+
+        assert self.candidate_connections_output is not None
+        deferred: list[CandidateDiagnostic] = []
+        spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
+        cursor_fields = ("SHAPE@",) + self._diag_field_names()
 
         def _z_pair(
             d_xy: tuple[float, float], near_x: float, near_y: float
@@ -5331,154 +5663,181 @@ class FillLineGaps:
             )
             return sz, ez
 
-        # Step-1A illegals: angle never computed; z values looked up here
-        for entry in state.step1a_illegal:
-            xy = dangle_xy.get(int(entry.dangle_oid))
-            if xy is None:
-                continue
-            _sz, _ez = _z_pair(xy, entry.cand.near_x, entry.cand.near_y)
-            cand_scope = ScopeRecord(status=entry.reason)
-            result.append(
-                CandidateDiagnostic(
-                    **self._make_base_diag_fields(
-                        entry.cand,
-                        entry.dangle_oid,
-                        entry.parent_id,
-                        xy,
-                        dangle_parent,
-                        dangles_key,
-                        lines_key,
+        with arcpy.da.InsertCursor(
+            self.candidate_connections_output, cursor_fields
+        ) as cur:
+
+            def _emit(d: CandidateDiagnostic) -> None:
+                geom = arcpy.Polyline(
+                    arcpy.Array(
+                        [
+                            arcpy.Point(d.dangle_x, d.dangle_y),
+                            arcpy.Point(d.near_x, d.near_y),
+                        ]
                     ),
-                    candidate_scope=cand_scope,
-                    network_scope=None,
-                    kruskal_scope=None,
-                    deferred_scope=None,
-                    final_status=cand_scope,
-                    best_fit_score=None,
-                    best_fit_rank=None,
-                    bonus_applied=None,
-                    norm_dist=None,
-                    norm_angle=None,
-                    assess=None,
-                    final_gap_source=None,
-                    start_z=_sz,
-                    end_z=_ez,
+                    spatial_reference,
                 )
-            )
+                cur.insertRow(self._diag_row(d, geom))
 
-        # Step-1B angle/Z-blocked illegals: z values carried in entry
-        for entry in state.step1b_illegal:
-            xy = dangle_xy.get(int(entry.dangle_oid))
-            if xy is None:
-                continue
-            cand_scope = ScopeRecord(status=entry.reason)
-            result.append(
-                CandidateDiagnostic(
-                    **self._make_base_diag_fields(
-                        entry.cand,
-                        entry.dangle_oid,
-                        entry.parent_id,
-                        xy,
-                        dangle_parent,
-                        dangles_key,
-                        lines_key,
-                    ),
-                    candidate_scope=cand_scope,
-                    network_scope=None,
-                    kruskal_scope=None,
-                    deferred_scope=None,
-                    final_status=cand_scope,
-                    best_fit_score=None,
-                    best_fit_rank=None,
-                    bonus_applied=None,
-                    norm_dist=None,
-                    norm_angle=None,
-                    assess=entry.assess,
-                    final_gap_source=None,
-                    start_z=entry.start_z,
-                    end_z=entry.end_z,
+            # Step-1A illegals: angle never computed; z values looked up here.
+            # Never accepted by Kruskal — stream directly.
+            for entry in state.step1a_illegal:
+                xy = dangle_xy.get(int(entry.dangle_oid))
+                if xy is None:
+                    continue
+                _sz, _ez = _z_pair(xy, entry.cand.near_x, entry.cand.near_y)
+                cand_scope = ScopeRecord(status=entry.reason)
+                _emit(
+                    CandidateDiagnostic(
+                        **self._make_base_diag_fields(
+                            entry.cand,
+                            entry.dangle_oid,
+                            entry.parent_id,
+                            xy,
+                            dangle_parent,
+                            dangles_key,
+                            lines_key,
+                        ),
+                        candidate_scope=cand_scope,
+                        network_scope=None,
+                        kruskal_scope=None,
+                        deferred_scope=None,
+                        final_status=cand_scope,
+                        best_fit_score=None,
+                        best_fit_rank=None,
+                        bonus_applied=None,
+                        norm_dist=None,
+                        norm_angle=None,
+                        assess=None,
+                        final_gap_source=None,
+                        start_z=_sz,
+                        end_z=_ez,
+                    )
                 )
-            )
 
-        # Compute per-dangle rank for scored candidates (1 = local winner)
-        scored_by_dangle: dict[int, list[_CandidateScored]] = {}
-        for entry in state.step1b_scored:
-            scored_by_dangle.setdefault(int(entry.dangle_oid), []).append(entry)
-        rank_map: dict[tuple[int, str, int], int] = {}
-        for d_oid, entries in scored_by_dangle.items():
-            for rank, entry in enumerate(
-                sorted(entries, key=lambda e: e.score_tuple), start=1
-            ):
-                rank_map[(d_oid, entry.cand.near_fc_key, entry.cand.near_fid)] = rank
+            # Eager release: source records are not referenced past this loop.
+            state.step1a_illegal.clear()
 
-        # Step-1B scored candidates
-        for entry in state.step1b_scored:
-            xy = dangle_xy.get(int(entry.dangle_oid))
-            if xy is None:
-                continue
-            rank = rank_map.get(
-                (entry.dangle_oid, entry.cand.near_fc_key, entry.cand.near_fid)
-            )
-            d_oid = int(entry.dangle_oid)
-            cand_scope = ScopeRecord(status="scored", norm_z=entry.dangle_norm_z)
+            # Step-1B angle/Z-blocked illegals: z values carried in entry.
+            # Never accepted by Kruskal — stream directly.
+            for entry in state.step1b_illegal:
+                xy = dangle_xy.get(int(entry.dangle_oid))
+                if xy is None:
+                    continue
+                cand_scope = ScopeRecord(status=entry.reason)
+                _emit(
+                    CandidateDiagnostic(
+                        **self._make_base_diag_fields(
+                            entry.cand,
+                            entry.dangle_oid,
+                            entry.parent_id,
+                            xy,
+                            dangle_parent,
+                            dangles_key,
+                            lines_key,
+                        ),
+                        candidate_scope=cand_scope,
+                        network_scope=None,
+                        kruskal_scope=None,
+                        deferred_scope=None,
+                        final_status=cand_scope,
+                        best_fit_score=None,
+                        best_fit_rank=None,
+                        bonus_applied=None,
+                        norm_dist=None,
+                        norm_angle=None,
+                        assess=entry.assess,
+                        final_gap_source=None,
+                        start_z=entry.start_z,
+                        end_z=entry.end_z,
+                    )
+                )
 
-            if not entry.is_local_winner:
-                net_scope = ScopeRecord(status="outscored_within_dangle")
-                kru_scope: Optional[ScopeRecord] = None
-                final_scope = net_scope
-                final_gs: Optional[str] = None
-            elif d_oid in state.connection_loser_oids:
-                net_scope = ScopeRecord(
-                    status="lost_connection_selection",
-                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
-                )
-                kru_scope = None
-                final_scope = net_scope
-                final_gs = None
-            elif d_oid in state.kruskal_rejected_oids:
-                net_scope = ScopeRecord(
-                    status="passed",
-                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
-                )
-                kru_scope = ScopeRecord(
-                    status="lost_kruskal_selection",
-                    norm_z=state.global_norm_z_by_dangle.get(d_oid),
-                )
-                final_scope = kru_scope
-                final_gs = None
-            elif d_oid in state.kruskal_crossing_rejected_oids:
-                net_scope = ScopeRecord(
-                    status="passed",
-                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
-                )
-                kru_scope = ScopeRecord(
-                    status="crosses_accepted_connector",
-                    norm_z=state.global_norm_z_by_dangle.get(d_oid),
-                )
-                final_scope = kru_scope
-                final_gs = None
-            elif d_oid in state.accepted_dangle_oids:
-                net_scope = ScopeRecord(
-                    status="passed",
-                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
-                )
-                kru_scope = ScopeRecord(
-                    status="accepted",
-                    norm_z=state.global_norm_z_by_dangle.get(d_oid),
-                )
-                final_scope = kru_scope
-                gs = state.gap_source_by_dangle.get(d_oid)
-                final_gs = gs.value if gs is not None else None
-            else:
-                # Local winner that didn't reach proposal construction
-                # (e.g. target dangle had no resolvable parent)
-                net_scope = ScopeRecord(status="passed")
-                kru_scope = None
-                final_scope = net_scope
-                final_gs = None
+            # Eager release: source records are not referenced past this loop.
+            state.step1b_illegal.clear()
 
-            result.append(
-                CandidateDiagnostic(
+            # Compute per-dangle rank for scored candidates (1 = local winner)
+            scored_by_dangle: dict[int, list[_CandidateScored]] = {}
+            for entry in state.step1b_scored:
+                scored_by_dangle.setdefault(int(entry.dangle_oid), []).append(entry)
+            rank_map: dict[tuple[int, str, int], int] = {}
+            for d_oid, entries in scored_by_dangle.items():
+                for rank, entry in enumerate(
+                    sorted(entries, key=lambda e: e.score_tuple), start=1
+                ):
+                    rank_map[(d_oid, entry.cand.near_fc_key, entry.cand.near_fid)] = (
+                        rank
+                    )
+
+            # Step-1B scored candidates: only the accepted-Kruskal branch
+            # below produces records eligible for late deferred-scope
+            # annotation; everything else streams.
+            for entry in state.step1b_scored:
+                xy = dangle_xy.get(int(entry.dangle_oid))
+                if xy is None:
+                    continue
+                rank = rank_map.get(
+                    (entry.dangle_oid, entry.cand.near_fc_key, entry.cand.near_fid)
+                )
+                d_oid = int(entry.dangle_oid)
+                cand_scope = ScopeRecord(status="scored", norm_z=entry.dangle_norm_z)
+
+                if not entry.is_local_winner:
+                    net_scope = ScopeRecord(status="outscored_within_dangle")
+                    kru_scope: Optional[ScopeRecord] = None
+                    final_scope = net_scope
+                    final_gs: Optional[str] = None
+                elif d_oid in state.connection_loser_oids:
+                    net_scope = ScopeRecord(
+                        status="lost_connection_selection",
+                        norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                    )
+                    kru_scope = None
+                    final_scope = net_scope
+                    final_gs = None
+                elif d_oid in state.kruskal_rejected_oids:
+                    net_scope = ScopeRecord(
+                        status="passed",
+                        norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                    )
+                    kru_scope = ScopeRecord(
+                        status="lost_kruskal_selection",
+                        norm_z=state.global_norm_z_by_dangle.get(d_oid),
+                    )
+                    final_scope = kru_scope
+                    final_gs = None
+                elif d_oid in state.kruskal_crossing_rejected_oids:
+                    net_scope = ScopeRecord(
+                        status="passed",
+                        norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                    )
+                    kru_scope = ScopeRecord(
+                        status="crosses_accepted_connector",
+                        norm_z=state.global_norm_z_by_dangle.get(d_oid),
+                    )
+                    final_scope = kru_scope
+                    final_gs = None
+                elif d_oid in state.accepted_dangle_oids:
+                    net_scope = ScopeRecord(
+                        status="passed",
+                        norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                    )
+                    kru_scope = ScopeRecord(
+                        status="accepted",
+                        norm_z=state.global_norm_z_by_dangle.get(d_oid),
+                    )
+                    final_scope = kru_scope
+                    gs = state.gap_source_by_dangle.get(d_oid)
+                    final_gs = gs.value if gs is not None else None
+                else:
+                    # Local winner that didn't reach proposal construction
+                    # (e.g. target dangle had no resolvable parent)
+                    net_scope = ScopeRecord(status="passed")
+                    kru_scope = None
+                    final_scope = net_scope
+                    final_gs = None
+
+                d = CandidateDiagnostic(
                     **self._make_base_diag_fields(
                         entry.cand,
                         entry.dangle_oid,
@@ -5503,8 +5862,13 @@ class FillLineGaps:
                     start_z=entry.start_z,
                     end_z=entry.end_z,
                 )
-            )
-        return result
+
+                if kru_scope is not None and kru_scope.status == "accepted":
+                    deferred.append(d)
+                else:
+                    _emit(d)
+
+        return deferred
 
     def _make_plan_entry(
         self,
@@ -5684,6 +6048,7 @@ class FillLineGaps:
             2 * self.connectivity_tolerance_meters + self.gap_tolerance_meters
         )
         resnap_table = self.wfm.build_file_path(file_name="resnap_near_table")
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(resnap) START (dangles={len(dangle_oids)}, target_parents={len(forced_parents_filtered)}, radius={search_radius} Meters)")  # [DBG_LINEGAP]
         arcpy.analysis.GenerateNearTable(
             in_features=resnap_dangles_lyr,
             near_features=[resnap_lines_lyr],
@@ -5692,9 +6057,10 @@ class FillLineGaps:
             location="LOCATION",
             angle="NO_ANGLE",
             closest="ALL",
-            closest_count=100,
+            closest_count=self.candidate_closest_count,
             method="PLANAR",
         )
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(resnap) END (resnap_table_rows={int(arcpy.management.GetCount(resnap_table)[0])})")  # [DBG_LINEGAP]
 
         best_xy: dict[tuple[int, int], tuple[float, float, float]] = {}
         fields = [
@@ -5738,6 +6104,7 @@ class FillLineGaps:
                 near_x=float(hit[0]),
                 near_y=float(hit[1]),
                 near_fc_key_raw=lines_key,
+                near_fid_raw=cap.forced_target_parent,
             )
             out[cap.parent_id] = self._make_plan_entry(
                 parent_id=cap.parent_id,
@@ -6225,7 +6592,7 @@ class FillLineGaps:
     ) -> None:
         """Record each accepted candidate's resnap outcome on its diagnostic.
         Precedence: displaced > winner > applied_resnapped > rejected."""
-        if self.candidate_connections_output is None or not diagnostics:
+        if not self._collect_diags or not diagnostics:
             return
 
         applied_oids = {v.dangle_oid for v in resnap_plan.values() if not v.skip}
@@ -6290,37 +6657,52 @@ class FillLineGaps:
             geometry and is exact.
         """
         environment_setup.main()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} run START")  # [DBG_LINEGAP]
 
         self.work_file_list = self.wfm.setup_work_file_paths(
             instance=self,
             file_structure=self.work_file_list,
         )
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _copy_input_lines START")  # [DBG_LINEGAP]
         self._copy_input_lines()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _copy_input_lines END (lines_copy_rows={int(arcpy.management.GetCount(self.lines_copy)[0])})")  # [DBG_LINEGAP]
         self._build_raster_handles()
         self._add_original_id_field()
         self._ensure_gap_generated_field()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _create_dangles START")  # [DBG_LINEGAP]
         self._create_dangles()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _create_dangles END (dangles_rows={int(arcpy.management.GetCount(self.dangles)[0])})")  # [DBG_LINEGAP]
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_external_target_layers_once START")  # [DBG_LINEGAP]
         self._build_external_target_layers_once()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_external_target_layers_once END")  # [DBG_LINEGAP]
+        self._setup_segmentation()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_targets_within_tolerance_of_dangles START")  # [DBG_LINEGAP]
         targets = self._select_targets_within_tolerance_of_dangles()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_targets_within_tolerance_of_dangles END (target_layers={len(targets)})")  # [DBG_LINEGAP]
 
         # Keep only dangles that have any candidate within base tolerance
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_true_dangles START")  # [DBG_LINEGAP]
         self._filter_true_dangles()
         dangles_for_plan = self.filtered_dangles
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_true_dangles END (filtered_dangles_rows={int(arcpy.management.GetCount(dangles_for_plan)[0])})")  # [DBG_LINEGAP]
 
         if self.line_changes_output is not None and self.write_output_metadata:
             file_utilities.delete_feature(input_feature=self.line_changes_output)
             self._setup_line_changes_output()
 
-        if self.candidate_connections_output is not None:
+        if self._collect_diags:
+            assert self.candidate_connections_output is not None
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_plan START")  # [DBG_LINEGAP]
         result = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
         plan = result.plan_by_parent
         resnap_captures = result.resnap_captures
         diagnostics = result.diagnostics
         accepted_connector_raw = result.accepted_connector_raw
         kruskal_rank_by_dangle_oid = result.kruskal_rank_by_dangle_oid
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_plan END (plan_parents={len(plan)}, resnap_captures={len(resnap_captures)}, diagnostics={len(diagnostics)})")  # [DBG_LINEGAP]
 
         # Capture snap-source dangle endpoints before _apply_plan moves them.
         snap_source_dangle_xy: dict[ParentId, tuple[float, float]] = {
@@ -6330,20 +6712,25 @@ class FillLineGaps:
             if info.edit_op is EditOp.SNAP
         }
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan START (plan_parents={len(plan)})")  # [DBG_LINEGAP]
         self._apply_plan(plan)
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan END")  # [DBG_LINEGAP]
 
         if resnap_captures:
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _resnap_connections START (captures={len(resnap_captures)})")  # [DBG_LINEGAP]
             resnap_plan = self._resnap_connections(
                 captures=resnap_captures,
                 dangles_fc=dangles_for_plan,
                 snap_source_dangle_xy=snap_source_dangle_xy,
             )
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _resnap_connections END (resnap_plan={len(resnap_plan)})")  # [DBG_LINEGAP]
 
             if (
                 self.reject_crossing_connectors
                 and resnap_plan
                 and accepted_connector_raw
             ):
+                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _recheck_resnap_crossings START (resnap_plan={len(resnap_plan)})")  # [DBG_LINEGAP]
                 (
                     resnap_plan,
                     resnap_crossing_rejected_oids,
@@ -6358,12 +6745,15 @@ class FillLineGaps:
                         self.crossing_check_spatial_reference
                     ),
                 )
+                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _recheck_resnap_crossings END (resnap_plan={len(resnap_plan)}, rejected={len(resnap_crossing_rejected_oids)})")  # [DBG_LINEGAP]
             else:
                 resnap_crossing_rejected_oids: set[DangleOid] = set()
                 resnap_crossing_displaced_oids: set[DangleOid] = set()
                 resnap_crossing_winner_oids: set[DangleOid] = set()
 
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan(resnap) START (entries={len(resnap_plan)})")  # [DBG_LINEGAP]
             self._apply_plan({pid: [entry] for pid, entry in resnap_plan.items()})
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan(resnap) END")  # [DBG_LINEGAP]
 
             self._update_deferred_diagnostics(
                 diagnostics=diagnostics,
@@ -6373,14 +6763,19 @@ class FillLineGaps:
                 winner_oids=resnap_crossing_winner_oids,
             )
 
-        if self.candidate_connections_output is not None and diagnostics:
+        if self._collect_diags and diagnostics:
+            assert self.candidate_connections_output is not None
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _write_candidate_connections_output START (diagnostics={len(diagnostics)})")  # [DBG_LINEGAP]
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
             self._write_candidate_connections_output(
                 fc_path=self.candidate_connections_output,
                 diagnostics=diagnostics,
                 spatial_reference=spatial_reference,
             )
+            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _write_candidate_connections_output END")  # [DBG_LINEGAP]
 
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _write_output START")  # [DBG_LINEGAP]
         self._write_output()
+        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} run END")  # [DBG_LINEGAP]
 
         self.wfm.delete_created_files()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1112,15 +1112,14 @@ class _DirectionalNormalization(NamedTuple):
     Undirected mode flips ``src_angle_deg`` and ``target_angle`` so a clean
     collinear pair scores 0°; directed mode replaces ``src_connector_diff``
     with the directional difference so anti-parallel src/connector reports
-    180° instead of collapsing under orientation_diff. ``src_poly_for_norm``
-    and ``endpoint_snap`` are surfaced so the metric helper can apply the
-    end-to-start topology rule without re-deriving them.
+    180° instead of collapsing under orientation_diff. ``endpoint_snap`` is
+    surfaced so the metric helper can apply the target-start topology rule
+    without re-deriving it.
     """
 
     src_angle_deg: float
     target_angle: float
     src_connector_diff: float
-    src_poly_for_norm: Any
     endpoint_snap: bool
 
 
@@ -2808,13 +2807,16 @@ class FillLineGaps:
         *,
         grouped: dict[DangleOid, list[NearCandidate]],
         lines_key: DatasetKey,
+        skip_dangles: set[DangleOid],
     ) -> dict[DangleOid, dict[ParentId, float]]:
         """Per source dangle, map every line-target parent_id to its near-table
         distance. Built once from the raw grouped near table so the dangle-pair
         connector-diff gate can do a flat lookup instead of a per-iteration
         dict-comp inside ``_select_dangle_proposals``. Distances reflect what
         arcpy reported regardless of legality (legal/illegal filtering decides
-        snap targets, not distance measurements).
+        snap targets, not distance measurements). ``skip_dangles`` excludes
+        dangles whose candidates will never reach the gate (e.g. directed
+        start-node sources rejected upstream by ``_filter_legal_candidates``).
         """
         return {
             d_oid: {
@@ -2823,6 +2825,7 @@ class FillLineGaps:
                 if c.near_fc_key == lines_key
             }
             for d_oid, cands in grouped.items()
+            if d_oid not in skip_dangles
         }
 
     # ----------------------------
@@ -3026,7 +3029,6 @@ class FillLineGaps:
             src_angle_deg=float(src_angle_deg),
             target_angle=float(target_angle),
             src_connector_diff=float(src_connector_diff),
-            src_poly_for_norm=src_poly_for_norm,
             endpoint_snap=bool(endpoint_snap),
         )
 
@@ -3200,8 +3202,16 @@ class FillLineGaps:
             float(src_angle_deg), float(connector_angle)
         )
 
-        # Non-line targets use src_connector_diff directly
+        # Non-line targets use src_connector_diff directly. In directed mode,
+        # promote to _directional_diff (0..180) so anti-parallel src/connector
+        # reports its true large angle instead of folding back into 0..90.
+        # Upstream filtering guarantees the src dangle is at its parent's end
+        # vertex when lines_are_directed, so src_angle already points outward.
         if not treat_as_line_like:
+            if self.lines_are_directed:
+                src_connector_diff = self._directional_diff(
+                    float(src_angle_deg), float(connector_angle)
+                )
             metric = float(src_connector_diff)
             block_thr = self.angle_block_threshold_degrees
             blocks = block_thr is not None and metric > float(block_thr)
@@ -3269,7 +3279,6 @@ class FillLineGaps:
             self.lines_are_directed or _is_dangle_pair or _is_dangle_parent_line
         )
 
-        src_poly_for_norm: Any = None
         endpoint_snap = False
         if _use_directional:
             _diff = self._directional_diff
@@ -3292,7 +3301,6 @@ class FillLineGaps:
             src_angle_deg = norm.src_angle_deg
             target_angle = norm.target_angle
             src_connector_diff = norm.src_connector_diff
-            src_poly_for_norm = norm.src_poly_for_norm
             endpoint_snap = norm.endpoint_snap
         else:
             _diff = self._orientation_diff
@@ -3316,27 +3324,24 @@ class FillLineGaps:
         # Directional, non-endpoint, directed: worst of angular alignment vs
         #     connector direction (a bad score on either makes the candidate bad).
         # Directional, endpoint snap, directed: only end-to-start is a valid
-        #     connection — anything else is forced to 180° (rejected). For valid
-        #     end-to-start dangle pairs connector_angle_diff_required_above_meters
-        #     decides whether to penalise bad connector direction: when the
-        #     candidate's gap distance exceeds the threshold the parent-line
-        #     lookup is consulted and max(src_target_diff, src_connector_diff)
-        #     applies if the parent line is also beyond the threshold.
+        #     connection — anything else is forced to 180° (rejected). Src-end
+        #     is guaranteed by upstream filtering (_filter_legal_candidates drops
+        #     start-node src dangles), so only target-start enforcement remains.
+        #     For valid end-to-start dangle pairs
+        #     connector_angle_diff_required_above_meters decides whether to
+        #     penalise bad connector direction: when the candidate's gap distance
+        #     exceeds the threshold the parent-line lookup is consulted and
+        #     max(src_target_diff, src_connector_diff) applies if the parent line
+        #     is also beyond the threshold.
         # Directional, undirected: src_target_diff after both normalisations.
         connector_diff_threshold = self.connector_angle_diff_required_above_meters
         if not _use_directional:
             metric = float(src_connector_diff)
         elif self.lines_are_directed and endpoint_snap:
-            _src_is_end = (
-                src_poly_for_norm is not None
-                and not self._xy_is_at_line_start(
-                    src_poly_for_norm, dangle_x, dangle_y
-                )
-            )
             _tgt_is_start = self._xy_is_at_line_start(
                 tgt_poly, tgt_snap_x, tgt_snap_y
             )
-            if not (_src_is_end and _tgt_is_start):
+            if not _tgt_is_start:
                 metric = 180.0
             elif (
                 connector_diff_threshold is not None
@@ -3792,18 +3797,6 @@ class FillLineGaps:
         if not grouped:
             return BuildPlanResult.empty(diagnostics=[])
 
-        # Built once when the dangle-pair distance gate is active; passed into
-        # _select_dangle_proposals so the gate has a flat per-dangle lookup
-        # instead of rebuilding it on every iteration.
-        dist_to_parent_line_by_dangle: Optional[
-            dict[DangleOid, dict[ParentId, float]]
-        ] = None
-        if self.connector_angle_diff_required_above_meters is not None:
-            dist_to_parent_line_by_dangle = self._build_dist_to_parent_line_by_dangle(
-                grouped=grouped,
-                lines_key=lines_key,
-            )
-
         collect_diags = self.candidate_connections_output is not None
 
         def _build_diagnostics(
@@ -3847,6 +3840,24 @@ class FillLineGaps:
             dangle_parent=dangle_parent,
             polyline_by_parent=polyline_by_parent,
         )
+
+        # Built once when the dangle-pair distance gate is active; passed into
+        # _select_dangle_proposals so the gate has a flat per-dangle lookup
+        # instead of rebuilding it on every iteration. Skips start-node src
+        # dangles since their candidates are dropped by _filter_legal_candidates
+        # and the gate is a no-op outside directed mode.
+        dist_to_parent_line_by_dangle: Optional[
+            dict[DangleOid, dict[ParentId, float]]
+        ] = None
+        if (
+            self.lines_are_directed
+            and self.connector_angle_diff_required_above_meters is not None
+        ):
+            dist_to_parent_line_by_dangle = self._build_dist_to_parent_line_by_dangle(
+                grouped=grouped,
+                lines_key=lines_key,
+                skip_dangles=directed_start_dangles,
+            )
 
         # ----------------------------
         # Step 2 - Legality gates (distance / network / illegal-target)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -840,11 +840,12 @@ class _CandidateContext:
     near_x: float
     near_y: float
     raw_distance: float
+    effective_distance: float  # raw_distance minus edge-case bonus when bonus_applied
     bonus_applied: bool
     # Scoring inputs (fixed; needed for diagnostics and score recomputation)
     start_z: Optional[float]  # Z at source dangle endpoint
     end_z: Optional[float]  # Z at target near-point
-    norm_dist: float  # raw_distance / gap_tolerance_meters
+    norm_dist: float  # dangle-scope min-max normalized effective distance
     # assess is always populated on constructed contexts — code paths that
     # early-return before proposal construction never reach _CandidateContext.
     assess: "AngleAssessment"
@@ -1177,11 +1178,30 @@ class _ScoredCandidateItem:
     score: "_ProposalScore"
     cand: NearCandidate
     raw_distance: float
+    effective_distance: float
     effective_for_scoring: float
     bonus_applied: bool
     assess: AngleAssessment
     norm_z: Optional[float]
     norm_dist: float
+    norm_angle: Optional[float]
+    end_z: Optional[float]
+
+
+@dataclass(frozen=True)
+class _PendingDangleItem:
+    """Pass-1 collection inside _select_dangle_proposals.
+
+    Holds inputs for a candidate that survived all gates. Pass 2 normalizes
+    effective_distance and end_z over the dangle's surviving candidate set,
+    then promotes each pending item to a final _ScoredCandidateItem.
+    """
+
+    cand: NearCandidate
+    assess: AngleAssessment
+    raw_distance: float
+    effective_distance: float
+    bonus_applied: bool
     norm_angle: Optional[float]
     end_z: Optional[float]
 
@@ -1816,18 +1836,45 @@ class FillLineGaps:
     ) -> Optional[float]:
         """
         Normalize target_end_z within the range of end_z_values.
-        Returns None when fewer than 2 valid values exist, range is flat, or target is None.
+
+        Returns None only when the target's own Z is missing (data unavailable
+        for this candidate); the dimension is then excluded from the composite.
+        Returns 0.0 when the scope is degenerate (fewer than 2 valid values or a
+        flat range): the lone candidate gets the best possible normalized score
+        on this dimension while the dimension stays in the composite at full
+        weight, preserving the user's best_fit_weights ratios.
         """
         if target_end_z is None:
             return None
         valid = [z for z in end_z_values if z is not None]
         if len(valid) < 2:
-            return None
+            return 0.0
         lo = min(valid)
         hi = max(valid)
         if hi == lo:
-            return None
+            return 0.0
         return (target_end_z - lo) / (hi - lo)
+
+    @staticmethod
+    def _normalize_within_scope(
+        values: "list[float]",
+        target: float,
+    ) -> float:
+        """
+        Min-max normalize ``target`` within ``values``.
+
+        Returns 0.0 when the scope is degenerate (fewer than 2 values or a flat
+        range): the lone candidate gets the best possible normalized score on
+        this dimension while the dimension stays in the composite at full
+        weight, preserving the user's best_fit_weights ratios.
+        """
+        if len(values) < 2:
+            return 0.0
+        lo = min(values)
+        hi = max(values)
+        if hi == lo:
+            return 0.0
+        return (target - lo) / (hi - lo)
 
     def _compute_best_fit_score(
         self,
@@ -4752,9 +4799,10 @@ class FillLineGaps:
 
             # Pre-scan end_z.  Run when Z scoring is active OR when diagnostic
             # output is requested so z values are available for all candidate rows.
+            # Z bounds for normalization are computed in pass 2 over the surviving
+            # (post-gate) candidate set, mirroring the per-scope semantics now
+            # applied to distance.
             end_z_by_cand_index: dict[int, Optional[float]] = {}
-            z_score_min: Optional[float] = None
-            z_score_max: Optional[float] = None
 
             if self._raster_handles and (
                 float(self.best_fit_weights.z) > 0.0 or collect_diags
@@ -4766,14 +4814,6 @@ class FillLineGaps:
                         _c.near_y,
                     )
                     end_z_by_cand_index[_i] = _ez
-
-                if float(self.best_fit_weights.z) > 0.0:
-                    _valid_z = [
-                        z for z in end_z_by_cand_index.values() if z is not None
-                    ]
-                    if _valid_z:
-                        z_score_min = min(_valid_z)
-                        z_score_max = max(_valid_z)
 
             # Build a mapping from parent line ID -> list of dangle XY coords.
             # Used in _assess_angle to detect when a line candidate is hit at a
@@ -4793,7 +4833,7 @@ class FillLineGaps:
                 else None
             )
 
-            scored_candidates: list[_ScoredCandidateItem] = []
+            pending_items: list[_PendingDangleItem] = []
 
             for _cand_idx, cand in enumerate(legal_rows):
                 assess = self._assess_angle(
@@ -4907,26 +4947,6 @@ class FillLineGaps:
                         bonus_allowed=bool(bonus_allowed),
                     )
                 )
-                bonus_rank = 0 if bonus_applied else 1
-
-                # 5) Normalized weighted composite score (dangle scope)
-                _tol = float(self.gap_tolerance_meters) or 1.0
-                _eff_norm_dist = float(effective_distance) / _tol
-
-                _norm_z: Optional[float] = None
-                if z_score_min is not None and z_score_max is not None:
-                    _ez = end_z_by_cand_index.get(_cand_idx)
-                    if _ez is not None:
-                        if z_score_max > z_score_min:
-                            _norm_z = (_ez - z_score_min) / (z_score_max - z_score_min)
-                        else:
-                            _norm_z = None  # flat range: Z cannot discriminate
-
-                effective_for_scoring = self._compute_best_fit_score(
-                    norm_dist=_eff_norm_dist,
-                    assess=assess,
-                    norm_z=_norm_z,
-                )
 
                 _norm_angle: Optional[float] = (
                     float(assess.angle_metric_deg) / float(assess.angle_max_deg)
@@ -4934,31 +4954,72 @@ class FillLineGaps:
                     else None
                 )
 
+                pending_items.append(
+                    _PendingDangleItem(
+                        cand=cand,
+                        assess=assess,
+                        raw_distance=float(raw_distance),
+                        effective_distance=float(effective_distance),
+                        bonus_applied=bool(bonus_applied),
+                        norm_angle=_norm_angle,
+                        end_z=end_z_by_cand_index.get(_cand_idx),
+                    )
+                )
+
+            if not pending_items:
+                continue
+
+            # ----------------------------
+            # Pass 2: per-dangle min-max normalization of distance + Z over the
+            # surviving candidate set, then composite computation. Degenerate
+            # scopes (single survivor or flat range) yield 0.0 so the dimension
+            # stays in the composite at full weight without biasing the lone
+            # candidate; missing-Z candidates keep norm_z=None which excludes
+            # the Z weight from the composite for that row.
+            # ----------------------------
+            _eff_dists = [p.effective_distance for p in pending_items]
+            _end_z_pool: list[Optional[float]] = [p.end_z for p in pending_items]
+
+            scored_candidates: list[_ScoredCandidateItem] = []
+            for p in pending_items:
+                _eff_norm_dist = self._normalize_within_scope(
+                    _eff_dists, p.effective_distance
+                )
+
+                _norm_z: Optional[float] = self._normalize_z_within(
+                    _end_z_pool, p.end_z
+                )
+
+                effective_for_scoring = self._compute_best_fit_score(
+                    norm_dist=_eff_norm_dist,
+                    assess=p.assess,
+                    norm_z=_norm_z,
+                )
+
+                bonus_rank = 0 if p.bonus_applied else 1
                 dangle_score = _ProposalScore(
                     composite=float(effective_for_scoring),
                     bonus_rank=int(bonus_rank),
-                    norm_dist=_eff_norm_dist,
-                    norm_angle=_norm_angle,
+                    norm_dist=float(_eff_norm_dist),
+                    norm_angle=p.norm_angle,
                     norm_z=_norm_z,
                 )
 
                 scored_candidates.append(
                     _ScoredCandidateItem(
                         score=dangle_score,
-                        cand=cand,
-                        raw_distance=float(raw_distance),
+                        cand=p.cand,
+                        raw_distance=float(p.raw_distance),
+                        effective_distance=float(p.effective_distance),
                         effective_for_scoring=float(effective_for_scoring),
-                        bonus_applied=bool(bonus_applied),
-                        assess=assess,
+                        bonus_applied=bool(p.bonus_applied),
+                        assess=p.assess,
                         norm_z=_norm_z,
-                        norm_dist=_eff_norm_dist,
-                        norm_angle=_norm_angle,
-                        end_z=end_z_by_cand_index.get(_cand_idx),
+                        norm_dist=float(_eff_norm_dist),
+                        norm_angle=p.norm_angle,
+                        end_z=p.end_z,
                     )
                 )
-
-            if not scored_candidates:
-                continue
 
             winner_item = min(
                 scored_candidates,
@@ -4971,6 +5032,7 @@ class FillLineGaps:
             winner_dangle_score = winner_item.score
             chosen = winner_item.cand
             raw_distance = winner_item.raw_distance
+            effective_distance = winner_item.effective_distance
             bonus_applied = winner_item.bonus_applied
             chosen_assess = winner_item.assess
             winner_norm_z = winner_item.norm_z
@@ -5037,7 +5099,6 @@ class FillLineGaps:
                 )
 
             pair_key = self._unordered_pair_key(src_node, tgt_node)
-            _tol_for_ctx = float(self.gap_tolerance_meters) or 1.0
 
             ctx = _CandidateContext(
                 dangle_oid=dangle_oid,
@@ -5054,10 +5115,11 @@ class FillLineGaps:
                 near_x=chosen.near_x,
                 near_y=chosen.near_y,
                 raw_distance=float(raw_distance),
+                effective_distance=float(effective_distance),
                 bonus_applied=bool(bonus_applied),
                 start_z=start_z,
                 end_z=winner_end_z,
-                norm_dist=float(raw_distance) / _tol_for_ctx,
+                norm_dist=float(winner_dangle_score.norm_dist),
                 assess=chosen_assess,
             )
 
@@ -5077,7 +5139,8 @@ class FillLineGaps:
         self,
         dangle_proposals: dict[DangleOid, _DangleProposal],
     ) -> tuple[dict[DangleOid, _ConnectionProposal], _NormZByDangle]:
-        """Connection normalization: re-normalize Z within each undirected A↔B connection group.
+        """Connection normalization: re-normalize distance and Z within each
+        undirected A↔B connection group, then recompute the composite.
 
         Returns (connection_proposals_by_dangle, connection_norm_z_by_dangle).
         """
@@ -5090,16 +5153,20 @@ class FillLineGaps:
         connection_norm_z_by_dangle: _NormZByDangle = {}
         for _pair_group in _by_connection_for_normalization.values():
             _group_end_z = [p.ctx.end_z for p in _pair_group]
+            _group_eff_dist = [p.ctx.effective_distance for p in _pair_group]
             for p in _pair_group:
                 net_norm_z = self._normalize_z_within(_group_end_z, p.ctx.end_z)
+                net_norm_dist = self._normalize_within_scope(
+                    _group_eff_dist, p.ctx.effective_distance
+                )
                 net_score = _ProposalScore(
                     composite=self._compute_best_fit_score(
-                        norm_dist=p.score.norm_dist,
+                        norm_dist=net_norm_dist,
                         assess=p.ctx.assess,
                         norm_z=net_norm_z,
                     ),
                     bonus_rank=p.score.bonus_rank,
-                    norm_dist=p.score.norm_dist,
+                    norm_dist=float(net_norm_dist),
                     norm_angle=p.score.norm_angle,
                     norm_z=net_norm_z,
                 )
@@ -5169,23 +5236,30 @@ class FillLineGaps:
         self,
         connection_proposals: list[_ConnectionProposal],
     ) -> tuple[list[_GlobalProposal], _NormZByDangle]:
-        """Global normalization: re-normalize Z across all connection winners.
+        """Global normalization: re-normalize distance and Z across all
+        connection winners, then recompute the composite.
 
         Returns (_global_winners, global_norm_z_by_dangle).
         """
         _all_end_z_global = [p.ctx.end_z for p in connection_proposals]
+        _all_eff_dist_global = [
+            p.ctx.effective_distance for p in connection_proposals
+        ]
         _global_winners: list[_GlobalProposal] = []
         global_norm_z_by_dangle: _NormZByDangle = {}
         for n_prop in connection_proposals:
             glob_norm_z = self._normalize_z_within(_all_end_z_global, n_prop.ctx.end_z)
+            glob_norm_dist = self._normalize_within_scope(
+                _all_eff_dist_global, n_prop.ctx.effective_distance
+            )
             glob_score = _ProposalScore(
                 composite=self._compute_best_fit_score(
-                    norm_dist=n_prop.score.norm_dist,
+                    norm_dist=glob_norm_dist,
                     assess=n_prop.ctx.assess,
                     norm_z=glob_norm_z,
                 ),
                 bonus_rank=n_prop.score.bonus_rank,
-                norm_dist=n_prop.score.norm_dist,
+                norm_dist=float(glob_norm_dist),
                 norm_angle=n_prop.score.norm_angle,
                 norm_z=glob_norm_z,
             )

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from enum import Enum
 import math
 import os
@@ -1126,21 +1126,49 @@ class _ScoredCandidateItem:
     end_z: Optional[float]
 
 
+@dataclass(frozen=True)
+class _AngleCaches:
+    """Polyline and line-type caches consumed by the CANDIDATE scope.
+
+    polyline_by_parent: self-line polylines keyed by parent_id.
+    polyline_by_external: polylines from external polyline targets, keyed by
+        dataset_key then SOURCE OID. Only populated for targets that survive
+        the line-like classification below.
+    is_external_line_like: per external dataset_key, whether it is treated as
+        a line-like target for scoring. Respects
+        connect_to_features_angle_mode overrides.
+    line_like_external_ds_keys: subset of is_external_line_like where the
+        value is True.
+    line_like_ds_keys: line_like_external_ds_keys plus lines_key when
+        fill_gaps_on_self is active.
+    """
+
+    polyline_by_parent: dict[ParentId, Any]
+    polyline_by_external: dict[DatasetKey, dict[int, Any]]
+    is_external_line_like: dict[DatasetKey, bool]
+    line_like_external_ds_keys: set[DatasetKey]
+    line_like_ds_keys: set[DatasetKey]
+
+
 @dataclass
 class _DiagnosticsState:
-    """All pipeline state collected during _build_plan for diagnostic assembly."""
+    """All pipeline state collected during _build_plan for diagnostic assembly.
 
-    step1a_illegal: list[_CandidateIllegalA]
-    step1b_illegal: list[_CandidateIllegalB]
-    step1b_scored: list[_CandidateScored]
-    connection_loser_oids: set[DangleOid]
-    kruskal_rejected_oids: set[DangleOid]
-    kruskal_crossing_rejected_oids: set[DangleOid]
-    accepted_dangle_oids: set[DangleOid]
-    gap_source_by_dangle: dict[DangleOid, GapSource]
-    dangle_norm_z_by_dangle: _NormZByDangle
-    connection_norm_z_by_dangle: _NormZByDangle
-    global_norm_z_by_dangle: _NormZByDangle
+    Every field defaults to empty so early bail-outs only need to pass the
+    fields that have actually been populated up to that point.
+    """
+
+    step1a_illegal: list[_CandidateIllegalA] = field(default_factory=list)
+    step1b_illegal: list[_CandidateIllegalB] = field(default_factory=list)
+    step1b_scored: list[_CandidateScored] = field(default_factory=list)
+    connection_loser_oids: set[DangleOid] = field(default_factory=set)
+    kruskal_rejected_oids: set[DangleOid] = field(default_factory=set)
+    kruskal_crossing_rejected_oids: set[DangleOid] = field(default_factory=set)
+    accepted_dangle_oids: set[DangleOid] = field(default_factory=set)
+    gap_source_by_dangle: dict[DangleOid, GapSource] = field(default_factory=dict)
+    dangle_norm_z_by_dangle: _NormZByDangle = field(default_factory=dict)
+    connection_norm_z_by_dangle: _NormZByDangle = field(default_factory=dict)
+    global_norm_z_by_dangle: _NormZByDangle = field(default_factory=dict)
 
 
 # Per-parent plan: each parent line carries a list of planned edits, applied in
@@ -1705,6 +1733,56 @@ class FillLineGaps:
             return str(getattr(desc, "shapeType", "")).lower() == "polyline"
         except Exception:
             return False
+
+    def _build_angle_caches(
+        self,
+        *,
+        target_layers: list[str],
+        lines_key: DatasetKey,
+    ) -> _AngleCaches:
+        polyline_by_parent = self._build_polyline_by_parent_id()
+
+        polyline_by_external: dict[DatasetKey, dict[int, Any]] = {}
+        is_external_line_like: dict[DatasetKey, bool] = {}
+
+        line_keys = self._line_dataset_keys()
+
+        for lyr in target_layers:
+            ds_key = self._dataset_key(lyr)
+
+            # Skip any internal line datasets
+            if ds_key in line_keys:
+                continue
+
+            mode = self._angle_mode_by_external_ds_key.get(
+                ds_key, logic_config.AngleTargetMode.AUTO
+            )
+            if mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
+                is_external_line_like[ds_key] = False
+                continue
+
+            if self._is_polyline_fc(lyr):
+                is_external_line_like[ds_key] = True
+                polyline_by_external[ds_key] = self._build_polyline_by_oid(lyr)
+            else:
+                is_external_line_like[ds_key] = False
+
+        line_like_external_ds_keys: set[DatasetKey] = {
+            ds_key for ds_key, is_line in is_external_line_like.items() if is_line
+        }
+        # Self-lines are included only when fill_gaps_on_self is active (otherwise
+        # no candidates with lines_key appear in the near table anyway).
+        line_like_ds_keys: set[DatasetKey] = line_like_external_ds_keys.copy()
+        if self.fill_gaps_on_self:
+            line_like_ds_keys.add(lines_key)
+
+        return _AngleCaches(
+            polyline_by_parent=polyline_by_parent,
+            polyline_by_external=polyline_by_external,
+            is_external_line_like=is_external_line_like,
+            line_like_external_ds_keys=line_like_external_ds_keys,
+            line_like_ds_keys=line_like_ds_keys,
+        )
 
     def _orientation(self, angle_deg: float) -> float:
         return float(angle_deg) % 180.0
@@ -3217,6 +3295,84 @@ class FillLineGaps:
                         stack.append(int(nb))
         return comp_id
 
+    def _compute_best_line_parent_by_dangle(
+        self,
+        *,
+        legal_rows_by_dangle: dict[DangleOid, list[NearCandidate]],
+        parent_id_by_dangle: dict[DangleOid, ParentId],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_key: DatasetKey,
+        lines_key: DatasetKey,
+        polyline_by_parent: dict[ParentId, Any],
+        polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        is_external_line_like: dict[DatasetKey, bool],
+    ) -> dict[DangleOid, ParentId]:
+        """Per dangle, pick the line-target parent that wins the angle-aware
+        best-fit score. Used downstream by the edge-case bonus detection in
+        _select_dangle_proposals."""
+        best_line_parent_by_dangle: dict[DangleOid, ParentId] = {}
+
+        for dangle_oid in sorted(legal_rows_by_dangle.keys()):
+            parent_id = int(parent_id_by_dangle[dangle_oid])
+
+            xy = dangle_xy.get(int(dangle_oid))
+            if xy is None:
+                continue
+            d_x, d_y = xy
+
+            src_poly = polyline_by_parent.get(int(parent_id))
+            src_angle = None
+            if src_poly is not None:
+                src_angle = self._local_line_angle_cached(
+                    dataset_key=lines_key,
+                    oid=int(parent_id),
+                    polyline=src_poly,
+                    x=float(d_x),
+                    y=float(d_y),
+                )
+
+            best = None
+            best_score = None
+
+            for cand in legal_rows_by_dangle[dangle_oid]:
+                if cand.near_fc_key != lines_key:
+                    continue
+
+                assess = self._assess_angle(
+                    src_parent_id=int(parent_id),
+                    dangle_x=float(d_x),
+                    dangle_y=float(d_y),
+                    src_angle_deg=src_angle,
+                    cand=cand,
+                    dangles_fc_key=dangles_key,
+                    lines_fc_key=lines_key,
+                    dangle_parent=dangle_parent,
+                    dangle_xy=dangle_xy,
+                    polyline_by_parent=polyline_by_parent,
+                    polyline_by_external=polyline_by_external,
+                    is_external_line_like=is_external_line_like,
+                )
+                if assess.blocks:
+                    continue
+
+                raw_dist = cand.near_dist
+                _tol = float(self.gap_tolerance_meters) or 1.0
+                eff = self._compute_best_fit_score(
+                    norm_dist=raw_dist / _tol, assess=assess
+                )
+
+                # Deterministic tie-break:
+                score = (float(eff), float(raw_dist), self._candidate_sort_key(cand))
+                if best_score is None or score < best_score:
+                    best_score = score
+                    best = cand.near_fid
+
+            if best is not None:
+                best_line_parent_by_dangle[int(dangle_oid)] = int(best)
+
+        return best_line_parent_by_dangle
+
     # ----------------------------
     # Build plan (two-phase: detect pairs first, then decide moves)
     # ----------------------------
@@ -3289,52 +3445,41 @@ class FillLineGaps:
 
         collect_diags = self.candidate_connections_output is not None
 
-        # ----------------------------
-        # Angle caches
-        # ----------------------------
-        polyline_by_parent = self._build_polyline_by_parent_id()
-
-        # External polyline caches and line-type map, keyed by dataset_key(layer).
-        # Built before candidate filtering so line_like_ds_keys is available.
-        polyline_by_external: dict[DatasetKey, dict[int, Any]] = {}
-        is_external_line_like: dict[DatasetKey, bool] = {}
-
-        line_keys = (
-            self._line_dataset_keys()
-        )  # {dataset_key(lines_copy), dataset_key(target_self)}
-
-        for lyr in target_layers:
-            ds_key = self._dataset_key(lyr)
-
-            # Skip any internal line datasets
-            if ds_key in line_keys:
-                continue
-
-            mode = self._angle_mode_by_external_ds_key.get(
-                ds_key, logic_config.AngleTargetMode.AUTO
+        def _build_diagnostics(
+            state: _DiagnosticsState,
+        ) -> list["CandidateDiagnostic"]:
+            return self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                state=state,
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
             )
-            if mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
-                is_external_line_like[ds_key] = False
-                continue
 
-            if self._is_polyline_fc(lyr):
-                is_external_line_like[ds_key] = True
-                polyline_by_external[ds_key] = self._build_polyline_by_oid(lyr)
-            else:
-                is_external_line_like[ds_key] = False
+        def _empty_result(state: _DiagnosticsState) -> BuildPlanResult:
+            return BuildPlanResult.empty(diagnostics=_build_diagnostics(state))
 
-        # ds_keys for line-like targets that receive the expanded tolerance.
-        # Self-lines are included only when fill_gaps_on_self is active (otherwise no
-        # candidates with lines_key appear in the near table anyway).
-        line_like_external_ds_keys: set[DatasetKey] = {
-            ds_key for ds_key, is_line in is_external_line_like.items() if is_line
-        }
-        line_like_ds_keys: set[DatasetKey] = line_like_external_ds_keys.copy()
-        if self.fill_gaps_on_self:
-            line_like_ds_keys.add(lines_key)
+        # ============================
+        # CANDIDATE SCOPE
+        # Decides which (dangle, target) pairs are legal, then picks one
+        # winning proposal per dangle.
+        # ============================
+
+        # ----------------------------
+        # Step 1 - Angle & polyline caches
+        # Built before candidate filtering so line_like_ds_keys is available.
+        # ----------------------------
+        angle_caches = self._build_angle_caches(
+            target_layers=target_layers, lines_key=lines_key,
+        )
+        polyline_by_parent = angle_caches.polyline_by_parent
+        polyline_by_external = angle_caches.polyline_by_external
+        is_external_line_like = angle_caches.is_external_line_like
+        line_like_external_ds_keys = angle_caches.line_like_external_ds_keys
+        line_like_ds_keys = angle_caches.line_like_ds_keys
 
         # In directed mode, source dangles at a line's start node are invalid sources.
-        # polyline_by_parent is already built above; dangle_xy was built at the top.
         directed_start_dangles = self._directed_start_dangle_oids(
             dangle_xy=dangle_xy,
             dangle_parent=dangle_parent,
@@ -3342,7 +3487,8 @@ class FillLineGaps:
         )
 
         # ----------------------------
-        # Dangle filtering: collect legal candidates per dangle
+        # Step 2 - Legality gates (distance / network / illegal-target)
+        # Collects legal (dangle, target) candidate rows.
         # ----------------------------
         legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
             self._filter_legal_candidates(
@@ -3361,7 +3507,7 @@ class FillLineGaps:
         )
 
         # ----------------------------
-        # Crossing conflict pre-filter (last legality check)
+        # Step 3 - Crossing pre-filters (last legality check)
         # Barrier check runs first so the subsequent check against existing
         # features only processes survivors.  The trimmed connector cache built
         # by _find_crossing_conflict_keys is reused in _run_kruskal.
@@ -3373,6 +3519,27 @@ class FillLineGaps:
             else None
         )
 
+        def _apply_crossing_filter(
+            reject_keys: set[tuple[int, str, int]], reason: str
+        ) -> None:
+            for _dangle_oid in list(legal_rows_by_dangle.keys()):
+                _parent_id = parent_id_by_dangle[_dangle_oid]
+                _remaining: list[NearCandidate] = []
+                for _cand in legal_rows_by_dangle[_dangle_oid]:
+                    _cand_key = (_dangle_oid, _cand.near_fc_key, _cand.near_fid)
+                    if _cand_key in reject_keys:
+                        if collect_diags:
+                            _step1a_illegal.append(
+                                _CandidateIllegalA(_dangle_oid, _parent_id, _cand, reason)
+                            )
+                    else:
+                        _remaining.append(_cand)
+                if _remaining:
+                    legal_rows_by_dangle[_dangle_oid] = _remaining
+                else:
+                    del legal_rows_by_dangle[_dangle_oid]
+                    parent_id_by_dangle.pop(_dangle_oid, None)
+
         if self.barrier_layers and legal_rows_by_dangle and _crossing_sr is not None:
             _barrier_keys = self._find_barrier_crossing_keys(
                 legal_rows_by_dangle=legal_rows_by_dangle,
@@ -3382,23 +3549,7 @@ class FillLineGaps:
                 spatial_reference=_crossing_sr,
             )
             if _barrier_keys:
-                for _dangle_oid in list(legal_rows_by_dangle.keys()):
-                    _parent_id = parent_id_by_dangle[_dangle_oid]
-                    _remaining: list[NearCandidate] = []
-                    for _cand in legal_rows_by_dangle[_dangle_oid]:
-                        _cand_key = (_dangle_oid, _cand.near_fc_key, _cand.near_fid)
-                        if _cand_key in _barrier_keys:
-                            if collect_diags:
-                                _step1a_illegal.append(
-                                    _CandidateIllegalA(_dangle_oid, _parent_id, _cand, "crosses_barrier_layer")
-                                )
-                        else:
-                            _remaining.append(_cand)
-                    if _remaining:
-                        legal_rows_by_dangle[_dangle_oid] = _remaining
-                    else:
-                        del legal_rows_by_dangle[_dangle_oid]
-                        parent_id_by_dangle.pop(_dangle_oid, None)
+                _apply_crossing_filter(_barrier_keys, "crosses_barrier_layer")
 
         trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
         if self.reject_crossing_connectors and legal_rows_by_dangle and _crossing_sr is not None:
@@ -3418,113 +3569,31 @@ class FillLineGaps:
                 )
             )
             if crossing_conflict_keys:
-                for _dangle_oid in list(legal_rows_by_dangle.keys()):
-                    _parent_id = parent_id_by_dangle[_dangle_oid]
-                    _remaining: list[NearCandidate] = []
-                    for _cand in legal_rows_by_dangle[_dangle_oid]:
-                        _cand_key = (_dangle_oid, _cand.near_fc_key, _cand.near_fid)
-                        if _cand_key in crossing_conflict_keys:
-                            if collect_diags:
-                                _step1a_illegal.append(
-                                    _CandidateIllegalA(_dangle_oid, _parent_id, _cand, "crosses_existing_feature")
-                                )
-                        else:
-                            _remaining.append(_cand)
-                    if _remaining:
-                        legal_rows_by_dangle[_dangle_oid] = _remaining
-                    else:
-                        del legal_rows_by_dangle[_dangle_oid]
-                        parent_id_by_dangle.pop(_dangle_oid, None)
+                _apply_crossing_filter(crossing_conflict_keys, "crosses_existing_feature")
 
         if not legal_rows_by_dangle:
-            return BuildPlanResult.empty(
-                diagnostics=self._assemble_diagnostics(
-                    collect_diags=collect_diags,
-                    state=_DiagnosticsState(
-                        step1a_illegal=_step1a_illegal,
-                        step1b_illegal=[],
-                        step1b_scored=[],
-                        connection_loser_oids=set(),
-                        kruskal_rejected_oids=set(),
-                        kruskal_crossing_rejected_oids=set(),
-                        accepted_dangle_oids=set(),
-                        gap_source_by_dangle={},
-                        dangle_norm_z_by_dangle={},
-                        connection_norm_z_by_dangle={},
-                        global_norm_z_by_dangle={},
-                    ),
-                    dangle_xy=dangle_xy,
-                    dangle_parent=dangle_parent,
-                    dangles_key=dangles_key,
-                    lines_key=lines_key,
-                ),
+            return _empty_result(
+                _DiagnosticsState(step1a_illegal=_step1a_illegal),
             )
 
         # ----------------------------
-        # Best line parent per dangle (angle-aware)
-        # Used by edge-case bonus detection.
+        # Step 4 - Best line parent per dangle (angle-aware)
+        # Used by edge-case bonus detection in the scoring step.
         # ----------------------------
-        best_line_parent_by_dangle: dict[DangleOid, ParentId] = {}
+        best_line_parent_by_dangle = self._compute_best_line_parent_by_dangle(
+            legal_rows_by_dangle=legal_rows_by_dangle,
+            parent_id_by_dangle=parent_id_by_dangle,
+            dangle_xy=dangle_xy,
+            dangle_parent=dangle_parent,
+            dangles_key=dangles_key,
+            lines_key=lines_key,
+            polyline_by_parent=polyline_by_parent,
+            polyline_by_external=polyline_by_external,
+            is_external_line_like=is_external_line_like,
+        )
 
-        for dangle_oid in sorted(legal_rows_by_dangle.keys()):
-            parent_id = int(parent_id_by_dangle[dangle_oid])
-
-            xy = dangle_xy.get(int(dangle_oid))
-            if xy is None:
-                continue
-            d_x, d_y = xy
-
-            src_poly = polyline_by_parent.get(int(parent_id))
-            src_angle = None
-            if src_poly is not None:
-                src_angle = self._local_line_angle_cached(
-                    dataset_key=lines_key,
-                    oid=int(parent_id),
-                    polyline=src_poly,
-                    x=float(d_x),
-                    y=float(d_y),
-                )
-
-            best = None
-            best_score = None
-
-            for cand in legal_rows_by_dangle[dangle_oid]:
-                if cand.near_fc_key != lines_key:
-                    continue
-
-                assess = self._assess_angle(
-                    src_parent_id=int(parent_id),
-                    dangle_x=float(d_x),
-                    dangle_y=float(d_y),
-                    src_angle_deg=src_angle,
-                    cand=cand,
-                    dangles_fc_key=dangles_key,
-                    lines_fc_key=lines_key,
-                    dangle_parent=dangle_parent,
-                    dangle_xy=dangle_xy,
-                    polyline_by_parent=polyline_by_parent,
-                    polyline_by_external=polyline_by_external,
-                    is_external_line_like=is_external_line_like,
-                )
-                if assess.blocks:
-                    continue
-
-                raw_dist = cand.near_dist
-                _tol = float(self.gap_tolerance_meters) or 1.0
-                eff = self._compute_best_fit_score(
-                    norm_dist=raw_dist / _tol, assess=assess
-                )
-
-                # Deterministic tie-break:
-                score = (float(eff), float(raw_dist), self._candidate_sort_key(cand))
-                if best_score is None or score < best_score:
-                    best_score = score
-                    best = cand.near_fid
-
-            if best is not None:
-                best_line_parent_by_dangle[int(dangle_oid)] = int(best)
         # ----------------------------
-        # Dangle selection: choose one proposal per dangle using angle-aware scoring
+        # Step 5 - Angle-aware selection: one proposal per dangle
         # ----------------------------
         _dangle_proposals, dangle_norm_z_by_dangle, _step1b_illegal, _step1b_scored = (
             self._select_dangle_proposals(
@@ -3547,56 +3616,33 @@ class FillLineGaps:
         )
 
         if not _dangle_proposals:
-            return BuildPlanResult.empty(
-                diagnostics=self._assemble_diagnostics(
-                    collect_diags=collect_diags,
-                    state=_DiagnosticsState(
-                        step1a_illegal=_step1a_illegal,
-                        step1b_illegal=_step1b_illegal,
-                        step1b_scored=_step1b_scored,
-                        connection_loser_oids=set(),
-                        kruskal_rejected_oids=set(),
-                        kruskal_crossing_rejected_oids=set(),
-                        accepted_dangle_oids=set(),
-                        gap_source_by_dangle={},
-                        dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                        connection_norm_z_by_dangle={},
-                        global_norm_z_by_dangle={},
-                    ),
-                    dangle_xy=dangle_xy,
-                    dangle_parent=dangle_parent,
-                    dangles_key=dangles_key,
-                    lines_key=lines_key,
+            return _empty_result(
+                _DiagnosticsState(
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
                 ),
             )
 
+        # ============================
+        # NETWORK SCOPE
+        # Resolves one winner per undirected A<->B connection group.
+        # ============================
+
         # ----------------------------
-        # Mutual detection (for labeling)
+        # Step 1 - Mutual detection (for labeling)
         # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
         # - network mutual: any proposal exists in both directions between the two network nodes
         # ----------------------------
         active: list[_DangleProposal] = list(_dangle_proposals.values())
         if not active:
-            return BuildPlanResult.empty(
-                diagnostics=self._assemble_diagnostics(
-                    collect_diags=collect_diags,
-                    state=_DiagnosticsState(
-                        step1a_illegal=_step1a_illegal,
-                        step1b_illegal=_step1b_illegal,
-                        step1b_scored=_step1b_scored,
-                        connection_loser_oids=set(),
-                        kruskal_rejected_oids=set(),
-                        kruskal_crossing_rejected_oids=set(),
-                        accepted_dangle_oids=set(),
-                        gap_source_by_dangle={},
-                        dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                        connection_norm_z_by_dangle={},
-                        global_norm_z_by_dangle={},
-                    ),
-                    dangle_xy=dangle_xy,
-                    dangle_parent=dangle_parent,
-                    dangles_key=dangles_key,
-                    lines_key=lines_key,
+            return _empty_result(
+                _DiagnosticsState(
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
                 ),
             )
         active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
@@ -3617,14 +3663,14 @@ class FillLineGaps:
         }
 
         # ----------------------------
-        # Connection normalization: re-normalize Z within each undirected A↔B connection group
+        # Step 2 - Connection normalization: re-normalize Z within each undirected A<->B connection group
         # ----------------------------
         connection_proposals_by_dangle, connection_norm_z_by_dangle = (
             self._run_connection_normalization(_dangle_proposals)
         )
 
         # ----------------------------
-        # Connection selection: one winner per undirected connection
+        # Step 3 - Connection selection: one winner per undirected connection
         # ----------------------------
         _connection_proposals, connection_loser_oids = self._run_connection_selection(
             connection_proposals_by_dangle=connection_proposals_by_dangle,
@@ -3633,15 +3679,20 @@ class FillLineGaps:
             collect_diags=collect_diags,
         )
 
+        # ============================
+        # KRUSKAL SCOPE
+        # Cycle prevention + crossing recheck across all connection winners.
+        # ============================
+
         # ----------------------------
-        # Global normalization: re-normalize Z across all connection winners
+        # Step 1 - Global normalization: re-normalize Z across all connection winners
         # ----------------------------
         _global_winners, global_norm_z_by_dangle = self._run_global_normalization(
             _connection_proposals
         )
 
         # ----------------------------
-        # Global selection: Kruskal cycle prevention across accepted connections
+        # Step 2 - Kruskal cycle prevention across accepted connections
         # ----------------------------
         (
             _global_proposals,
@@ -3664,45 +3715,8 @@ class FillLineGaps:
         )
 
         if not _global_proposals:
-            return BuildPlanResult.empty(
-                diagnostics=self._assemble_diagnostics(
-                    collect_diags=collect_diags,
-                    state=_DiagnosticsState(
-                        step1a_illegal=_step1a_illegal,
-                        step1b_illegal=_step1b_illegal,
-                        step1b_scored=_step1b_scored,
-                        connection_loser_oids=connection_loser_oids,
-                        kruskal_rejected_oids=kruskal_rejected_oids,
-                        kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
-                        accepted_dangle_oids=accepted_dangle_oids,
-                        gap_source_by_dangle=gap_source_by_dangle,
-                        dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                        connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-                        global_norm_z_by_dangle=global_norm_z_by_dangle,
-                    ),
-                    dangle_xy=dangle_xy,
-                    dangle_parent=dangle_parent,
-                    dangles_key=dangles_key,
-                    lines_key=lines_key,
-                ),
-            )
-
-        # ----------------------------
-        # Resnap candidate identification
-        # ----------------------------
-        resnap_captures = self._identify_resnap_captures(_global_proposals)
-
-        # ----------------------------
-        # Build plan_by_parent: parent_id -> list[plan_entry]
-        # ----------------------------
-        plan_by_parent = self._assemble_plan_entries(_global_proposals)
-
-        return BuildPlanResult(
-            plan_by_parent=plan_by_parent,
-            resnap_captures=resnap_captures,
-            diagnostics=self._assemble_diagnostics(
-                collect_diags=collect_diags,
-                state=_DiagnosticsState(
+            return _empty_result(
+                _DiagnosticsState(
                     step1a_illegal=_step1a_illegal,
                     step1b_illegal=_step1b_illegal,
                     step1b_scored=_step1b_scored,
@@ -3715,10 +3729,40 @@ class FillLineGaps:
                     connection_norm_z_by_dangle=connection_norm_z_by_dangle,
                     global_norm_z_by_dangle=global_norm_z_by_dangle,
                 ),
-                dangle_xy=dangle_xy,
-                dangle_parent=dangle_parent,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
+            )
+
+        # ============================
+        # DEFERRED SCOPE
+        # Resolved later in run() after _apply_plan + _resnap_connections.
+        # ============================
+
+        # ----------------------------
+        # Step 1 - Resnap candidate identification
+        # ----------------------------
+        resnap_captures = self._identify_resnap_captures(_global_proposals)
+
+        # ----------------------------
+        # Step 2 - Plan entry assembly: parent_id -> list[plan_entry]
+        # ----------------------------
+        plan_by_parent = self._assemble_plan_entries(_global_proposals)
+
+        return BuildPlanResult(
+            plan_by_parent=plan_by_parent,
+            resnap_captures=resnap_captures,
+            diagnostics=_build_diagnostics(
+                _DiagnosticsState(
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    connection_loser_oids=connection_loser_oids,
+                    kruskal_rejected_oids=kruskal_rejected_oids,
+                    kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
+                    accepted_dangle_oids=accepted_dangle_oids,
+                    gap_source_by_dangle=gap_source_by_dangle,
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                    connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+                    global_norm_z_by_dangle=global_norm_z_by_dangle,
+                ),
             ),
             accepted_connector_raw=accepted_connector_raw,
             kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
@@ -5453,6 +5497,40 @@ class FillLineGaps:
                         row = row + (None,) * len(meta_fields)
                     icur.insertRow(row)
 
+    def _update_deferred_diagnostics(
+        self,
+        *,
+        diagnostics: list[CandidateDiagnostic],
+        resnap_plan: dict[ParentId, PlanEntry],
+        rejected_oids: set[DangleOid],
+        displaced_oids: set[DangleOid],
+        winner_oids: set[DangleOid],
+    ) -> None:
+        """Record each accepted candidate's resnap outcome on its diagnostic.
+        Precedence: displaced > winner > applied_resnapped > rejected."""
+        if self.candidate_connections_output is None or not diagnostics:
+            return
+
+        applied_oids = {v.dangle_oid for v in resnap_plan.values() if not v.skip}
+        for diag in diagnostics:
+            if diag.kruskal_scope is None or diag.kruskal_scope.status != "accepted":
+                continue
+            d_oid = int(diag.dangle_oid)
+            if d_oid in displaced_oids:
+                deferred = ScopeRecord(status="resnap_crossing_displaced")
+                diag.deferred_scope = deferred
+                diag.final_status = deferred
+            elif d_oid in winner_oids:
+                diag.deferred_scope = ScopeRecord(status="referenced_as_winner")
+            elif d_oid in applied_oids:
+                deferred = ScopeRecord(status="applied_resnapped")
+                diag.deferred_scope = deferred
+                diag.final_status = deferred
+            elif d_oid in rejected_oids:
+                deferred = ScopeRecord(status="resnap_crossing_rejected")
+                diag.deferred_scope = deferred
+                diag.final_status = deferred
+
     def _write_output(self) -> None:
         arcpy.management.CopyFeatures(self.lines_copy, self.output_lines)
 
@@ -5536,29 +5614,13 @@ class FillLineGaps:
 
             self._apply_plan({pid: [entry] for pid, entry in resnap_plan.items()})
 
-            if self.candidate_connections_output is not None and diagnostics:
-                resnapped_dangle_oids = {
-                    v.dangle_oid
-                    for v in resnap_plan.values()
-                    if not v.skip
-                }
-                for diag in diagnostics:
-                    d_oid = int(diag.dangle_oid)
-                    if diag.kruskal_scope is not None and diag.kruskal_scope.status == "accepted":
-                        if d_oid in resnap_crossing_displaced_oids:
-                            deferred = ScopeRecord(status="resnap_crossing_displaced")
-                            diag.deferred_scope = deferred
-                            diag.final_status = deferred
-                        elif d_oid in resnap_crossing_winner_oids:
-                            diag.deferred_scope = ScopeRecord(status="referenced_as_winner")
-                        elif d_oid in resnapped_dangle_oids:
-                            deferred = ScopeRecord(status="applied_resnapped")
-                            diag.deferred_scope = deferred
-                            diag.final_status = deferred
-                        elif d_oid in resnap_crossing_rejected_oids:
-                            deferred = ScopeRecord(status="resnap_crossing_rejected")
-                            diag.deferred_scope = deferred
-                            diag.final_status = deferred
+            self._update_deferred_diagnostics(
+                diagnostics=diagnostics,
+                resnap_plan=resnap_plan,
+                rejected_oids=resnap_crossing_rejected_oids,
+                displaced_oids=resnap_crossing_displaced_oids,
+                winner_oids=resnap_crossing_winner_oids,
+            )
 
         if self.candidate_connections_output is not None and diagnostics:
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2404,11 +2404,13 @@ class FillLineGaps:
                 self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
             )
             _endpoint_snap = _is_dangle_pair or _is_dangle_parent_line
-            # Normalize src to "exit toward gap" convention UNLESS this is a directional
-            # endpoint snap — in that case raw flow direction + topology check takes over,
-            # and the flip would collapse A>>B and A<>B onto identical inputs.
+            # In directional mode: always use raw forward direction (no flip).
+            # The topology check handles endpoint snaps; for mid-line snaps, raw angles
+            # give consistent directionality across all target types.
+            # In UNDIRECTED mode: flip if at start so src points "exit toward gap"
+            # for symmetric dangle-pair scoring.
             if src_poly_for_norm is not None and src_angle_deg is not None:
-                if not (_is_directional and _endpoint_snap):
+                if not _is_directional:
                     if self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y):
                         src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1577,25 +1577,30 @@ class FillLineGaps:
         self._local_angle_cache[key] = angle
         return angle
 
-    def _line_measure_at_xy(self, polyline, x: float, y: float) -> Optional[float]:
+    def _xy_is_at_line_start(self, polyline, x: float, y: float) -> bool:
         """
-        Returns the percentage measure [0, 1] of the nearest point to (x, y) on polyline.
-        Returns None if the query fails or the result is unavailable.
+        Returns True if (x, y) is geometrically closer to the start of polyline than to
+        its end, False otherwise (including on any geometry failure).
+
+        Uses squared-distance comparison between (x, y) and polyline.firstPoint /
+        polyline.lastPoint — no ArcPy queryPointAndDistance call, so this is immune
+        to the map-unit vs percentage ambiguity in that API.
+
+        Used for angle normalisation: flip the forward tangent to the exit direction
+        when the dangle sits at the start of its parent line, leave it when at the end.
         """
         if polyline is None:
-            return None
+            return False
         try:
-            sr = getattr(polyline, "spatialReference", None)
-            pt = arcpy.PointGeometry(arcpy.Point(float(x), float(y)), sr)
-            try:
-                q = polyline.queryPointAndDistance(pt, use_percentage=True)
-            except TypeError:
-                q = polyline.queryPointAndDistance(pt, True)
-            if q and len(q) >= 2 and q[1] is not None:
-                return float(q[1])
+            first = polyline.firstPoint
+            last = polyline.lastPoint
+            if first is None or last is None:
+                return False
+            d_start = (x - first.X) ** 2 + (y - first.Y) ** 2
+            d_end = (x - last.X) ** 2 + (y - last.Y) ** 2
+            return d_start < d_end
         except Exception:
-            pass
-        return None
+            return False
 
     # ----------------------------
     # Target staging
@@ -2394,19 +2399,18 @@ class FillLineGaps:
             _diff = self._directional_diff
             angle_max_deg = 180.0
 
-            # Normalize both angles to a digitization-independent convention so
-            # that directional diffs are 0 for a perfect collinear gap fill
-            # regardless of which end of each line the dangle sits on.
-            #
-            # src_angle_deg -> "exit direction from source dangle toward the gap"
-            #   Forward tangent points away from the line when the dangle is at
-            #   the end (m >= 0.5); it points INTO the line when at the start
-            #   (m < 0.5), so we reverse it.
             src_poly_for_norm = polyline_by_parent.get(int(src_parent_id))
+            _is_directional = (
+                self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
+            )
+            _endpoint_snap = _is_dangle_pair or _is_dangle_parent_line
+            # Normalize src to "exit toward gap" convention UNLESS this is a directional
+            # endpoint snap — in that case raw flow direction + topology check takes over,
+            # and the flip would collapse A>>B and A<>B onto identical inputs.
             if src_poly_for_norm is not None and src_angle_deg is not None:
-                src_m = self._line_measure_at_xy(src_poly_for_norm, dangle_x, dangle_y)
-                if src_m is not None and src_m < 0.5:
-                    src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
+                if not (_is_directional and _endpoint_snap):
+                    if self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y):
+                        src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
 
             # In UNDIRECTED mode (_use_directional triggered by dangle-pair / dangle-parent-line):
             # normalise target_angle to "entry direction into target interior" so that both
@@ -2418,8 +2422,7 @@ class FillLineGaps:
             if self.source_direction_mode == logic_config.SourceDirectionMode.UNDIRECTED:
                 _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
                 _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
-                tgt_m = self._line_measure_at_xy(tgt_poly, _tgt_snap_x, _tgt_snap_y)
-                if tgt_m is not None and tgt_m >= 0.5:
+                if not self._xy_is_at_line_start(tgt_poly, _tgt_snap_x, _tgt_snap_y):
                     target_angle = (float(target_angle) + 180.0) % 360.0
         else:
             _diff = self._orientation_diff
@@ -2439,7 +2442,31 @@ class FillLineGaps:
         )
 
         if _use_directional:
-            metric = float(src_target_diff)
+            if _is_directional and _endpoint_snap:
+                # Topology-aware metric: only end→start is a valid directional connection.
+                # "Opposite attracts": src_is_end AND target_is_start → use direction diff.
+                # All other combinations (end→end, start→start, start→end) → 180° (BAD).
+                _snap_x = float(tx) if _is_dangle_pair else float(near_x)
+                _snap_y = float(ty) if _is_dangle_pair else float(near_y)
+                _src_is_end = (
+                    src_poly_for_norm is not None
+                    and not self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y)
+                )
+                _tgt_is_start = self._xy_is_at_line_start(tgt_poly, _snap_x, _snap_y)
+                if _src_is_end and _tgt_is_start:
+                    metric = float(src_target_diff)
+                else:
+                    metric = 180.0
+            elif _is_directional:
+                # Non-endpoint line-like target: blend angular alignment with connector
+                # direction so mid-line snaps are not purely angle-driven.
+                _src_conn_directional = self._directional_diff(
+                    float(src_angle_deg), float(connector_angle)
+                )
+                metric = 0.5 * float(src_target_diff) + 0.5 * _src_conn_directional
+            else:
+                # UNDIRECTED dangle-pair / dangle-parent-line after both normalizations.
+                metric = float(src_target_diff)
         else:
             metric = float(src_connector_diff)
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2030,6 +2030,7 @@ class FillLineGaps:
         polyline_by_parent: dict[int, Any],
         polyline_by_external: dict[str, dict[int, Any]],
         is_external_line_like: dict[str, bool],
+        dangle_target_parents: Optional[set] = None,
     ) -> AngleAssessment:
         ds_key = str(cand["near_fc_key"])
         near_fid = int(cand["near_fid"])
@@ -2152,10 +2153,20 @@ class FillLineGaps:
                 src_connector_diff=float(src_connector_diff),
             )
 
-        # Dangle-pair targets: use directional comparison so anti-parallel lines
-        # are not collapsed to zero diff. All other line-like targets keep the
-        # undirected orientation-based comparison.
-        if ds_key == dangles_fc_key:
+        # Dangle-pair targets use directional comparison so anti-parallel lines
+        # are not collapsed to zero diff. A line candidate to the parent of a
+        # known target-dangle candidate represents the same connection opportunity
+        # and must be scored with identical directional semantics to prevent it
+        # from getting an unfair undirected scoring advantage.
+        _is_dangle_pair = ds_key == dangles_fc_key
+        _is_dangle_parent_line = (
+            ds_key == lines_fc_key
+            and dangle_target_parents is not None
+            and int(near_fid) in dangle_target_parents
+        )
+        _use_directional = _is_dangle_pair or _is_dangle_parent_line
+
+        if _use_directional:
             _diff = self._directional_diff
             angle_max_deg = 180.0
 
@@ -2176,7 +2187,12 @@ class FillLineGaps:
             # target_angle -> "entry direction into target interior from its dangle"
             #   Forward tangent equals the entry direction when the dangle is at
             #   the start (m < 0.5); it must be reversed when at the end (m >= 0.5).
-            tgt_m = self._line_measure_at_xy(tgt_poly, float(tx), float(ty))
+            # For a true dangle candidate the snap point is the target dangle XY;
+            # for a line candidate that shares the same parent, the snap point is
+            # the GenerateNearTable hit on the line (near_x, near_y).
+            _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
+            _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
+            tgt_m = self._line_measure_at_xy(tgt_poly, _tgt_snap_x, _tgt_snap_y)
             if tgt_m is not None and tgt_m >= 0.5:
                 target_angle = (float(target_angle) + 180.0) % 360.0
         else:
@@ -2186,10 +2202,10 @@ class FillLineGaps:
         connector_target_diff = _diff(float(connector_angle), float(target_angle))
         src_target_diff = _diff(float(src_angle_deg), float(target_angle))
         # connector_transition_diff mixes src→connector and connector→target.
-        # For dangle pairs, use directional src→connector to stay consistent.
+        # For directional cases, use directional src→connector to stay consistent.
         _src_conn_for_transition = (
             self._directional_diff(float(src_angle_deg), float(connector_angle))
-            if ds_key == dangles_fc_key
+            if _use_directional
             else float(src_connector_diff)
         )
         connector_transition_diff = 0.5 * (
@@ -2840,6 +2856,17 @@ class FillLineGaps:
                     y=float(d_y),
                 )
 
+            # Parent IDs of target-dangle candidates for this source dangle.
+            # A line candidate to one of these parents represents the same
+            # connection opportunity as the dangle candidate and must be scored
+            # with identical directional semantics (no undirected bypass).
+            _dangle_target_parents: set[int] = set()
+            for _c in legal_rows:
+                if str(_c["near_fc_key"]) == str(dangles_key):
+                    _p = dangle_parent.get(int(_c["near_fid"]))
+                    if _p is not None:
+                        _dangle_target_parents.add(int(_p))
+
             scored_candidates: list[
                 tuple[
                     tuple[float, int, float, int, int, str, int],  # score tuple
@@ -2865,6 +2892,7 @@ class FillLineGaps:
                     polyline_by_parent=polyline_by_parent,
                     polyline_by_external=polyline_by_external,
                     is_external_line_like=is_external_line_like,
+                    dangle_target_parents=_dangle_target_parents,
                 )
 
                 # 1) Candidate blocking (angle_block_threshold_degrees)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -840,7 +840,6 @@ class AngleAssessment:
     connector_target_diff: Optional[float] = None
     src_target_diff: Optional[float] = None
     connector_transition_diff: Optional[float] = None
-    line_match_diff: Optional[float] = None
 
 
 @dataclass
@@ -896,6 +895,7 @@ class CandidateDiagnostic:
 # ---------------------------------------------------------------------------
 # Pipeline type aliases
 # ---------------------------------------------------------------------------
+_DangleXYsByParent:    TypeAlias = dict[int, list[tuple[float, float]]]
 _IllegalTargets:       TypeAlias = dict[int, dict[str, set[int]]]
 _CandRow:              TypeAlias = dict[str, Any]
 _Grouped:              TypeAlias = dict[int, list[_CandRow]]
@@ -967,9 +967,6 @@ class FillLineGaps:
             else float(adv.angle_extra_dangle_threshold_degrees)
         )
         self.best_fit_weights = adv.best_fit_weights
-
-        w = float(getattr(adv, "line_alignment_weight", 0.6))
-        self.line_alignment_weight = max(0.0, min(1.0, w))
 
         self.angle_local_half_window_m = float(
             getattr(adv, "angle_local_half_window_m", 2.0)
@@ -2190,7 +2187,7 @@ class FillLineGaps:
         polyline_by_parent: dict[int, Any],
         polyline_by_external: dict[str, dict[int, Any]],
         is_external_line_like: dict[str, bool],
-        dangle_target_parents: Optional[set] = None,
+        dangle_xys_by_parent: Optional[_DangleXYsByParent] = None,
     ) -> AngleAssessment:
         ds_key = str(cand["near_fc_key"])
         near_fid = int(cand["near_fid"])
@@ -2259,7 +2256,6 @@ class FillLineGaps:
         connector_target_diff: Optional[float] = None
         src_target_diff: Optional[float] = None
         connector_transition_diff: Optional[float] = None
-        line_match_diff: Optional[float] = None
 
         if ds_key == lines_fc_key:
             tgt_parent = int(near_fid)
@@ -2319,11 +2315,13 @@ class FillLineGaps:
         # and must be scored with identical directional semantics to prevent it
         # from getting an unfair undirected scoring advantage.
         _is_dangle_pair = ds_key == dangles_fc_key
-        _is_dangle_parent_line = (
-            ds_key == lines_fc_key
-            and dangle_target_parents is not None
-            and int(near_fid) in dangle_target_parents
-        )
+        _is_dangle_parent_line = False
+        if ds_key == lines_fc_key and dangle_xys_by_parent is not None:
+            _tol = self.connectivity_tolerance_meters
+            _is_dangle_parent_line = any(
+                abs(dx - near_x) < _tol and abs(dy - near_y) < _tol
+                for dx, dy in dangle_xys_by_parent.get(int(near_fid), [])
+            )
         _use_directional = _is_dangle_pair or _is_dangle_parent_line
 
         if _use_directional:
@@ -2372,13 +2370,10 @@ class FillLineGaps:
             _src_conn_for_transition + float(connector_target_diff)
         )
 
-        w = float(self.line_alignment_weight)
-        connector_w = 1.0 - w
-        line_match_diff = connector_w * float(connector_transition_diff) + w * float(
-            src_target_diff
-        )
-
-        metric = float(line_match_diff)
+        if _use_directional:
+            metric = float(src_target_diff)
+        else:
+            metric = float(src_connector_diff)
 
         blocks = self.angle_block_threshold_degrees is not None and metric > float(
             self.angle_block_threshold_degrees
@@ -2401,7 +2396,6 @@ class FillLineGaps:
             connector_target_diff=float(connector_target_diff),
             src_target_diff=float(src_target_diff),
             connector_transition_diff=float(connector_transition_diff),
-            line_match_diff=float(line_match_diff),
         )
 
     def _pair_token_from_candidate(
@@ -3139,16 +3133,14 @@ class FillLineGaps:
                         z_score_min = min(_valid_z)
                         z_score_max = max(_valid_z)
 
-            # Parent IDs of target-dangle candidates for this source dangle.
-            # A line candidate to one of these parents represents the same
-            # connection opportunity as the dangle candidate and must be scored
-            # with identical directional semantics (no undirected bypass).
-            _dangle_target_parents: set[int] = set()
-            for _c in legal_rows:
-                if str(_c["near_fc_key"]) == str(dangles_key):
-                    _p = dangle_parent.get(int(_c["near_fid"]))
-                    if _p is not None:
-                        _dangle_target_parents.add(int(_p))
+            # Build a mapping from parent line ID -> list of dangle XY coords.
+            # Used in _assess_angle to detect when a line candidate is hit at a
+            # dangle endpoint, so it can be scored with directional semantics.
+            _dangle_xys_by_parent: _DangleXYsByParent = {}
+            for _d_oid, _d_parent in dangle_parent.items():
+                _d_xy = dangle_xy.get(_d_oid)
+                if _d_xy is not None:
+                    _dangle_xys_by_parent.setdefault(int(_d_parent), []).append(_d_xy)
 
             # (_ProposalScore, cand, raw_dist, best_fit, bonus, assess, norm_z, end_z)
             scored_candidates: list[tuple[Any, ...]] = []
@@ -3167,7 +3159,7 @@ class FillLineGaps:
                     polyline_by_parent=polyline_by_parent,
                     polyline_by_external=polyline_by_external,
                     is_external_line_like=is_external_line_like,
-                    dangle_target_parents=_dangle_target_parents,
+                    dangle_xys_by_parent=_dangle_xys_by_parent,
                 )
 
                 _cand_end_z: Optional[float] = end_z_by_cand_index.get(_cand_idx)
@@ -3851,7 +3843,6 @@ class FillLineGaps:
                 entry["meta_connector_transition_diff"] = (
                     assess.connector_transition_diff
                 )
-                entry["meta_line_match_diff"] = assess.line_match_diff
                 entry["meta_angle_metric_deg"] = assess.angle_metric_deg
                 entry["meta_best_fit_score"] = best_fit_score
         return entry
@@ -4071,7 +4062,6 @@ class FillLineGaps:
             "connector_target_diff",
             "src_target_diff",
             "connector_transition_diff",
-            "line_match_diff",
             "angle_metric_deg",
             "best_fit_score",
         ]
@@ -4111,7 +4101,6 @@ class FillLineGaps:
                     meta.get("meta_connector_target_diff"),
                     meta.get("meta_src_target_diff"),
                     meta.get("meta_connector_transition_diff"),
-                    meta.get("meta_line_match_diff"),
                     meta.get("meta_angle_metric_deg"),
                     meta.get("meta_best_fit_score"),
                     meta.get("meta_bonus_applied"),
@@ -4146,7 +4135,6 @@ class FillLineGaps:
             "connector_target_diff",
             "src_target_diff",
             "connector_transition_diff",
-            "line_match_diff",
         ):
             arcpy.management.AddField(fc_path, fname, "DOUBLE")
         arcpy.management.AddField(fc_path, "final_gap_source", "TEXT", field_length=20)
@@ -4183,7 +4171,6 @@ class FillLineGaps:
             "connector_target_diff",
             "src_target_diff",
             "connector_transition_diff",
-            "line_match_diff",
             "final_gap_source",
             "candidate_status",
             "status_reason",
@@ -4216,7 +4203,6 @@ class FillLineGaps:
                     a.connector_target_diff if a is not None else None,
                     a.src_target_diff if a is not None else None,
                     a.connector_transition_diff if a is not None else None,
-                    a.line_match_diff if a is not None else None,
                     d.final_gap_source,
                     d.candidate_status,
                     d.status_reason,
@@ -4297,7 +4283,6 @@ class FillLineGaps:
                                     "meta_connector_target_diff",
                                     "meta_src_target_diff",
                                     "meta_connector_transition_diff",
-                                    "meta_line_match_diff",
                                     "meta_angle_metric_deg",
                                     "meta_best_fit_score",
                                     "meta_bonus_applied",
@@ -4340,7 +4325,6 @@ class FillLineGaps:
                 "connector_target_diff",
                 "src_target_diff",
                 "connector_transition_diff",
-                "line_match_diff",
                 "angle_metric_deg",
                 "best_fit_score",
                 "bonus_applied",

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -97,6 +97,27 @@ class FillLineGaps:
         text = str(value).replace("\\", "/")
         return text.split("/")[-1]
 
+    def _line_dataset_keys(self) -> set[str]:
+        return {
+            self._dataset_key(self.lines_copy),
+            self._dataset_key(self.target_self),
+        }
+
+    def _normalize_target_key(
+        self, *, near_fc_key: str, lines_key: str, line_keys: set[str]
+    ) -> str:
+        if near_fc_key in line_keys:
+            return lines_key
+        return near_fc_key
+
+    def _oid_to_original_id_lookup(self, fc: str) -> dict[int, int]:
+        oid_field = arcpy.Describe(fc).OIDFieldName
+        out: dict[int, int] = {}
+        with arcpy.da.SearchCursor(fc, [oid_field, self.ORIGINAL_ID]) as cur:
+            for oid, original_id in cur:
+                out[int(oid)] = int(original_id)
+        return out
+
     # ----------------------------
     # Preprocessing
     # ----------------------------
@@ -371,7 +392,7 @@ class FillLineGaps:
         self,
         *,
         candidates_sorted: list[dict],
-        lines_fc_key: str,
+        lines_fc_keys: set[str],
         other_parent_id: int,
         base_tol: float,
     ) -> Optional[dict]:
@@ -380,7 +401,7 @@ class FillLineGaps:
         within base_tol.
         """
         for cand in candidates_sorted:
-            if cand["near_fc_key"] != lines_fc_key:
+            if cand["near_fc_key"] not in lines_fc_keys:
                 continue
             if int(cand["near_fid"]) != int(other_parent_id):
                 continue
@@ -417,11 +438,17 @@ class FillLineGaps:
         *,
         near_table: str,
         dangles_fc_key: str,
+        lines_copy_key: str,
+        target_self_key: str,
+        lines_copy_oid_to_orig: dict[int, int],
+        target_self_oid_to_orig: dict[int, int],
     ) -> dict[int, list[dict]]:
-        """
-        grouped[in_dangle_oid] = list of candidates sorted later by dist.
-        """
+
         grouped: dict[int, list[dict]] = {}
+
+        # Canonical key for “input lines”
+        lines_key = self._dataset_key(self.lines_copy)
+        line_keys = self._line_dataset_keys()
 
         fields = [
             self.F_IN_FID,
@@ -441,7 +468,20 @@ class FillLineGaps:
                 nf_id = int(near_fid)
                 dist = float(near_dist)
 
-                near_fc_key = self._dataset_key(near_fc)
+                raw_key = self._dataset_key(near_fc)
+                nf_id = int(near_fid)
+
+                # Convert line-like near_fid into ORIGINAL_ID space
+                if raw_key == lines_copy_key:
+                    nf_id = lines_copy_oid_to_orig.get(nf_id, nf_id)
+                elif raw_key == target_self_key:
+                    nf_id = target_self_oid_to_orig.get(nf_id, nf_id)
+
+                near_fc_key = self._normalize_target_key(
+                    near_fc_key=raw_key,
+                    lines_key=lines_key,
+                    line_keys=line_keys,
+                )
 
                 # Defensive guard against self-dangle returning as candidate
                 if near_fc_key == dangles_fc_key and nf_id == in_id:
@@ -449,7 +489,8 @@ class FillLineGaps:
 
                 grouped.setdefault(in_id, []).append(
                     {
-                        "near_fc_key": near_fc_key,
+                        "near_fc_key_raw": raw_key,  # optional: keep for debugging
+                        "near_fc_key": near_fc_key,  # normalized key
                         "near_fid": nf_id,
                         "near_dist": dist,
                         "near_x": float(near_x),
@@ -488,6 +529,10 @@ class FillLineGaps:
             if other_parent is None:
                 return False
 
+            # making sure self parent line never is legal
+            if ds_key == lines_fc_key and int(oid) == int(parent_id):
+                return False
+
             # treat as snapping to that parent line for illegal checks
             if self._is_illegal(
                 illegal=illegal,
@@ -518,7 +563,7 @@ class FillLineGaps:
         *,
         dangle_parent: dict[int, int],
         dangles_fc_key: str,
-        lines_fc_key: str,
+        lines_fc_keys: set[str],
         cand: dict,
     ) -> Optional[int]:
         """
@@ -532,7 +577,7 @@ class FillLineGaps:
             other_parent = dangle_parent.get(oid)
             return int(other_parent) if other_parent is not None else None
 
-        if ds_key == lines_fc_key:
+        if ds_key in lines_fc_keys:
             return int(oid)
 
         return None
@@ -599,35 +644,73 @@ class FillLineGaps:
             target_layers=target_layers,
         )
 
-        dangles_key = self._dataset_key(self.dangles)
+        dangles_key = self._dataset_key(dangles_fc)
+
         lines_key = self._dataset_key(self.lines_copy)
+        lines_fc_keys = self._line_dataset_keys()
+        near_features = list(target_layers) + [dangles_fc]
 
         base_tol = float(self.gap_tolerance_meters)
         dangle_tol = float(self._expanded_dangle_tolerance_meters())
 
+        lines_copy_key = self._dataset_key(self.lines_copy)
+        target_self_key = self._dataset_key(self.target_self)
+
+        lines_copy_oid_to_orig = self._oid_to_original_id_lookup(self.lines_copy)
+        target_self_oid_to_orig = (
+            self._oid_to_original_id_lookup(self.target_self)
+            if self.fill_gaps_on_self
+            else {}
+        )
         # One near-table for everything (expanded radius so we can see dangle pairs)
-        near_features = list(target_layers) + [self.dangles]
         self._generate_near_table(
             in_dangles=dangles_fc,
             near_features=near_features,
             search_radius=self._expanded_dangle_tolerance_linear_unit(),
             out_table=self.near_table,
         )
-
         grouped = self._read_near_table_grouped(
             near_table=self.near_table,
             dangles_fc_key=dangles_key,
+            lines_copy_key=lines_copy_key,
+            target_self_key=target_self_key,
+            lines_copy_oid_to_orig=lines_copy_oid_to_orig,
+            target_self_oid_to_orig=target_self_oid_to_orig,
         )
+
+        # DEBUG: inspect first candidates
+        lines_key = self._dataset_key(self.lines_copy)
+        zero = 0
+        line = 0
+        total = 0
+
+        for in_id, rows in list(grouped.items())[:2000]:  # sample
+            if not rows:
+                continue
+            r0 = min(rows, key=lambda r: r["near_dist"])
+            total += 1
+            if float(r0["near_dist"]) == 0.0:
+                zero += 1
+            if r0["near_fc_key"] == lines_key:
+                line += 1
+
+        arcpy.AddMessage(f"DEBUG sample={total} zero_dist={zero} line_key={line}")
+
         if not grouped:
             return {}
 
         # ----------------------------
         # Phase 1: per dangle -> first legal + pair token
         # ----------------------------
+        total_dangles = 0
+        no_parent = 0
+        no_legal = 0
         per_dangle: dict[int, dict] = {}
         for dangle_oid, candidates in grouped.items():
+            total_dangles += 1
             parent_id = dangle_parent.get(int(dangle_oid))
             if parent_id is None:
+                no_parent += 1
                 continue
 
             rows = sorted(candidates, key=lambda r: r["near_dist"])
@@ -642,12 +725,12 @@ class FillLineGaps:
                 dangle_tol=dangle_tol,
             )
             if first_legal is None:
+                no_legal += 1
                 continue
-
             token = self._pair_token_from_candidate(
                 dangle_parent=dangle_parent,
                 dangles_fc_key=dangles_key,
-                lines_fc_key=lines_key,
+                lines_fc_keys=lines_fc_keys,
                 cand=first_legal,
             )
 
@@ -657,7 +740,17 @@ class FillLineGaps:
                 "first_legal": first_legal,
                 "pair_token_parent": token,  # other parent id if pair-like
             }
+            if len(per_dangle) < 20:
+                arcpy.AddMessage(
+                    f"DEBUG example: dangle_oid={dangle_oid} parent={parent_id} "
+                    f"first_legal key={first_legal['near_fc_key']} raw={first_legal.get('near_fc_key_raw')} "
+                    f"near_fid={first_legal['near_fid']} dist={first_legal['near_dist']}"
+                )
 
+        arcpy.AddMessage(
+            f"DEBUG grouped={len(grouped)} total={total_dangles} "
+            f"no_parent={no_parent} no_legal={no_legal}"
+        )
         if not per_dangle:
             return {}
 
@@ -788,13 +881,13 @@ class FillLineGaps:
             # (2) Explicit parent-line proximity rows (must be within base tolerance)
             a_to_b_line = self._find_specific_line_candidate(
                 candidates_sorted=info["rows"],
-                lines_fc_key=lines_key,
+                lines_fc_keys=lines_fc_keys,
                 other_parent_id=int(b_parent),
                 base_tol=float(base_tol),
             )
             b_to_a_line = self._find_specific_line_candidate(
                 candidates_sorted=b_info["rows"],
-                lines_fc_key=lines_key,
+                lines_fc_keys=lines_fc_keys,
                 other_parent_id=int(a_parent),
                 base_tol=float(base_tol),
             )

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1413,6 +1413,14 @@ class FillLineGaps:
         self.conn_table = "connected_table"
 
         self.external_target_layers: list[str] = []
+        # FCs to use as against_fcs in the connector-crossing pre-filter.
+        # Polyline connect_to_features are reused as-is; polygon
+        # connect_to_features contribute their boundary as a polyline FC
+        # built once via PolygonToLine in
+        # _build_external_target_layers_once.  Populated only when
+        # reject_crossing_connectors is True; entries are pure paths so
+        # the existing line-vs-line crossing path applies uniformly.
+        self.external_target_crossing_layers: list[str] = []
 
         self.work_file_list = [
             self.lines_copy,
@@ -2075,6 +2083,26 @@ class FillLineGaps:
                 )
 
             self.external_target_layers.append(output_name)
+
+            # Companion entry for the connector-crossing pre-filter.
+            # Polyline sources reuse output_name; polygon sources are
+            # converted to their boundary polyline once via PolygonToLine
+            # so the line-vs-line crossing path handles them uniformly.
+            # Other shape types (points) are skipped — a connector cannot
+            # cross a point.
+            if self.reject_crossing_connectors:
+                if self._is_polyline_fc(output_name):
+                    self.external_target_crossing_layers.append(output_name)
+                elif self._is_polygon_fc(output_name):
+                    outline_name = self.wfm.build_file_path(
+                        file_name=f"target_feature_{index}_polygon_outline"
+                    )
+                    arcpy.management.PolygonToLine(
+                        in_features=output_name,
+                        out_feature_class=outline_name,
+                    )
+                    self.external_target_crossing_layers.append(outline_name)
+
             out_key = self._dataset_key(output_name)
 
             raw_map = self._connect_to_features_angle_mode_raw
@@ -3940,14 +3968,14 @@ class FillLineGaps:
             and _crossing_sr is not None
         ):
             # self-lines (lines_copy) plus every connect_to_features layer
-            # that can be crossed.  Shape-type filter is applied directly
-            # rather than reusing polyline_by_external: that cache is built
-            # for angle scoring and excludes FORCE_NON_LINE polylines and
-            # all polygons, neither of which should be excluded here.
-            _check_layers: list[str] = [self.lines_copy]
-            for _lyr in self.external_target_layers:
-                if self._is_polyline_fc(_lyr) or self._is_polygon_fc(_lyr):
-                    _check_layers.append(_lyr)
+            # eligible for the line-vs-line crossing pre-filter.  Polygon
+            # sources have already been converted to their boundary polyline
+            # in _build_external_target_layers_once so a single uniform path
+            # applies here.
+            _check_layers: list[str] = [
+                self.lines_copy,
+                *self.external_target_crossing_layers,
+            ]
             crossing_conflict_keys, trimmed_connector_cache = (
                 self._find_crossing_conflict_keys(
                     legal_rows_by_dangle=legal_rows_by_dangle,

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -799,7 +799,8 @@ class CandidateDiagnostic:
 
     status_reason values per status:
         illegal:              beyond_distance_tolerance | same_network | illegal_target |
-                              blocked_by_angle | expanded_dangle_angle_disallowed
+                              blocked_by_angle | expanded_dangle_angle_disallowed |
+                              blocked_by_z_drop
         legal_not_selected:   outscored_within_dangle
         selected_for_dangle:  deferred | lost_pair_competition | lost_cycle_prevention |
                               deferred_rejected_connectivity
@@ -823,6 +824,9 @@ class CandidateDiagnostic:
     assess: Optional[AngleAssessment]
     target_parent_id: Optional[int]
     final_gap_source: Optional[str] # gap_source value for applied_to_output rows; None otherwise
+    start_z: Optional[float] = None # Z at the dangle point (candidate start); None when no rasters
+    end_z: Optional[float] = None   # Z at the near point (candidate end);   None when no rasters
+    norm_z: Optional[float] = None  # Per-dangle-normalised Z score [0,1]; None for illegals/no rasters
 
 
 class FillLineGaps:
@@ -904,6 +908,17 @@ class FillLineGaps:
         self._angle_mode_by_external_ds_key: dict[str, logic_config.AngleTargetMode] = (
             {}
         )
+
+        # ----------------------------
+        # Z / elevation layer
+        # ----------------------------
+        self.raster_paths: tuple[str, ...] = (
+            tuple(adv.raster_paths) if adv.raster_paths else ()
+        )
+        self.z_drop_threshold: Optional[float] = (
+            None if adv.z_drop_threshold is None else float(adv.z_drop_threshold)
+        )
+        self._raster_handles: list[geometry_tools.RasterHandle] = []
 
         # Local angle cache (dataset_key, oid, rx, ry) -> Optional[float]
         self._local_angle_cache: dict[tuple[str, int, int, int], Optional[float]] = {}
@@ -1226,17 +1241,26 @@ class FillLineGaps:
         return raw_distance, effective_distance, bool(bonus_applied), score
 
     def _compute_best_fit_score(
-        self, *, norm_dist: float, assess: "AngleAssessment"
+        self,
+        *,
+        norm_dist: float,
+        assess: "AngleAssessment",
+        norm_z: Optional[float] = None,
     ) -> float:
         """
         Normalized weighted composite best-fit score. Lower is better.
 
         Unavailable dimensions are excluded from the composite and the score
         is normalized by the sum of available weights only.  This ensures a
-        missing angle is neutral rather than treated as a perfect fit.
+        missing dimension is neutral rather than treated as a perfect fit.
+
+        norm_z: Z contribution normalized to [0, 1] within the current dangle's
+            candidate set, where 0 = lowest end elevation (most downstream, best)
+            and 1 = highest (most upstream, worst).  None excludes the Z weight.
         """
         w_d = float(self.best_fit_weights.distance)
         w_a = float(self.best_fit_weights.angle)
+        w_z = float(self.best_fit_weights.z)
 
         total_w = w_d
         score = w_d * float(norm_dist)
@@ -1246,6 +1270,11 @@ class FillLineGaps:
             score += w_a * norm_a
             total_w += w_a
         # angle unavailable: exclude w_a from total so the score is not biased
+
+        if norm_z is not None and w_z > 0.0:
+            score += w_z * float(norm_z)
+            total_w += w_z
+        # z unavailable: exclude w_z from total so the score is not biased
 
         return float(score) / float(total_w) if total_w > 0.0 else 0.0
 
@@ -1328,6 +1357,40 @@ class FillLineGaps:
         if ang < 0.0:
             ang += 360.0
         return float(ang)
+
+    def _build_raster_handles(self) -> None:
+        """
+        Load each raster in self.raster_paths into a RasterHandle windowed to
+        the extent of the input lines.  Called once at the start of run().
+        Populates self._raster_handles; no-ops when raster_paths is empty.
+        """
+        if not self.raster_paths:
+            return
+
+        try:
+            ext = arcpy.Describe(self.input_lines).extent
+            clip_kwargs = dict(
+                clip_xmin=ext.XMin,
+                clip_ymin=ext.YMin,
+                clip_xmax=ext.XMax,
+                clip_ymax=ext.YMax,
+            )
+        except Exception:
+            clip_kwargs = {}
+
+        handles = []
+        for path in self.raster_paths:
+            try:
+                handles.append(
+                    geometry_tools.build_raster_handle(raster_path=path, **clip_kwargs)
+                )
+            except Exception as exc:
+                arcpy.AddWarning(
+                    f"Could not load raster {path}: {exc}. "
+                    "Z values from this raster will be None."
+                )
+
+        self._raster_handles = handles
 
     def _local_angle_cache_key(
         self, *, dataset_key: str, oid: int, x: float, y: float
@@ -2545,11 +2608,25 @@ class FillLineGaps:
                 return []
             result: list[CandidateDiagnostic] = []
 
+            def _z_pair(
+                d_xy: tuple[float, float], near_x: float, near_y: float
+            ) -> tuple[Optional[float], Optional[float]]:
+                if not self._raster_handles:
+                    return None, None
+                sz = geometry_tools.local_z_at_xy(
+                    self._raster_handles, float(d_xy[0]), float(d_xy[1])
+                )
+                ez = geometry_tools.local_z_at_xy(
+                    self._raster_handles, float(near_x), float(near_y)
+                )
+                return sz, ez
+
             # Step-1A illegals: angle never computed for these
             for d_oid, p_id, cand, reason in _step1a_illegal:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
                     continue
+                _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
                 result.append(CandidateDiagnostic(
                     parent_id=p_id,
                     dangle_oid=d_oid,
@@ -2570,6 +2647,9 @@ class FillLineGaps:
                         cand, dangle_parent, dangles_key, lines_key
                     ),
                     final_gap_source=None,
+                    start_z=_sz,
+                    end_z=_ez,
+                    norm_z=None,
                 ))
 
             # Step-1B angle-blocked illegals: angle computed
@@ -2577,6 +2657,7 @@ class FillLineGaps:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
                     continue
+                _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
                 result.append(CandidateDiagnostic(
                     parent_id=p_id,
                     dangle_oid=d_oid,
@@ -2597,6 +2678,9 @@ class FillLineGaps:
                         cand, dangle_parent, dangles_key, lines_key
                     ),
                     final_gap_source=None,
+                    start_z=_sz,
+                    end_z=_ez,
+                    norm_z=None,
                 ))
 
             # Compute per-dangle rank for scored candidates (1 = local winner)
@@ -2613,7 +2697,7 @@ class FillLineGaps:
 
             # Step-1B scored candidates
             for (
-                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner, _score
+                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner, _score, sc_norm_z
             ) in _step1b_scored:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
@@ -2647,6 +2731,7 @@ class FillLineGaps:
                     reason = None
                     final_gs = None
 
+                _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
                 result.append(CandidateDiagnostic(
                     parent_id=p_id,
                     dangle_oid=d_oid,
@@ -2667,6 +2752,9 @@ class FillLineGaps:
                         cand, dangle_parent, dangles_key, lines_key
                     ),
                     final_gap_source=final_gs,
+                    start_z=_sz,
+                    end_z=_ez,
+                    norm_z=sc_norm_z,
                 ))
             return result
 
@@ -2856,6 +2944,36 @@ class FillLineGaps:
                     y=float(d_y),
                 )
 
+            # ----------------------------
+            # Z setup for this dangle
+            # ----------------------------
+            # start_z is fixed for all candidates of this dangle.
+            start_z: Optional[float] = None
+            if self._raster_handles:
+                start_z = geometry_tools.local_z_at_xy(
+                    self._raster_handles, float(d_x), float(d_y)
+                )
+
+            # Pre-scan end_z for per-dangle normalization (needed for Z weight in
+            # best-fit score). Only done when Z weight is active.
+            end_z_by_cand_index: dict[int, Optional[float]] = {}
+            z_score_min: Optional[float] = None
+            z_score_max: Optional[float] = None
+
+            if self._raster_handles and float(self.best_fit_weights.z) > 0.0:
+                for _i, _c in enumerate(legal_rows):
+                    _ez = geometry_tools.local_z_at_xy(
+                        self._raster_handles,
+                        float(_c["near_x"]),
+                        float(_c["near_y"]),
+                    )
+                    end_z_by_cand_index[_i] = _ez
+
+                _valid_z = [z for z in end_z_by_cand_index.values() if z is not None]
+                if _valid_z:
+                    z_score_min = min(_valid_z)
+                    z_score_max = max(_valid_z)
+
             # Parent IDs of target-dangle candidates for this source dangle.
             # A line candidate to one of these parents represents the same
             # connection opportunity as the dangle candidate and must be scored
@@ -2875,10 +2993,11 @@ class FillLineGaps:
                     float,  # effective_distance_for_scoring
                     bool,  # bonus_applied
                     "AngleAssessment",  # assess for winning candidate metadata
+                    Optional[float],  # norm_z
                 ]
             ] = []
 
-            for cand in legal_rows:
+            for _cand_idx, cand in enumerate(legal_rows):
                 assess = self._assess_angle(
                     src_parent_id=int(parent_id),
                     dangle_x=float(d_x),
@@ -2925,7 +3044,30 @@ class FillLineGaps:
                         )
                     continue
 
-                # 3) Edge-case bonus eligibility is angle-controlled (and conservative when angle missing)
+                # 3) Z drop gate (z_drop_threshold)
+                if self.z_drop_threshold is not None and start_z is not None:
+                    _end_z = end_z_by_cand_index.get(
+                        _cand_idx,
+                        geometry_tools.local_z_at_xy(
+                            self._raster_handles,
+                            float(cand["near_x"]),
+                            float(cand["near_y"]),
+                        ),
+                    )
+                    if _end_z is not None and (_end_z - start_z) > self.z_drop_threshold:
+                        if collect_diags:
+                            _step1b_illegal.append(
+                                (
+                                    dangle_oid,
+                                    parent_id,
+                                    cand,
+                                    assess,
+                                    "blocked_by_z_drop",
+                                )
+                            )
+                        continue
+
+                # 4) Edge-case bonus eligibility is angle-controlled (and conservative when angle missing)
                 bonus_allowed = True
                 if is_dangle_target:
                     # conservative policy: if angle is unavailable => no expanded behavior, no bonus
@@ -2945,10 +3087,22 @@ class FillLineGaps:
                     )
                 )
 
-                # 4) Normalized weighted composite score
+                # 5) Normalized weighted composite score
                 _tol = float(self.gap_tolerance_meters) or 1.0
+
+                _norm_z: Optional[float] = None
+                if z_score_min is not None and z_score_max is not None:
+                    _ez = end_z_by_cand_index.get(_cand_idx)
+                    if _ez is not None:
+                        if z_score_max > z_score_min:
+                            _norm_z = (_ez - z_score_min) / (z_score_max - z_score_min)
+                        else:
+                            _norm_z = 0.0
+
                 effective_for_scoring = self._compute_best_fit_score(
-                    norm_dist=float(effective_distance) / _tol, assess=assess
+                    norm_dist=float(effective_distance) / _tol,
+                    assess=assess,
+                    norm_z=_norm_z,
                 )
 
                 # Keep score tuple shape stable; only replace the first element
@@ -2970,6 +3124,7 @@ class FillLineGaps:
                         float(effective_for_scoring),
                         bool(bonus_applied),
                         assess,
+                        _norm_z,
                     )
                 )
 
@@ -2984,11 +3139,12 @@ class FillLineGaps:
                 effective_distance_for_scoring,
                 bonus_applied,
                 chosen_assess,
+                _,
             ) = winner_item
 
             if collect_diags:
                 for sc_tuple in scored_candidates:
-                    sc_score, sc_cand, sc_raw, sc_best_fit, sc_bonus, sc_assess = sc_tuple
+                    sc_score, sc_cand, sc_raw, sc_best_fit, sc_bonus, sc_assess, sc_norm_z = sc_tuple
                     _step1b_scored.append((
                         dangle_oid,
                         parent_id,
@@ -2999,6 +3155,7 @@ class FillLineGaps:
                         bool(sc_bonus),
                         sc_tuple is winner_item,
                         sc_score,  # score tuple for per-dangle rank computation
+                        sc_norm_z,
                     ))
 
             # ----------------------------
@@ -3642,6 +3799,9 @@ class FillLineGaps:
         arcpy.management.AddField(fc_path, "final_gap_source", "TEXT", field_length=20)
         arcpy.management.AddField(fc_path, "candidate_status", "TEXT", field_length=25)
         arcpy.management.AddField(fc_path, "status_reason", "TEXT", field_length=50)
+        arcpy.management.AddField(fc_path, "start_z", "DOUBLE")
+        arcpy.management.AddField(fc_path, "end_z", "DOUBLE")
+        arcpy.management.AddField(fc_path, "norm_z", "DOUBLE")
 
     def _write_candidate_connections_output(
         self,
@@ -3672,6 +3832,9 @@ class FillLineGaps:
             "final_gap_source",
             "candidate_status",
             "status_reason",
+            "start_z",
+            "end_z",
+            "norm_z",
         ]
         with arcpy.da.InsertCursor(fc_path, fields) as cur:
             for d in diagnostics:
@@ -3700,6 +3863,9 @@ class FillLineGaps:
                     d.final_gap_source,
                     d.candidate_status,
                     d.status_reason,
+                    d.start_z,
+                    d.end_z,
+                    d.norm_z,
                 ))
 
     def _apply_plan(self, plan) -> None:
@@ -3852,6 +4018,7 @@ class FillLineGaps:
         )
 
         self._copy_input_lines()
+        self._build_raster_handles()
         self._add_original_id_field()
         self._create_dangles()
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -907,9 +907,9 @@ class _GlobalProposal:
     def from_network(
         cls, n: "_ConnectionProposal", score: "_ProposalScore"
     ) -> "_GlobalProposal":
-        assert n.gap_source is not None, (
-            "_ConnectionProposal.gap_source must be stamped before promotion to Stage B"
-        )
+        assert (
+            n.gap_source is not None
+        ), "_ConnectionProposal.gap_source must be stamped before promotion to Stage B"
         return cls(
             ctx=n.ctx,
             dangle_norm_z=n.dangle_norm_z,
@@ -1106,6 +1106,44 @@ class _CandidateScored(NamedTuple):
     end_z: Optional[float]
 
 
+class _DirectionalNormalization(NamedTuple):
+    """Outcome of normalising angles for the directional metric.
+
+    Undirected mode flips ``src_angle_deg`` and ``target_angle`` so a clean
+    collinear pair scores 0°; directed mode replaces ``src_connector_diff``
+    with the directional difference so anti-parallel src/connector reports
+    180° instead of collapsing under orientation_diff. ``src_poly_for_norm``
+    and ``endpoint_snap`` are surfaced so the metric helper can apply the
+    end-to-start topology rule without re-deriving them.
+    """
+
+    src_angle_deg: float
+    target_angle: float
+    src_connector_diff: float
+    src_poly_for_norm: Any
+    endpoint_snap: bool
+
+
+class _TargetAngleResolution(NamedTuple):
+    """Result of resolving a candidate's target polyline and snap point.
+
+    target_angle is None when the polyline is missing (parent unknown, geometry
+    not cached). tgt_poly mirrors that — None when the helper cannot resolve
+    geometry. snap_x/snap_y are the coordinates used for both local angle
+    sampling and downstream endpoint topology checks; for dangle-pair targets
+    these prefer the precise dangle XY over the near-table snap.
+    target_parent_id is set for line-like input candidates (line target →
+    own parent; dangle target → the other dangle's parent line), None for
+    external datasets.
+    """
+
+    target_angle: Optional[float]
+    tgt_poly: Any
+    snap_x: float
+    snap_y: float
+    target_parent_id: Optional[ParentId] = None
+
+
 @dataclass(frozen=True)
 class _ScoredCandidateItem:
     """One scored candidate row inside _select_dangle_proposals.
@@ -1295,7 +1333,9 @@ class FillLineGaps:
         )
         self.edit_method = logic_config.EditMethod(adv.edit_method)
 
-        self.connectivity_scope = logic_config.ConnectivityScope(conn.connectivity_scope)
+        self.connectivity_scope = logic_config.ConnectivityScope(
+            conn.connectivity_scope
+        )
         self.connectivity_tolerance_meters = float(conn.connectivity_tolerance_meters)
         self.line_connectivity_mode = logic_config.LineConnectivityMode(
             conn.line_connectivity_mode
@@ -1307,8 +1347,10 @@ class FillLineGaps:
             )
 
         self.lines_are_directed: bool = bool(ang.lines_are_directed)
-        self.dangle_pair_apply_connector_diff: bool = bool(
-            ang.dangle_pair_apply_connector_diff
+        self.connector_angle_diff_required_above_meters: Optional[float] = (
+            None
+            if ang.connector_angle_diff_required_above_meters is None
+            else float(ang.connector_angle_diff_required_above_meters)
         )
 
         self.angle_block_threshold_degrees = (
@@ -1455,11 +1497,11 @@ class FillLineGaps:
     ) -> bool:
         """Return ``True`` if two parent lines share a network under the topology scope.
 
-          - NONE: always ``False``.
-          - DIRECT_CONNECTION: ``True`` iff ``b`` is in ``a``'s direct
-            neighbor set.
-          - Component scopes: ``True`` iff both parents share a
-            connectivity id.
+        - NONE: always ``False``.
+        - DIRECT_CONNECTION: ``True`` iff ``b`` is in ``a``'s direct
+          neighbor set.
+        - Component scopes: ``True`` iff both parents share a
+          connectivity id.
         """
         scope = topology.scope
 
@@ -1925,7 +1967,6 @@ class FillLineGaps:
     # ----------------------------
     # Source direction orientation
     # ----------------------------
-
 
     def _local_angle_cache_key(
         self, *, dataset_key: str, oid: int, x: float, y: float
@@ -2915,6 +2956,210 @@ class FillLineGaps:
             return near_fid  # already in ORIGINAL_ID space
         return None
 
+    def _dangle_pair_requires_connector_diff(
+        self,
+        *,
+        target_parent_id: Optional[ParentId],
+        dist_to_parent_line_by_id: Optional[dict[ParentId, float]],
+    ) -> bool:
+        """Decide whether the connector-diff penalty fires for a dangle pair.
+
+        Caller has already verified the threshold is set and that the candidate's
+        own gap distance exceeds it (the cheap dangle-distance short-circuit), so
+        the only remaining question is whether the parent line itself is also
+        beyond the threshold. If the lookup cannot resolve a distance — missing
+        target parent, lookup unavailable, parent filtered out — the call is
+        conservative and applies the penalty.
+        """
+        threshold = self.connector_angle_diff_required_above_meters
+        if (
+            threshold is None
+            or target_parent_id is None
+            or dist_to_parent_line_by_id is None
+        ):
+            return True
+        dist = dist_to_parent_line_by_id.get(int(target_parent_id))
+        if dist is None:
+            return True
+        return float(dist) > float(threshold)
+
+    def _normalize_directional_angles(
+        self,
+        *,
+        src_parent_id: ParentId,
+        src_angle_deg: float,
+        target_angle: float,
+        src_connector_diff: float,
+        connector_angle: float,
+        dangle_x: float,
+        dangle_y: float,
+        tgt_poly: Any,
+        tgt_snap_x: float,
+        tgt_snap_y: float,
+        is_dangle_pair: bool,
+        is_dangle_parent_line: bool,
+        polyline_by_parent: dict[ParentId, Any],
+    ) -> _DirectionalNormalization:
+        """Apply the directional-mode flips and src_connector_diff override.
+
+        Undirected mode: flip src_angle if the source line starts at the dangle
+        (so it points outward toward the gap); flip target_angle when the snap
+        is not at the target line's start (so both dangles in a pair receive
+        a 0° score for a clean collinear fill).
+
+        Directed mode: lines are pre-oriented, so skip flips and re-express
+        src_connector_diff using directional_diff so anti-parallel src/connector
+        reports 180° instead of collapsing under orientation_diff.
+        """
+        src_poly_for_norm = polyline_by_parent.get(int(src_parent_id))
+        endpoint_snap = is_dangle_pair or is_dangle_parent_line
+
+        if not self.lines_are_directed:
+            if (
+                src_poly_for_norm is not None
+                and self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y)
+            ):
+                src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
+            if not self._xy_is_at_line_start(tgt_poly, tgt_snap_x, tgt_snap_y):
+                target_angle = (float(target_angle) + 180.0) % 360.0
+        else:
+            src_connector_diff = self._directional_diff(
+                float(src_angle_deg), float(connector_angle)
+            )
+
+        return _DirectionalNormalization(
+            src_angle_deg=float(src_angle_deg),
+            target_angle=float(target_angle),
+            src_connector_diff=float(src_connector_diff),
+            src_poly_for_norm=src_poly_for_norm,
+            endpoint_snap=bool(endpoint_snap),
+        )
+
+    def _resolve_target_angle_and_snap(
+        self,
+        *,
+        cand: NearCandidate,
+        ds_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+        dangles_fc_key: DatasetKey,
+        dangle_parent: dict[DangleOid, ParentId],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        polyline_by_parent: dict[ParentId, Any],
+        polyline_by_external: dict[DatasetKey, dict[int, Any]],
+    ) -> _TargetAngleResolution:
+        """Resolve the target polyline, its local angle, and the snap point.
+
+        For dangle-pair targets the snap defaults to the precise dangle XY
+        (more accurate than the near-table snap, which is rounded). Other
+        targets use the near-table coordinates directly.
+        """
+        near_fid = cand.near_fid
+        snap_x = float(cand.near_x)
+        snap_y = float(cand.near_y)
+
+        if ds_key == lines_fc_key:
+            tgt_parent = int(near_fid)
+            tgt_poly = polyline_by_parent.get(tgt_parent)
+            if tgt_poly is None:
+                return _TargetAngleResolution(
+                    None, None, snap_x, snap_y, target_parent_id=tgt_parent
+                )
+            target_angle = self._local_line_angle_cached(
+                dataset_key=lines_fc_key,
+                oid=tgt_parent,
+                polyline=tgt_poly,
+                x=snap_x,
+                y=snap_y,
+            )
+            return _TargetAngleResolution(
+                target_angle, tgt_poly, snap_x, snap_y, target_parent_id=tgt_parent
+            )
+
+        if ds_key == dangles_fc_key:
+            other_dangle_oid = int(near_fid)
+            other_parent = dangle_parent.get(other_dangle_oid)
+            if other_parent is None:
+                return _TargetAngleResolution(None, None, snap_x, snap_y)
+            tgt_poly = polyline_by_parent.get(int(other_parent))
+            if tgt_poly is None:
+                return _TargetAngleResolution(
+                    None, None, snap_x, snap_y, target_parent_id=int(other_parent)
+                )
+            xy = dangle_xy.get(other_dangle_oid)
+            if xy is not None:
+                snap_x, snap_y = float(xy[0]), float(xy[1])
+            target_angle = self._local_line_angle_cached(
+                dataset_key=lines_fc_key,
+                oid=int(other_parent),
+                polyline=tgt_poly,
+                x=snap_x,
+                y=snap_y,
+            )
+            return _TargetAngleResolution(
+                target_angle,
+                tgt_poly,
+                snap_x,
+                snap_y,
+                target_parent_id=int(other_parent),
+            )
+
+        ext = polyline_by_external.get(ds_key, {})
+        tgt_poly = ext.get(int(near_fid))
+        if tgt_poly is None:
+            return _TargetAngleResolution(None, None, snap_x, snap_y)
+        target_angle = self._local_line_angle_cached(
+            dataset_key=ds_key,
+            oid=int(near_fid),
+            polyline=tgt_poly,
+            x=snap_x,
+            y=snap_y,
+        )
+        return _TargetAngleResolution(target_angle, tgt_poly, snap_x, snap_y)
+
+    def _resolve_treat_as_line_like(
+        self,
+        *,
+        ds_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+        dangles_fc_key: DatasetKey,
+        is_external_line_like: dict[DatasetKey, bool],
+    ) -> bool:
+        """Decide whether a candidate's dataset should use line-aware angle scoring.
+
+        Input lines and dangles are always line-like. External datasets honour
+        the AngleTargetMode override; AUTO defers to the runtime detection
+        cached in ``is_external_line_like``.
+        """
+        if ds_key == lines_fc_key or ds_key == dangles_fc_key:
+            return True
+        mode = self._angle_mode_by_external_ds_key.get(
+            ds_key, logic_config.AngleTargetMode.AUTO
+        )
+        if mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
+            return False
+        return bool(is_external_line_like.get(ds_key, False))
+
+    def _unavailable_assessment(
+        self,
+        *,
+        ds_key: DatasetKey,
+        dangles_fc_key: DatasetKey,
+        src_connector_diff: Optional[float] = None,
+    ) -> AngleAssessment:
+        """Assessment used when an angle input is missing.
+
+        Conservative policy: never block, never penalise. The extra-dangle
+        allowance only restricts dangle-layer candidates, so it stays True
+        for every other ds_key.
+        """
+        return AngleAssessment(
+            available=False,
+            blocks=False,
+            allow_extra_dangle=ds_key != dangles_fc_key,
+            angle_metric_deg=None,
+            src_connector_diff=src_connector_diff,
+        )
+
     def _assess_angle(
         self,
         *,
@@ -2931,6 +3176,7 @@ class FillLineGaps:
         polyline_by_external: dict[DatasetKey, dict[int, Any]],
         is_external_line_like: dict[DatasetKey, bool],
         dangle_xys_by_parent: Optional[_DangleXYsByParent] = None,
+        dist_to_parent_line_by_id: Optional[dict[ParentId, float]] = None,
     ) -> AngleAssessment:
         ds_key = cand.near_fc_key
         near_fid = cand.near_fid
@@ -2941,27 +3187,18 @@ class FillLineGaps:
             from_x=dangle_x, from_y=dangle_y, to_x=near_x, to_y=near_y
         )
 
-        # Determine line-like vs non-line
-        if ds_key == lines_fc_key or ds_key == dangles_fc_key:
-            treat_as_line_like = True
-        else:
-            mode = self._angle_mode_by_external_ds_key.get(
-                ds_key, logic_config.AngleTargetMode.AUTO
-            )
-            if mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
-                treat_as_line_like = False
-            else:
-                treat_as_line_like = bool(is_external_line_like.get(ds_key, False))
+        treat_as_line_like = self._resolve_treat_as_line_like(
+            ds_key=ds_key,
+            lines_fc_key=lines_fc_key,
+            dangles_fc_key=dangles_fc_key,
+            is_external_line_like=is_external_line_like,
+        )
 
         # Base requirements
         if src_angle_deg is None or connector_angle is None:
-            # Angle unavailable => no block, no penalty; conservative extra-dangle policy handled below
-            allow_extra = ds_key != dangles_fc_key  # only relevant for dangle targets
-            return AngleAssessment(
-                available=False,
-                blocks=False,
-                allow_extra_dangle=bool(allow_extra),
-                angle_metric_deg=None,
+            return self._unavailable_assessment(
+                ds_key=ds_key,
+                dangles_fc_key=dangles_fc_key,
             )
 
         src_connector_diff = self._orientation_diff(
@@ -2971,21 +3208,14 @@ class FillLineGaps:
         # Non-line targets use src_connector_diff directly
         if not treat_as_line_like:
             metric = float(src_connector_diff)
-
-            blocks = self.angle_block_threshold_degrees is not None and metric > float(
-                self.angle_block_threshold_degrees
+            block_thr = self.angle_block_threshold_degrees
+            blocks = block_thr is not None and metric > float(block_thr)
+            extra_thr = self.angle_extra_dangle_threshold_degrees
+            allow_extra = (
+                ds_key != dangles_fc_key
+                or extra_thr is None
+                or metric <= float(extra_thr)
             )
-
-            # extra-dangle threshold only affects dangle targets
-            allow_extra = True
-            if ds_key == dangles_fc_key:
-                if self.angle_extra_dangle_threshold_degrees is None:
-                    allow_extra = True
-                else:
-                    allow_extra = metric <= float(
-                        self.angle_extra_dangle_threshold_degrees
-                    )
-
             return AngleAssessment(
                 available=True,
                 blocks=bool(blocks),
@@ -2995,60 +3225,30 @@ class FillLineGaps:
             )
 
         # Line-like targets: need target angle too
-        target_angle: Optional[float] = None
         connector_target_diff: Optional[float] = None
         src_target_diff: Optional[float] = None
         connector_transition_diff: Optional[float] = None
 
-        if ds_key == lines_fc_key:
-            tgt_parent = int(near_fid)
-            tgt_poly = polyline_by_parent.get(tgt_parent)
-            if tgt_poly is not None:
-                target_angle = self._local_line_angle_cached(
-                    dataset_key=lines_fc_key,
-                    oid=tgt_parent,
-                    polyline=tgt_poly,
-                    x=near_x,
-                    y=near_y,
-                )
-
-        elif ds_key == dangles_fc_key:
-            other_dangle_oid = int(near_fid)
-            other_parent = dangle_parent.get(other_dangle_oid)
-            if other_parent is not None:
-                tgt_poly = polyline_by_parent.get(int(other_parent))
-                if tgt_poly is not None:
-                    # Prefer true dangle XY lookup; fall back to near_x/near_y
-                    xy = dangle_xy.get(other_dangle_oid)
-                    tx, ty = xy if xy is not None else (near_x, near_y)
-                    target_angle = self._local_line_angle_cached(
-                        dataset_key=lines_fc_key,
-                        oid=int(other_parent),
-                        polyline=tgt_poly,
-                        x=float(tx),
-                        y=float(ty),
-                    )
-
-        else:
-            ext = polyline_by_external.get(ds_key, {})
-            tgt_poly = ext.get(int(near_fid))
-            if tgt_poly is not None:
-                target_angle = self._local_line_angle_cached(
-                    dataset_key=ds_key,
-                    oid=int(near_fid),
-                    polyline=tgt_poly,
-                    x=near_x,
-                    y=near_y,
-                )
+        resolved = self._resolve_target_angle_and_snap(
+            cand=cand,
+            ds_key=ds_key,
+            lines_fc_key=lines_fc_key,
+            dangles_fc_key=dangles_fc_key,
+            dangle_parent=dangle_parent,
+            dangle_xy=dangle_xy,
+            polyline_by_parent=polyline_by_parent,
+            polyline_by_external=polyline_by_external,
+        )
+        target_angle = resolved.target_angle
+        tgt_poly = resolved.tgt_poly
+        tgt_snap_x = resolved.snap_x
+        tgt_snap_y = resolved.snap_y
+        target_parent_id = resolved.target_parent_id
 
         if target_angle is None:
-            # Unavailable => no block/penalty; conservative extra-dangle policy for dangle targets
-            allow_extra = ds_key != dangles_fc_key
-            return AngleAssessment(
-                available=False,
-                blocks=False,
-                allow_extra_dangle=bool(allow_extra),
-                angle_metric_deg=None,
+            return self._unavailable_assessment(
+                ds_key=ds_key,
+                dangles_fc_key=dangles_fc_key,
                 src_connector_diff=float(src_connector_diff),
             )
 
@@ -3071,47 +3271,34 @@ class FillLineGaps:
         # - comparing dangle-pair / dangle-parent-line targets in undirected mode, to avoid
         #   collapsing anti-parallel lines to zero diff.
         _use_directional = (
-            self.lines_are_directed
-            or _is_dangle_pair
-            or _is_dangle_parent_line
+            self.lines_are_directed or _is_dangle_pair or _is_dangle_parent_line
         )
 
+        src_poly_for_norm: Any = None
+        endpoint_snap = False
         if _use_directional:
             _diff = self._directional_diff
             angle_max_deg = 180.0
-
-            src_poly_for_norm = polyline_by_parent.get(int(src_parent_id))
-            _endpoint_snap = _is_dangle_pair or _is_dangle_parent_line
-            # In directed mode: always use raw forward direction (no flip).
-            # The topology check handles endpoint snaps; for mid-line snaps, raw angles
-            # give consistent directionality across all target types.
-            # In undirected mode: flip if at start so src points "exit toward gap"
-            # for symmetric dangle-pair scoring.
-            if src_poly_for_norm is not None and src_angle_deg is not None:
-                if not self.lines_are_directed:
-                    if self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y):
-                        src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
-
-            # In undirected mode (_use_directional triggered by dangle-pair / dangle-parent-line):
-            # normalise target_angle to "entry direction into target interior" so that both
-            # dangles in a pair score symmetrically (0° for a good collinear fill).
-            # In directed mode: leave target_angle as the raw flow direction of the target
-            # line at the snap point. The source exits toward the gap; the target should flow
-            # in the same direction for a good match — flipping would collapse the score to
-            # 0° for both dangles regardless of their relative orientation.
-            if not self.lines_are_directed:
-                _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
-                _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
-                if not self._xy_is_at_line_start(tgt_poly, _tgt_snap_x, _tgt_snap_y):
-                    target_angle = (float(target_angle) + 180.0) % 360.0
-            # In directed mode, override src_connector_diff to use directional diff
-            # so that anti-parallel src/connector (e.g. west vs east) reports 180° (BAD)
-            # rather than collapsing to 0° under orientation_diff.
-            # Undirected mode keeps the orientation-based value computed earlier.
-            if self.lines_are_directed:
-                src_connector_diff = self._directional_diff(
-                    float(src_angle_deg), float(connector_angle)
-                )
+            norm = self._normalize_directional_angles(
+                src_parent_id=src_parent_id,
+                src_angle_deg=float(src_angle_deg),
+                target_angle=float(target_angle),
+                src_connector_diff=float(src_connector_diff),
+                connector_angle=float(connector_angle),
+                dangle_x=dangle_x,
+                dangle_y=dangle_y,
+                tgt_poly=tgt_poly,
+                tgt_snap_x=tgt_snap_x,
+                tgt_snap_y=tgt_snap_y,
+                is_dangle_pair=_is_dangle_pair,
+                is_dangle_parent_line=_is_dangle_parent_line,
+                polyline_by_parent=polyline_by_parent,
+            )
+            src_angle_deg = norm.src_angle_deg
+            target_angle = norm.target_angle
+            src_connector_diff = norm.src_connector_diff
+            src_poly_for_norm = norm.src_poly_for_norm
+            endpoint_snap = norm.endpoint_snap
         else:
             _diff = self._orientation_diff
             angle_max_deg = 90.0
@@ -3129,48 +3316,61 @@ class FillLineGaps:
             _src_conn_for_transition + float(connector_target_diff)
         )
 
-        if _use_directional:
-            if self.lines_are_directed and _endpoint_snap:
-                # Topology-aware metric: only end→start is a valid directional connection.
-                # "Opposite attracts": src_is_end AND target_is_start → use direction diff.
-                # All other combinations (end→end, start→start, start→end) → 180° (BAD).
-                _snap_x = float(tx) if _is_dangle_pair else float(near_x)
-                _snap_y = float(ty) if _is_dangle_pair else float(near_y)
-                _src_is_end = (
-                    src_poly_for_norm is not None
-                    and not self._xy_is_at_line_start(
-                        src_poly_for_norm, dangle_x, dangle_y
-                    )
+        # Pick the angle metric per the directional/topology rules.
+        # Non-directional: src_connector_diff alone.
+        # Directional, non-endpoint, directed: worst of angular alignment vs
+        #     connector direction (a bad score on either makes the candidate bad).
+        # Directional, endpoint snap, directed: only end-to-start is a valid
+        #     connection — anything else is forced to 180° (rejected). For valid
+        #     end-to-start dangle pairs connector_angle_diff_required_above_meters
+        #     decides whether to penalise bad connector direction: when the
+        #     candidate's gap distance exceeds the threshold the parent-line
+        #     lookup is consulted and max(src_target_diff, src_connector_diff)
+        #     applies if the parent line is also beyond the threshold.
+        # Directional, undirected: src_target_diff after both normalisations.
+        connector_diff_threshold = self.connector_angle_diff_required_above_meters
+        if not _use_directional:
+            metric = float(src_connector_diff)
+        elif self.lines_are_directed and endpoint_snap:
+            _src_is_end = (
+                src_poly_for_norm is not None
+                and not self._xy_is_at_line_start(
+                    src_poly_for_norm, dangle_x, dangle_y
                 )
-                _tgt_is_start = self._xy_is_at_line_start(tgt_poly, _snap_x, _snap_y)
-                if _src_is_end and _tgt_is_start:
-                    metric = (
-                        max(float(src_target_diff), float(src_connector_diff))
-                        if self.dangle_pair_apply_connector_diff and _is_dangle_pair
-                        else float(src_target_diff)
-                    )
-                else:
-                    metric = 180.0
-            elif self.lines_are_directed:
-                # Non-endpoint line-like target: worst of angular alignment vs connector
-                # direction — a bad score on either component makes the candidate bad.
+            )
+            _tgt_is_start = self._xy_is_at_line_start(
+                tgt_poly, tgt_snap_x, tgt_snap_y
+            )
+            if not (_src_is_end and _tgt_is_start):
+                metric = 180.0
+            elif (
+                connector_diff_threshold is not None
+                and _is_dangle_pair
+                # Cheap short-circuit: parent line cannot be farther than its
+                # own dangle endpoint, so a close dangle implies a close parent
+                # — skip the lookup and use src_target_diff.
+                and float(cand.near_dist) > float(connector_diff_threshold)
+                and self._dangle_pair_requires_connector_diff(
+                    target_parent_id=target_parent_id,
+                    dist_to_parent_line_by_id=dist_to_parent_line_by_id,
+                )
+            ):
                 metric = max(float(src_target_diff), float(src_connector_diff))
             else:
-                # Undirected dangle-pair / dangle-parent-line after both normalizations.
                 metric = float(src_target_diff)
+        elif self.lines_are_directed:
+            metric = max(float(src_target_diff), float(src_connector_diff))
         else:
-            metric = float(src_connector_diff)
+            metric = float(src_target_diff)
 
-        blocks = self.angle_block_threshold_degrees is not None and metric > float(
-            self.angle_block_threshold_degrees
+        block_thr = self.angle_block_threshold_degrees
+        blocks = block_thr is not None and metric > float(block_thr)
+        extra_thr = self.angle_extra_dangle_threshold_degrees
+        allow_extra = (
+            ds_key != dangles_fc_key
+            or extra_thr is None
+            or metric <= float(extra_thr)
         )
-
-        allow_extra = True
-        if ds_key == dangles_fc_key:
-            if self.angle_extra_dangle_threshold_degrees is None:
-                allow_extra = True
-            else:
-                allow_extra = metric <= float(self.angle_extra_dangle_threshold_degrees)
 
         return AngleAssessment(
             available=True,
@@ -3612,7 +3812,8 @@ class FillLineGaps:
         # Built before candidate filtering so line_like_ds_keys is available.
         # ----------------------------
         angle_caches = self._build_angle_caches(
-            target_layers=target_layers, lines_key=lines_key,
+            target_layers=target_layers,
+            lines_key=lines_key,
         )
         polyline_by_parent = angle_caches.polyline_by_parent
         polyline_by_external = angle_caches.polyline_by_external
@@ -3671,7 +3872,9 @@ class FillLineGaps:
                     if _cand_key in reject_keys:
                         if collect_diags:
                             _step1a_illegal.append(
-                                _CandidateIllegalA(_dangle_oid, _parent_id, _cand, reason)
+                                _CandidateIllegalA(
+                                    _dangle_oid, _parent_id, _cand, reason
+                                )
                             )
                     else:
                         _remaining.append(_cand)
@@ -3693,7 +3896,11 @@ class FillLineGaps:
                 _apply_crossing_filter(_barrier_keys, "crosses_barrier_layer")
 
         trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
-        if self.reject_crossing_connectors and legal_rows_by_dangle and _crossing_sr is not None:
+        if (
+            self.reject_crossing_connectors
+            and legal_rows_by_dangle
+            and _crossing_sr is not None
+        ):
             # lines_copy provides self-line geometries; external polyline layers
             # whose ds_key is in polyline_by_external were loaded as angle caches.
             _check_layers: list[str] = [self.lines_copy]
@@ -3710,7 +3917,9 @@ class FillLineGaps:
                 )
             )
             if crossing_conflict_keys:
-                _apply_crossing_filter(crossing_conflict_keys, "crosses_existing_feature")
+                _apply_crossing_filter(
+                    crossing_conflict_keys, "crosses_existing_feature"
+                )
 
         if not legal_rows_by_dangle:
             return _empty_result(
@@ -3923,7 +4132,11 @@ class FillLineGaps:
         topology: TopologyModel,
         collect_diags: bool,
         directed_source_illegal_oids: set[DangleOid],
-    ) -> tuple[dict[DangleOid, list[NearCandidate]], dict[DangleOid, ParentId], list[_CandidateIllegalA]]:
+    ) -> tuple[
+        dict[DangleOid, list[NearCandidate]],
+        dict[DangleOid, ParentId],
+        list[_CandidateIllegalA],
+    ]:
         """Dangle filtering: collect legal candidates per dangle.
 
         Returns (legal_rows_by_dangle, parent_id_by_dangle, step1a_illegal).
@@ -3949,7 +4162,9 @@ class FillLineGaps:
                         if cand.near_fc_key == lines_key and cand.near_fid == parent_id:
                             continue
                         _step1a_illegal.append(
-                            _CandidateIllegalA(dangle_oid, parent_id, cand, "directed_start_node")
+                            _CandidateIllegalA(
+                                dangle_oid, parent_id, cand, "directed_start_node"
+                            )
                         )
                 continue
 
@@ -3988,7 +4203,9 @@ class FillLineGaps:
                         dangle_candidate_tol=dangle_tol,
                         topology=topology,
                     )
-                    _step1a_illegal.append(_CandidateIllegalA(dangle_oid, parent_id, cand, reason))
+                    _step1a_illegal.append(
+                        _CandidateIllegalA(dangle_oid, parent_id, cand, reason)
+                    )
 
             if not legal_rows:
                 continue
@@ -4097,6 +4314,17 @@ class FillLineGaps:
                 if _d_xy is not None:
                     _dangle_xys_by_parent.setdefault(int(_d_parent), []).append(_d_xy)
 
+            # Per-dangle parent-line distance lookup used by the dangle-pair
+            # connector-diff distance gate. Only built when the threshold is
+            # set; otherwise the metric ladder skips the gate entirely.
+            dist_to_parent_line_by_id: Optional[dict[ParentId, float]] = None
+            if self.connector_angle_diff_required_above_meters is not None:
+                dist_to_parent_line_by_id = {
+                    int(c.near_fid): float(c.near_dist)
+                    for c in legal_rows
+                    if c.near_fc_key == lines_key
+                }
+
             scored_candidates: list[_ScoredCandidateItem] = []
 
             for _cand_idx, cand in enumerate(legal_rows):
@@ -4114,6 +4342,7 @@ class FillLineGaps:
                     polyline_by_external=polyline_by_external,
                     is_external_line_like=is_external_line_like,
                     dangle_xys_by_parent=_dangle_xys_by_parent,
+                    dist_to_parent_line_by_id=dist_to_parent_line_by_id,
                 )
 
                 _cand_end_z: Optional[float] = end_z_by_cand_index.get(_cand_idx)
@@ -4122,7 +4351,15 @@ class FillLineGaps:
                 if assess.blocks:
                     if collect_diags:
                         _step1b_illegal.append(
-                            _CandidateIllegalB(dangle_oid, parent_id, cand, assess, "blocked_by_angle", start_z, _cand_end_z)
+                            _CandidateIllegalB(
+                                dangle_oid,
+                                parent_id,
+                                cand,
+                                assess,
+                                "blocked_by_angle",
+                                start_z,
+                                _cand_end_z,
+                            )
                         )
                     continue
 
@@ -4140,7 +4377,15 @@ class FillLineGaps:
                 ):
                     if collect_diags:
                         _step1b_illegal.append(
-                            _CandidateIllegalB(dangle_oid, parent_id, cand, assess, "expanded_dangle_angle_disallowed", start_z, _cand_end_z)
+                            _CandidateIllegalB(
+                                dangle_oid,
+                                parent_id,
+                                cand,
+                                assess,
+                                "expanded_dangle_angle_disallowed",
+                                start_z,
+                                _cand_end_z,
+                            )
                         )
                     continue
 
@@ -4161,7 +4406,15 @@ class FillLineGaps:
                     ):
                         if collect_diags:
                             _step1b_illegal.append(
-                                _CandidateIllegalB(dangle_oid, parent_id, cand, assess, "blocked_by_z_drop", start_z, _cand_end_z)
+                                _CandidateIllegalB(
+                                    dangle_oid,
+                                    parent_id,
+                                    cand,
+                                    assess,
+                                    "blocked_by_z_drop",
+                                    start_z,
+                                    _cand_end_z,
+                                )
                             )
                         continue
 
@@ -4240,7 +4493,11 @@ class FillLineGaps:
 
             winner_item = min(
                 scored_candidates,
-                key=lambda item: (item.score.composite, item.score.bonus_rank, item.raw_distance),
+                key=lambda item: (
+                    item.score.composite,
+                    item.score.bonus_rank,
+                    item.raw_distance,
+                ),
             )
             winner_dangle_score = winner_item.score
             chosen = winner_item.cand
@@ -4640,7 +4897,10 @@ class FillLineGaps:
                 and int(prop.ctx.dangle_oid) not in kruskal_crossing_rejected_oids
             )
             gap_source_by_dangle.update(
-                {int(prop.ctx.dangle_oid): prop.gap_source for prop in _global_proposals}
+                {
+                    int(prop.ctx.dangle_oid): prop.gap_source
+                    for prop in _global_proposals
+                }
             )
 
         return (
@@ -4695,7 +4955,9 @@ class FillLineGaps:
         kruskal_rank_by_dangle_oid: dict[DangleOid, int],
         trim_distance: float,
         spatial_reference: Any,
-    ) -> tuple[dict[ParentId, PlanEntry], set[DangleOid], set[DangleOid], set[DangleOid]]:
+    ) -> tuple[
+        dict[ParentId, PlanEntry], set[DangleOid], set[DangleOid], set[DangleOid]
+    ]:
         """Re-check resnap captures against accepted connector geometries.
 
         Called after _resnap_connections resolves final geometry for deferred
@@ -4926,7 +5188,15 @@ class FillLineGaps:
             cand_scope = ScopeRecord(status=entry.reason)
             result.append(
                 CandidateDiagnostic(
-                    **self._make_base_diag_fields(entry.cand, entry.dangle_oid, entry.parent_id, xy, dangle_parent, dangles_key, lines_key),
+                    **self._make_base_diag_fields(
+                        entry.cand,
+                        entry.dangle_oid,
+                        entry.parent_id,
+                        xy,
+                        dangle_parent,
+                        dangles_key,
+                        lines_key,
+                    ),
                     candidate_scope=cand_scope,
                     network_scope=None,
                     kruskal_scope=None,
@@ -4952,7 +5222,15 @@ class FillLineGaps:
             cand_scope = ScopeRecord(status=entry.reason)
             result.append(
                 CandidateDiagnostic(
-                    **self._make_base_diag_fields(entry.cand, entry.dangle_oid, entry.parent_id, xy, dangle_parent, dangles_key, lines_key),
+                    **self._make_base_diag_fields(
+                        entry.cand,
+                        entry.dangle_oid,
+                        entry.parent_id,
+                        xy,
+                        dangle_parent,
+                        dangles_key,
+                        lines_key,
+                    ),
                     candidate_scope=cand_scope,
                     network_scope=None,
                     kruskal_scope=None,
@@ -4976,7 +5254,9 @@ class FillLineGaps:
             scored_by_dangle.setdefault(int(entry.dangle_oid), []).append(entry)
         rank_map: dict[tuple[int, str, int], int] = {}
         for d_oid, entries in scored_by_dangle.items():
-            for rank, entry in enumerate(sorted(entries, key=lambda e: e.score_tuple), start=1):
+            for rank, entry in enumerate(
+                sorted(entries, key=lambda e: e.score_tuple), start=1
+            ):
                 rank_map[(d_oid, entry.cand.near_fc_key, entry.cand.near_fid)] = rank
 
         # Step-1B scored candidates
@@ -5047,7 +5327,15 @@ class FillLineGaps:
 
             result.append(
                 CandidateDiagnostic(
-                    **self._make_base_diag_fields(entry.cand, entry.dangle_oid, entry.parent_id, xy, dangle_parent, dangles_key, lines_key),
+                    **self._make_base_diag_fields(
+                        entry.cand,
+                        entry.dangle_oid,
+                        entry.parent_id,
+                        xy,
+                        dangle_parent,
+                        dangles_key,
+                        lines_key,
+                    ),
                     candidate_scope=cand_scope,
                     network_scope=net_scope,
                     kruskal_scope=kru_scope,

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -968,7 +968,10 @@ class AngleAssessment:
     allow_extra_dangle: bool  # expanded dangle tol + edge-case bonus
     angle_metric_deg: Optional[float]
     # Normalisation range for angle_metric_deg used in best-fit scoring.
-    # 90.0 for undirected targets; 180.0 for directional dangle-pair targets.
+    # 90.0 for undirected line-like targets and non-line targets in undirected mode;
+    # 180.0 whenever directional comparison is in effect — i.e. lines_are_directed,
+    # or a dangle endpoint snap (target is a dangle, or the parent line at one of
+    # its dangle endpoints) regardless of mode.
     angle_max_deg: float = 90.0
 
     # Diagnostics (optional)
@@ -3354,41 +3357,56 @@ class FillLineGaps:
             _src_conn_for_transition + float(connector_target_diff)
         )
 
-        # Pick the angle metric per the directional/topology rules.
-        # Non-directional: src_connector_diff alone.
-        # Directional, non-endpoint, directed: worst of angular alignment vs
-        #     connector direction (a bad score on either makes the candidate bad).
-        # Directional, endpoint snap, directed: only end-to-start is a valid
-        #     connection — anything else is forced to 180° (rejected). Src-end
-        #     is guaranteed by upstream filtering (_filter_legal_candidates drops
-        #     start-node src dangles), so only target-start enforcement remains.
-        #     For valid end-to-start dangle pairs
-        #     connector_angle_diff_required_above_meters decides whether to
-        #     penalise bad connector direction: when the candidate's gap distance
-        #     exceeds the threshold the parent-line lookup is consulted and
-        #     max(src_target_diff, src_connector_diff) applies if the parent line
-        #     is also beyond the threshold.
-        # Directional, undirected: src_target_diff after both normalisations.
+        # Pick the angle metric.
+        #
+        # Non-directional path (lines_are_directed=False, target is not a dangle
+        # endpoint snap): src_connector_diff alone.
+        #
+        # Undirected dangle endpoint snap (lines_are_directed=False but target is a
+        # dangle or the parent line at a dangle endpoint): src_target_diff after the
+        # normalisation flips, so a clean collinear pair scores 0°.
+        #
+        # Directional path (lines_are_directed=True): default to
+        # max(src_target_diff, src_connector_diff) for line-like targets — a bad
+        # score on either makes the candidate bad. At endpoint snaps two extra
+        # rules apply:
+        #   - End-to-start enforcement: target must be at its line's start, else
+        #     metric is forced to 180° (rejection). Src-end is guaranteed
+        #     upstream by _filter_legal_candidates, so only target-start needs to
+        #     be checked here.
+        #   - Close-dangle exception: connector_angle_diff_required_above_meters
+        #     decides whether to penalise bad connector direction. When the
+        #     parent line of the target dangle is within the threshold the
+        #     geometry already constrains src↔connector alignment, so use
+        #     src_target_diff alone. None disables the penalty entirely (always
+        #     src_target_diff at endpoint snaps); 0 always penalises (always
+        #     max(...)). For dangle-pair targets a per-dangle parent-line lookup
+        #     is consulted only when cand.near_dist > threshold (a closer dangle
+        #     implies an at-least-as-close parent). For dangle-parent-line
+        #     targets cand.near_dist *is* the parent-line distance, so the
+        #     direct comparison decides without a lookup.
         connector_diff_threshold = self.connector_angle_diff_required_above_meters
         if not _use_directional:
             metric = float(src_connector_diff)
-        elif self.lines_are_directed and endpoint_snap:
-            _tgt_is_start = self._xy_is_at_line_start(
-                tgt_poly, tgt_snap_x, tgt_snap_y
-            )
-            if not _tgt_is_start:
+        elif not self.lines_are_directed:
+            # Undirected dangle endpoint snap (dangle pair or dangle-parent-line).
+            metric = float(src_target_diff)
+        elif endpoint_snap:
+            if not self._xy_is_at_line_start(tgt_poly, tgt_snap_x, tgt_snap_y):
                 metric = 180.0
-            elif (
-                connector_diff_threshold is not None
-                and _is_dangle_pair
-                # Cheap short-circuit: parent line cannot be farther than its
-                # own dangle endpoint, so a close dangle implies a close parent
-                # — skip the lookup and use src_target_diff.
-                and float(cand.near_dist) > float(connector_diff_threshold)
-            ):
-                # Inline parent-line distance gate. Conservative when the lookup
-                # cannot resolve a parent line (missing target parent, lookup
-                # disabled, or parent absent from the global table).
+            elif connector_diff_threshold is None:
+                metric = float(src_target_diff)
+            elif float(connector_diff_threshold) == 0.0:
+                metric = max(float(src_target_diff), float(src_connector_diff))
+            elif float(cand.near_dist) <= float(connector_diff_threshold):
+                # Close enough that the parent line is guaranteed within the
+                # threshold (dangle-pair: parent passes through the dangle;
+                # dangle-parent-line: target IS the parent). No lookup needed.
+                metric = float(src_target_diff)
+            elif _is_dangle_pair:
+                # Dangle target outside the threshold — the parent line might
+                # still be within (e.g. running parallel back toward the source).
+                # Lookup required. Conservative on miss (treat as outside).
                 _parent_dist = (
                     dist_to_parent_line_by_id.get(int(target_parent_id))
                     if (
@@ -3398,18 +3416,18 @@ class FillLineGaps:
                     else None
                 )
                 if (
-                    _parent_dist is None
-                    or float(_parent_dist) > float(connector_diff_threshold)
+                    _parent_dist is not None
+                    and float(_parent_dist) <= float(connector_diff_threshold)
                 ):
-                    metric = max(float(src_target_diff), float(src_connector_diff))
-                else:
                     metric = float(src_target_diff)
+                else:
+                    metric = max(float(src_target_diff), float(src_connector_diff))
             else:
-                metric = float(src_target_diff)
-        elif self.lines_are_directed:
-            metric = max(float(src_target_diff), float(src_connector_diff))
+                # Dangle-parent-line outside the threshold: parent_dist == near_dist
+                # by construction, so the parent is also outside. No lookup.
+                metric = max(float(src_target_diff), float(src_connector_diff))
         else:
-            metric = float(src_target_diff)
+            metric = max(float(src_target_diff), float(src_connector_diff))
 
         block_thr = self.angle_block_threshold_degrees
         blocks = block_thr is not None and metric > float(block_thr)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2125,14 +2125,7 @@ class FillLineGaps:
             if not entry.get("skip", False)
         }
 
-        # Defer phase (one-sided “closest to a dangle-pair object”)
-        if deferred_by_parent:
-            self._resolve_deferred_moves(
-                plan=plan,
-                deferred=deferred_by_parent,
-            )
-
-        return plan
+        return plan, deferred_by_parent
 
     def _make_plan_entry(
         self,
@@ -2186,43 +2179,47 @@ class FillLineGaps:
     # Deferred handling
     # ----------------------------
 
-    def _resolve_deferred_moves(
+    def _build_deferred_plan(
         self,
         *,
-        plan: dict[int, dict],
         deferred: dict[int, dict],
-    ) -> None:
-        """
-        Your requirement (simplified, but aligned):
-          - If A “wanted” B as closest but B didn’t want A, A waits.
-          - After other edits, run another near table that finds snap point on B’s line,
-            accepting a much larger tolerance.
-          - Then add A to the plan pointing to the forced target line geometry.
+        dangles_fc: str,
+    ) -> dict[int, dict]:
+        # Deferred dangles layer
+        dangles_oid = arcpy.Describe(dangles_fc).OIDFieldName
+        dangle_oids = sorted({int(v["dangle_oid"]) for v in deferred.values()})
+        if not dangle_oids:
+            return {}
 
-        Implementation:
-          - We force near_features = [lines_copy]
-          - We run GenerateNearTable from the deferred dangles to lines_copy with large radius
-          - For each deferred parent A, we select the row with NEAR_FID == forced_target_parent (B)
-        """
-        # Build a feature layer of deferred dangles (by OBJECTID)
-        dangles_oid = arcpy.Describe(self.filtered_dangles).OIDFieldName
-        ids = [str(int(v["dangle_oid"])) for v in deferred.values()]
-        if not ids:
-            return
-
-        where = f"{arcpy.AddFieldDelimiters(self.filtered_dangles, dangles_oid)} IN ({','.join(ids)})"
+        where_d = f"{arcpy.AddFieldDelimiters(dangles_fc, dangles_oid)} IN ({','.join(map(str, dangle_oids))})"
         deferred_lyr = "deferred_dangles_lyr"
-        arcpy.management.MakeFeatureLayer(self.filtered_dangles, deferred_lyr, where)
+        arcpy.management.MakeFeatureLayer(dangles_fc, deferred_lyr, where_d)
 
-        # Large tolerance: choose something intentionally generous but bounded.
-        # If you want this configurable later, put it in AdvancedConfig.
+        # Locked forced-target lines layer (UPDATED geometry because pass 1 already ran)
+        forced_parents = sorted(
+            {int(v["forced_target_parent"]) for v in deferred.values()}
+        )
+        where_l = f"{arcpy.AddFieldDelimiters(self.lines_copy, self.ORIGINAL_ID)} IN ({','.join(map(str, forced_parents))})"
+        forced_lines_lyr = "forced_lines_lyr"
+        arcpy.management.MakeFeatureLayer(self.lines_copy, forced_lines_lyr, where_l)
+
+        # Map near OID -> parent id (do NOT assume OID == ORIGINAL_ID)
+        lines_oid = arcpy.Describe(forced_lines_lyr).OIDFieldName
+        near_oid_to_parent: dict[int, int] = {}
+        with arcpy.da.SearchCursor(
+            forced_lines_lyr, [lines_oid, self.ORIGINAL_ID]
+        ) as cur:
+            for oid, pid in cur:
+                near_oid_to_parent[int(oid)] = int(pid)
+
+        # Large tolerance (keep your current heuristic)
         large_m = max(50, int(self.gap_tolerance_meters) * 10)
         large_tol = f"{int(large_m)} Meters"
 
         forced_table = self.wfm.build_file_path(file_name="deferred_forced_table")
         arcpy.analysis.GenerateNearTable(
             in_features=deferred_lyr,
-            near_features=[self.lines_copy],
+            near_features=[forced_lines_lyr],
             out_table=forced_table,
             search_radius=large_tol,
             location="LOCATION",
@@ -2232,10 +2229,8 @@ class FillLineGaps:
             method="PLANAR",
         )
 
-        lines_key = self._dataset_key(self.lines_copy)
-
-        # Map in_dangle_oid -> list of (near_fid, near_x, near_y, dist)
-        grouped: dict[int, list[tuple[int, float, float, float]]] = {}
+        # Best near point per (dangle_oid, forced_parent)
+        best_xy: dict[tuple[int, int], tuple[float, float, float]] = {}  # -> (x,y,dist)
         fields = [
             self.F_IN_FID,
             self.F_NEAR_FID,
@@ -2247,53 +2242,59 @@ class FillLineGaps:
             for in_fid, near_fid, near_dist, near_x, near_y in cur:
                 if near_fid is None or near_dist is None:
                     continue
-                grouped.setdefault(int(in_fid), []).append(
-                    (int(near_fid), float(near_x), float(near_y), float(near_dist))
-                )
+                d_oid = int(in_fid)
+                near_parent = near_oid_to_parent.get(int(near_fid))
+                if near_parent is None:
+                    continue
 
-        if not grouped:
-            return
+                dist = float(near_dist)
+                key = (d_oid, int(near_parent))
+                prev = best_xy.get(key)
+                if prev is None or dist < prev[2]:
+                    best_xy[key] = (float(near_x), float(near_y), dist)
 
-        # For each deferred parent, locate the row for its forced target parent line id
+        if not best_xy:
+            return {}
+
+        # Dangle XY (only build once)
+        dangle_xy = self._build_dangle_xy_lookup(dangles_fc)
+
+        lines_key = self._dataset_key(self.lines_copy)
+        out: dict[int, dict] = {}
+
         for a_parent, info in deferred.items():
             a_parent = int(a_parent)
-            if a_parent in plan:
-                continue  # already moved via other logic
-
-            dangle_oid_val = int(info["dangle_oid"])
+            d_oid = int(info["dangle_oid"])
             forced_parent = int(info["forced_target_parent"])
 
-            rows = grouped.get(dangle_oid_val, [])
-            chosen_row = None
-            for near_fid, near_x, near_y, dist in rows:
-                if int(near_fid) == int(forced_parent):
-                    chosen_row = (near_x, near_y)
-                    break
-
-            if chosen_row is None:
+            hit = best_xy.get((d_oid, forced_parent))
+            if hit is None:
                 continue
 
-            # Need dangle XY from current dangle feature (it might be unchanged, but safer)
-            xy_lookup = self._build_dangle_xy_lookup(self.filtered_dangles)
-            dangle_x, dangle_y = xy_lookup.get(dangle_oid_val, (None, None))
-            if dangle_x is None:
+            dxy = dangle_xy.get(d_oid)
+            if dxy is None:
                 continue
+            dangle_x, dangle_y = dxy
 
-            plan[a_parent] = {
+            near_x, near_y, _ = hit
+
+            out[a_parent] = {
                 "processed": False,
                 "skip": False,
                 "gap_source": self.GAP_SOURCE_DEFERRED,
                 "edit_op": str(
                     self._resolve_edit_op(gap_source=self.GAP_SOURCE_DEFERRED).value
                 ),
-                "dangle_oid": dangle_oid_val,
+                "dangle_oid": d_oid,
                 "dangle_x": float(dangle_x),
                 "dangle_y": float(dangle_y),
-                "near_x": float(chosen_row[0]),
-                "near_y": float(chosen_row[1]),
+                "near_x": float(near_x),
+                "near_y": float(near_y),
                 "chosen_near_fc_key": lines_key,
-                "chosen_near_fid": forced_parent,
+                "chosen_near_fid": forced_parent,  # parent-id space, consistent with your plan
             }
+
+        return out
 
     # ----------------------------
     # Change output + edits (unchanged from your current version except gap_source field)
@@ -2343,13 +2344,9 @@ class FillLineGaps:
         geom = arcpy.Polyline(arr, spatial_reference)
         return (geom, int(original_id), float(dist), str(gap_source))
 
-    def _apply_edits(self, plan: dict[int, dict]) -> None:
+    def _apply_plan(self, plan: dict[int, dict]) -> None:
         if not plan:
-            arcpy.management.CopyFeatures(self.lines_copy, self.output_lines)
             return
-
-        if self.line_changes_output is not None:
-            self._setup_line_changes_output()
 
         spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
         change_rows: list[tuple] = []
@@ -2362,10 +2359,7 @@ class FillLineGaps:
                 info = plan.get(pid)
                 if not info:
                     continue
-                if (
-                    info.get("skip", False) is True
-                    or info.get("processed", False) is True
-                ):
+                if info.get("skip", False) or info.get("processed", False):
                     continue
 
                 edit_op = str(info.get("edit_op", EditOp.EXTEND.value))
@@ -2386,7 +2380,9 @@ class FillLineGaps:
                         near_x=float(info["near_x"]),
                         near_y=float(info["near_y"]),
                     )
+
                 cur.updateRow((original_id, new_shape))
+                info["processed"] = True  # optional
 
                 if self.line_changes_output is not None:
                     row = self._build_change_row(
@@ -2414,6 +2410,7 @@ class FillLineGaps:
                 for row in change_rows:
                     icur.insertRow(row)
 
+    def _write_output(self) -> None:
         arcpy.management.CopyFeatures(self.lines_copy, self.output_lines)
 
     # ----------------------------
@@ -2439,7 +2436,23 @@ class FillLineGaps:
         self._filter_true_dangles()
         dangles_for_plan = self.filtered_dangles
 
-        plan = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
-        self._apply_edits(plan)
+        if self.line_changes_output is not None:
+            if arcpy.Exists(self.line_changes_output):
+                arcpy.management.Delete(self.line_changes_output)
+            self._setup_line_changes_output()
+
+        plan, deferred = self._build_plan(
+            dangles_fc=dangles_for_plan, target_layers=targets
+        )
+
+        self._apply_plan(plan)
+
+        if deferred:
+            deferred_plan = self._build_deferred_plan(
+                deferred=deferred, dangles_fc=dangles_for_plan
+            )
+            self._apply_plan(deferred_plan)
+
+        self._write_output()
 
         self.wfm.delete_created_files()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1844,6 +1844,13 @@ class FillLineGaps:
         except Exception:
             return False
 
+    def _is_polygon_fc(self, fc: str) -> bool:
+        try:
+            desc = arcpy.Describe(fc)
+            return str(getattr(desc, "shapeType", "")).lower() == "polygon"
+        except Exception:
+            return False
+
     def _build_angle_caches(
         self,
         *,
@@ -3932,11 +3939,14 @@ class FillLineGaps:
             and legal_rows_by_dangle
             and _crossing_sr is not None
         ):
-            # lines_copy provides self-line geometries; external polyline layers
-            # whose ds_key is in polyline_by_external were loaded as angle caches.
+            # self-lines (lines_copy) plus every connect_to_features layer
+            # that can be crossed.  Shape-type filter is applied directly
+            # rather than reusing polyline_by_external: that cache is built
+            # for angle scoring and excludes FORCE_NON_LINE polylines and
+            # all polygons, neither of which should be excluded here.
             _check_layers: list[str] = [self.lines_copy]
-            for _lyr in target_layers:
-                if self._dataset_key(_lyr) in polyline_by_external:
+            for _lyr in self.external_target_layers:
+                if self._is_polyline_fc(_lyr) or self._is_polygon_fc(_lyr):
                     _check_layers.append(_lyr)
             crossing_conflict_keys, trimmed_connector_cache = (
                 self._find_crossing_conflict_keys(

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -3367,9 +3367,11 @@ class FillLineGaps:
         # normalisation flips, so a clean collinear pair scores 0°.
         #
         # Directional path (lines_are_directed=True): default to
-        # max(src_target_diff, src_connector_diff) for line-like targets — a bad
-        # score on either makes the candidate bad. At endpoint snaps two extra
-        # rules apply:
+        # max(src_target_diff, src_connector_diff, connector_target_diff) for
+        # line-like targets — a bad score on any of the three joints makes the
+        # candidate bad. The third term catches the case where src→target looks
+        # aligned overall but the connector enters the target broadside, which
+        # the two-term max cannot see. At endpoint snaps two extra rules apply:
         #   - End-to-start enforcement: target must be at its line's start, else
         #     metric is forced to 180° (rejection). Src-end is guaranteed
         #     upstream by _filter_legal_candidates, so only target-start needs to
@@ -3380,9 +3382,9 @@ class FillLineGaps:
         #     geometry already constrains src↔connector alignment, so use
         #     src_target_diff alone. None disables the penalty entirely (always
         #     src_target_diff at endpoint snaps); 0 always penalises (always
-        #     max(...)). For dangle-pair targets a per-dangle parent-line lookup
-        #     is consulted only when cand.near_dist > threshold (a closer dangle
-        #     implies an at-least-as-close parent). For dangle-parent-line
+        #     three-term max). For dangle-pair targets a per-dangle parent-line
+        #     lookup is consulted only when cand.near_dist > threshold (a closer
+        #     dangle implies an at-least-as-close parent). For dangle-parent-line
         #     targets cand.near_dist *is* the parent-line distance, so the
         #     direct comparison decides without a lookup.
         connector_diff_threshold = self.connector_angle_diff_required_above_meters
@@ -3397,7 +3399,11 @@ class FillLineGaps:
             elif connector_diff_threshold is None:
                 metric = float(src_target_diff)
             elif float(connector_diff_threshold) == 0.0:
-                metric = max(float(src_target_diff), float(src_connector_diff))
+                metric = max(
+                    float(src_target_diff),
+                    float(src_connector_diff),
+                    float(connector_target_diff),
+                )
             elif float(cand.near_dist) <= float(connector_diff_threshold):
                 # Close enough that the parent line is guaranteed within the
                 # threshold (dangle-pair: parent passes through the dangle;
@@ -3421,13 +3427,25 @@ class FillLineGaps:
                 ):
                     metric = float(src_target_diff)
                 else:
-                    metric = max(float(src_target_diff), float(src_connector_diff))
+                    metric = max(
+                        float(src_target_diff),
+                        float(src_connector_diff),
+                        float(connector_target_diff),
+                    )
             else:
                 # Dangle-parent-line outside the threshold: parent_dist == near_dist
                 # by construction, so the parent is also outside. No lookup.
-                metric = max(float(src_target_diff), float(src_connector_diff))
+                metric = max(
+                    float(src_target_diff),
+                    float(src_connector_diff),
+                    float(connector_target_diff),
+                )
         else:
-            metric = max(float(src_target_diff), float(src_connector_diff))
+            metric = max(
+                float(src_target_diff),
+                float(src_connector_diff),
+                float(connector_target_diff),
+            )
 
         block_thr = self.angle_block_threshold_degrees
         blocks = block_thr is not None and metric > float(block_thr)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -41,6 +41,7 @@ class TopologyModel:
 class EditOp(str, Enum):
     SNAP = "snap"
     EXTEND = "extend"
+    NEW_LINE = "new_line"
 
 
 class GapSource(str, Enum):
@@ -112,6 +113,19 @@ class PlanEntry:
     processed: bool = False
     skip: bool = False
     meta: Optional[PlanEntryMeta] = None
+
+
+@dataclass(frozen=True)
+class _GeneratedLineRecord:
+    """One pending NEW_LINE materialisation collected during ``_apply_plan``
+    and consumed by ``_insert_generated_lines`` after the UpdateCursor closes.
+    """
+
+    parent_original_id: ParentId
+    dangle_x: float
+    dangle_y: float
+    near_x: float
+    near_y: float
 
 
 class _UnionFind:
@@ -1280,6 +1294,14 @@ class FillLineGaps:
 
     ORIGINAL_ID = "line_gap_original_id"
 
+    # Output flag: 1 on rows materialised by EditMethod.NEW_LINE, 0 otherwise.
+    FIELD_GAP_GENERATED = "fill_line_gap_generated"
+
+    # Sentinel ORIGINAL_ID for generated rows. Real ORIGINAL_IDs come from
+    # OBJECTID (>= 1), so -1 cannot collide with any plan key — keeps the
+    # second _apply_plan (resnap) pass from walking into generated rows.
+    GENERATED_ORIGINAL_ID_SENTINEL = -1
+
     # Change output fields
     FIELD_GAP_DIST_M = "gap_dist_m"
     FIELD_GAP_SOURCE = "gap_source"
@@ -1482,8 +1504,8 @@ class FillLineGaps:
     def _resolve_edit_op(self, *, gap_source: GapSource) -> EditOp:
         """Map ``edit_method`` + ``gap_source`` onto the geometry edit to perform.
 
-        ``FORCED_SNAP`` and ``FORCED_EXTEND`` ignore ``gap_source``.
-        ``AUTO`` snaps dangle-to-dangle pairs
+        ``FORCED_SNAP``, ``FORCED_EXTEND`` and ``NEW_LINE`` ignore
+        ``gap_source``.  ``AUTO`` snaps dangle-to-dangle pairs
         (``GapSource.PAIR_DANGLE``) and extends everything else.
         """
         method = self.edit_method
@@ -1492,6 +1514,8 @@ class FillLineGaps:
             return EditOp.SNAP
         if method == logic_config.EditMethod.FORCED_EXTEND:
             return EditOp.EXTEND
+        if method == logic_config.EditMethod.NEW_LINE:
+            return EditOp.NEW_LINE
 
         # AUTO
         if gap_source is GapSource.PAIR_DANGLE:
@@ -1820,6 +1844,27 @@ class FillLineGaps:
             expression=f"!{oid_field}!",
             expression_type="PYTHON3",
         )
+
+    def _ensure_gap_generated_field(self) -> None:
+        """Idempotently provision ``FIELD_GAP_GENERATED`` on ``lines_copy``.
+
+        If the field is missing, add it as SHORT and bulk-set every
+        existing row to 0.  If the field already exists (e.g. because the
+        input is the output of a prior run), values are preserved
+        verbatim — generated rows from the prior run keep their 1.
+        """
+        existing = {f.name for f in arcpy.ListFields(self.lines_copy)}
+        if self.FIELD_GAP_GENERATED in existing:
+            return
+
+        arcpy.management.AddField(
+            self.lines_copy, self.FIELD_GAP_GENERATED, "SHORT"
+        )
+        with arcpy.da.UpdateCursor(
+            self.lines_copy, [self.FIELD_GAP_GENERATED]
+        ) as cur:
+            for _ in cur:
+                cur.updateRow((0,))
 
     def _create_dangles(self) -> None:
         arcpy.management.FeatureVerticesToPoints(
@@ -5949,9 +5994,11 @@ class FillLineGaps:
         with pending plan entries, applies each entry in order — SNAP moves
         the dangle endpoint exactly to the target point; EXTEND inserts the
         target point as the new endpoint while preserving the existing
-        vertices.  When ``line_changes_output`` is set and metadata writing
-        is enabled, a per-edit row is collected and inserted after all
-        geometry updates are complete.
+        vertices; NEW_LINE leaves the parent untouched and is materialised
+        as a new feature in a post-pass insert (see
+        ``_insert_generated_lines``).  When ``line_changes_output`` is set
+        and metadata writing is enabled, a per-edit row is collected and
+        inserted after all geometry updates are complete.
 
         How:
             Each ``PlanEntry`` carries ``skip`` and ``processed`` flags.
@@ -5969,6 +6016,7 @@ class FillLineGaps:
 
         spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
         change_rows: list[tuple] = []
+        generated_records: list[_GeneratedLineRecord] = []
 
         with arcpy.da.UpdateCursor(
             self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"]
@@ -5984,6 +6032,7 @@ class FillLineGaps:
                     continue
 
                 current_shape = shape
+                shape_modified = False
 
                 for info in pending:
                     if info.edit_op is EditOp.SNAP:
@@ -5994,13 +6043,26 @@ class FillLineGaps:
                             near_x=info.near_x,
                             near_y=info.near_y,
                         )
-                    else:
+                        shape_modified = True
+                    elif info.edit_op is EditOp.EXTEND:
                         current_shape = self._extend_endpoint(
                             shape=current_shape,
                             dangle_x=info.dangle_x,
                             dangle_y=info.dangle_y,
                             near_x=info.near_x,
                             near_y=info.near_y,
+                        )
+                        shape_modified = True
+                    else:
+                        # NEW_LINE — defer to post-pass insert; parent untouched.
+                        generated_records.append(
+                            _GeneratedLineRecord(
+                                parent_original_id=pid,
+                                dangle_x=info.dangle_x,
+                                dangle_y=info.dangle_y,
+                                near_x=info.near_x,
+                                near_y=info.near_y,
+                            )
                         )
 
                     info.processed = True
@@ -6022,7 +6084,14 @@ class FillLineGaps:
                         if row is not None:
                             change_rows.append(row)
 
-                cur.updateRow((original_id, current_shape))
+                if shape_modified:
+                    cur.updateRow((original_id, current_shape))
+
+        if generated_records:
+            self._insert_generated_lines(
+                records=generated_records,
+                spatial_reference=spatial_reference,
+            )
 
         if (
             self.line_changes_output is not None
@@ -6053,6 +6122,97 @@ class FillLineGaps:
                         # Polygon (non-line) rows have no angle metadata; pad with None.
                         row = row + (None,) * len(meta_fields)
                     icur.insertRow(row)
+
+    def _insert_generated_lines(
+        self,
+        *,
+        records: list[_GeneratedLineRecord],
+        spatial_reference,
+    ) -> None:
+        """Materialise NEW_LINE plan entries as new features in ``lines_copy``.
+
+        Each record is written as a 2-vertex polyline (dangle -> near) that
+        carries a copy of the parent line's attributes — every field except
+        the OID, the geometry, ``Shape_Length``/``Shape_Area``,
+        ``ORIGINAL_ID``, and ``FIELD_GAP_GENERATED``.  ``ORIGINAL_ID`` is
+        forced to ``GENERATED_ORIGINAL_ID_SENTINEL`` so the second
+        ``_apply_plan`` (resnap) pass cannot mistake a generated row for a
+        real parent; ``FIELD_GAP_GENERATED`` is forced to 1.
+
+        Records whose dangle and near coordinates coincide are skipped — a
+        zero-length connector should not have been considered a gap, but
+        the guard keeps the insert pass safe.
+        """
+        if not records:
+            return
+
+        oid_field = arcpy.Describe(self.lines_copy).OIDFieldName
+        excluded = {
+            oid_field,
+            self.FIELD_GAP_GENERATED,
+            self.ORIGINAL_ID,
+        }
+        copyable_fields: list[str] = []
+        for f in arcpy.ListFields(self.lines_copy):
+            if f.type in ("Geometry", "OID", "GlobalID"):
+                continue
+            if f.name in excluded:
+                continue
+            if f.name in ("Shape_Length", "Shape_Area"):
+                continue
+            copyable_fields.append(f.name)
+
+        needed_parent_ids = {r.parent_original_id for r in records}
+        parent_attrs: dict[ParentId, tuple] = {}
+        if copyable_fields:
+            with arcpy.da.SearchCursor(
+                self.lines_copy, [self.ORIGINAL_ID] + copyable_fields
+            ) as scur:
+                for row in scur:
+                    pid = int(row[0])
+                    if pid in needed_parent_ids and pid not in parent_attrs:
+                        parent_attrs[pid] = tuple(row[1:])
+
+        insert_fields = (
+            copyable_fields
+            + [self.ORIGINAL_ID, self.FIELD_GAP_GENERATED, "SHAPE@"]
+        )
+
+        epsilon_sq = 1e-10
+        with arcpy.da.InsertCursor(self.lines_copy, insert_fields) as icur:
+            for rec in records:
+                dx = rec.near_x - rec.dangle_x
+                dy = rec.near_y - rec.dangle_y
+                if dx * dx + dy * dy <= epsilon_sq:
+                    continue
+
+                if copyable_fields:
+                    attrs = parent_attrs.get(rec.parent_original_id)
+                    if attrs is None:
+                        # Parent vanished from lines_copy between cursor
+                        # passes — should not happen, but skip rather
+                        # than write None for every field.
+                        continue
+                else:
+                    attrs = ()
+
+                geom = arcpy.Polyline(
+                    arcpy.Array(
+                        [
+                            arcpy.Point(rec.dangle_x, rec.dangle_y),
+                            arcpy.Point(rec.near_x, rec.near_y),
+                        ]
+                    ),
+                    spatial_reference,
+                )
+                icur.insertRow(
+                    tuple(attrs)
+                    + (
+                        self.GENERATED_ORIGINAL_ID_SENTINEL,
+                        1,
+                        geom,
+                    )
+                )
 
     def _update_deferred_diagnostics(
         self,
@@ -6139,6 +6299,7 @@ class FillLineGaps:
         self._copy_input_lines()
         self._build_raster_handles()
         self._add_original_id_field()
+        self._ensure_gap_generated_field()
         self._create_dangles()
         self._build_external_target_layers_once()
         targets = self._select_targets_within_tolerance_of_dangles()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -42,6 +42,7 @@ class FillLineGaps:
         self.increased_tolerance_edge_case_distance_meters = int(
             adv.increased_tolerance_edge_case_distance_meters
         )
+        self.edit_method = logic_config.EditMethod(adv.edit_method)
 
         if self.connect_to_features is None and self.fill_gaps_on_self is False:
             raise ValueError(
@@ -117,6 +118,80 @@ class FillLineGaps:
             for oid, original_id in cur:
                 out[int(oid)] = int(original_id)
         return out
+
+    def _resolve_edit_op(self, *, gap_source: str) -> logic_config.EditOp:
+        method = self.edit_method
+
+        if method == logic_config.EditMethod.FORCED_SNAP:
+            return logic_config.EditOp.SNAP
+        if method == logic_config.EditMethod.FORCED_EXTEND:
+            return logic_config.EditOp.EXTEND
+
+        # AUTO
+        if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE:
+            return logic_config.EditOp.SNAP
+        return logic_config.EditOp.EXTEND
+
+    def _choose_endpoint_index(
+        self, *, points: list, dangle_x: float, dangle_y: float, tol: float = 0.001
+    ) -> int:
+        first = points[0]
+        last = points[-1]
+
+        def matches(point, x: float, y: float) -> bool:
+            return abs(point.X - x) <= tol and abs(point.Y - y) <= tol
+
+        if matches(first, dangle_x, dangle_y):
+            return 0
+        if matches(last, dangle_x, dangle_y):
+            return -1
+
+        # Fallback: closest end
+        d_first = (first.X - dangle_x) ** 2 + (first.Y - dangle_y) ** 2
+        d_last = (last.X - dangle_x) ** 2 + (last.Y - dangle_y) ** 2
+        return 0 if d_first <= d_last else -1
+
+    def _snap_endpoint(
+        self, *, shape, dangle_x: float, dangle_y: float, near_x: float, near_y: float
+    ):
+        if shape is None:
+            return shape
+
+        part = shape.getPart(0)
+        points = [pt for pt in part]
+        if len(points) < 2:
+            return shape
+
+        idx = self._choose_endpoint_index(
+            points=points, dangle_x=dangle_x, dangle_y=dangle_y
+        )
+
+        points[idx] = arcpy.Point(near_x, near_y)
+        return arcpy.Polyline(arcpy.Array(points), shape.spatialReference)
+
+    def _extend_endpoint(
+        self, *, shape, dangle_x: float, dangle_y: float, near_x: float, near_y: float
+    ):
+        if shape is None:
+            return shape
+
+        part = shape.getPart(0)
+        points = [pt for pt in part]
+        if len(points) < 2:
+            return shape
+
+        idx = self._choose_endpoint_index(
+            points=points, dangle_x=dangle_x, dangle_y=dangle_y
+        )
+
+        # If extending at the start, insert new point before first.
+        # If extending at the end, append new point after last.
+        if idx == 0:
+            points.insert(0, arcpy.Point(near_x, near_y))
+        else:
+            points.append(arcpy.Point(near_x, near_y))
+
+        return arcpy.Polyline(arcpy.Array(points), shape.spatialReference)
 
     # ----------------------------
     # Preprocessing
@@ -529,10 +604,6 @@ class FillLineGaps:
             if other_parent is None:
                 return False
 
-            # making sure self parent line never is legal
-            if ds_key == lines_fc_key and int(oid) == int(parent_id):
-                return False
-
             # treat as snapping to that parent line for illegal checks
             if self._is_illegal(
                 illegal=illegal,
@@ -546,6 +617,10 @@ class FillLineGaps:
 
         # non-dangle
         if dist > base_tol:
+            return False
+
+        # hard guard: never snap to own parent line (canonical lines key)
+        if ds_key == lines_fc_key and int(oid) == int(parent_id):
             return False
 
         if self._is_illegal(
@@ -983,10 +1058,12 @@ class FillLineGaps:
         chosen: dict,
         gap_source: str,
     ) -> dict:
+        edit_op = self._resolve_edit_op(gap_source=str(gap_source))
         return {
             "processed": False,
             "skip": False,
             "gap_source": str(gap_source),
+            "edit_op": str(edit_op.value),
             "dangle_oid": int(dangle_oid),
             "dangle_x": float(dangle_x),
             "dangle_y": float(dangle_y),
@@ -1120,6 +1197,9 @@ class FillLineGaps:
                 "processed": False,
                 "skip": False,
                 "gap_source": self.GAP_SOURCE_DEFERRED,
+                "edit_op": str(
+                    self._resolve_edit_op(gap_source=self.GAP_SOURCE_DEFERRED).value
+                ),
                 "dangle_oid": dangle_oid_val,
                 "dangle_x": float(dangle_x),
                 "dangle_y": float(dangle_y),
@@ -1177,35 +1257,6 @@ class FillLineGaps:
         geom = arcpy.Polyline(arr, spatial_reference)
         return (geom, int(original_id), float(dist), str(gap_source))
 
-    def _move_endpoint(
-        self, shape, dangle_x: float, dangle_y: float, near_x: float, near_y: float
-    ):
-        if shape is None:
-            return shape
-        part = shape.getPart(0)
-        points = [pt for pt in part]
-        if len(points) < 2:
-            return shape
-
-        first = points[0]
-        last = points[-1]
-
-        tol = 0.001
-
-        def matches(point, x: float, y: float) -> bool:
-            return abs(point.X - x) <= tol and abs(point.Y - y) <= tol
-
-        if matches(first, dangle_x, dangle_y):
-            points[0] = arcpy.Point(near_x, near_y)
-        elif matches(last, dangle_x, dangle_y):
-            points[-1] = arcpy.Point(near_x, near_y)
-        else:
-            d_first = (first.X - dangle_x) ** 2 + (first.Y - dangle_y) ** 2
-            d_last = (last.X - dangle_x) ** 2 + (last.Y - dangle_y) ** 2
-            points[0 if d_first <= d_last else -1] = arcpy.Point(near_x, near_y)
-
-        return arcpy.Polyline(arcpy.Array(points), shape.spatialReference)
-
     def _apply_edits(self, plan: dict[int, dict]) -> None:
         if not plan:
             arcpy.management.CopyFeatures(self.lines_copy, self.output_lines)
@@ -1231,13 +1282,24 @@ class FillLineGaps:
                 ):
                     continue
 
-                new_shape = self._move_endpoint(
-                    shape=shape,
-                    dangle_x=float(info["dangle_x"]),
-                    dangle_y=float(info["dangle_y"]),
-                    near_x=float(info["near_x"]),
-                    near_y=float(info["near_y"]),
-                )
+                edit_op = str(info.get("edit_op", logic_config.EditOp.EXTEND.value))
+
+                if edit_op == logic_config.EditOp.SNAP.value:
+                    new_shape = self._snap_endpoint(
+                        shape=shape,
+                        dangle_x=float(info["dangle_x"]),
+                        dangle_y=float(info["dangle_y"]),
+                        near_x=float(info["near_x"]),
+                        near_y=float(info["near_y"]),
+                    )
+                else:
+                    new_shape = self._extend_endpoint(
+                        shape=shape,
+                        dangle_x=float(info["dangle_x"]),
+                        dangle_y=float(info["dangle_y"]),
+                        near_x=float(info["near_x"]),
+                        near_y=float(info["near_y"]),
+                    )
                 cur.updateRow((original_id, new_shape))
 
                 if self.line_changes_output is not None:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2803,6 +2803,28 @@ class FillLineGaps:
 
         return grouped
 
+    def _build_dist_to_parent_line_by_dangle(
+        self,
+        *,
+        grouped: dict[DangleOid, list[NearCandidate]],
+        lines_key: DatasetKey,
+    ) -> dict[DangleOid, dict[ParentId, float]]:
+        """Per source dangle, map every line-target parent_id to its near-table
+        distance. Built once from the raw grouped near table so the dangle-pair
+        connector-diff gate can do a flat lookup instead of a per-iteration
+        dict-comp inside ``_select_dangle_proposals``. Distances reflect what
+        arcpy reported regardless of legality (legal/illegal filtering decides
+        snap targets, not distance measurements).
+        """
+        return {
+            d_oid: {
+                int(c.near_fid): float(c.near_dist)
+                for c in cands
+                if c.near_fc_key == lines_key
+            }
+            for d_oid, cands in grouped.items()
+        }
+
     # ----------------------------
     # Planning: choose closest legal + detect pairs
     # ----------------------------
@@ -2955,33 +2977,6 @@ class FillLineGaps:
         if ds_key == lines_fc_key:
             return near_fid  # already in ORIGINAL_ID space
         return None
-
-    def _dangle_pair_requires_connector_diff(
-        self,
-        *,
-        target_parent_id: Optional[ParentId],
-        dist_to_parent_line_by_id: Optional[dict[ParentId, float]],
-    ) -> bool:
-        """Decide whether the connector-diff penalty fires for a dangle pair.
-
-        Caller has already verified the threshold is set and that the candidate's
-        own gap distance exceeds it (the cheap dangle-distance short-circuit), so
-        the only remaining question is whether the parent line itself is also
-        beyond the threshold. If the lookup cannot resolve a distance — missing
-        target parent, lookup unavailable, parent filtered out — the call is
-        conservative and applies the penalty.
-        """
-        threshold = self.connector_angle_diff_required_above_meters
-        if (
-            threshold is None
-            or target_parent_id is None
-            or dist_to_parent_line_by_id is None
-        ):
-            return True
-        dist = dist_to_parent_line_by_id.get(int(target_parent_id))
-        if dist is None:
-            return True
-        return float(dist) > float(threshold)
 
     def _normalize_directional_angles(
         self,
@@ -3350,12 +3345,25 @@ class FillLineGaps:
                 # own dangle endpoint, so a close dangle implies a close parent
                 # — skip the lookup and use src_target_diff.
                 and float(cand.near_dist) > float(connector_diff_threshold)
-                and self._dangle_pair_requires_connector_diff(
-                    target_parent_id=target_parent_id,
-                    dist_to_parent_line_by_id=dist_to_parent_line_by_id,
-                )
             ):
-                metric = max(float(src_target_diff), float(src_connector_diff))
+                # Inline parent-line distance gate. Conservative when the lookup
+                # cannot resolve a parent line (missing target parent, lookup
+                # disabled, or parent absent from the global table).
+                _parent_dist = (
+                    dist_to_parent_line_by_id.get(int(target_parent_id))
+                    if (
+                        dist_to_parent_line_by_id is not None
+                        and target_parent_id is not None
+                    )
+                    else None
+                )
+                if (
+                    _parent_dist is None
+                    or float(_parent_dist) > float(connector_diff_threshold)
+                ):
+                    metric = max(float(src_target_diff), float(src_connector_diff))
+                else:
+                    metric = float(src_target_diff)
             else:
                 metric = float(src_target_diff)
         elif self.lines_are_directed:
@@ -3784,6 +3792,18 @@ class FillLineGaps:
         if not grouped:
             return BuildPlanResult.empty(diagnostics=[])
 
+        # Built once when the dangle-pair distance gate is active; passed into
+        # _select_dangle_proposals so the gate has a flat per-dangle lookup
+        # instead of rebuilding it on every iteration.
+        dist_to_parent_line_by_dangle: Optional[
+            dict[DangleOid, dict[ParentId, float]]
+        ] = None
+        if self.connector_angle_diff_required_above_meters is not None:
+            dist_to_parent_line_by_dangle = self._build_dist_to_parent_line_by_dangle(
+                grouped=grouped,
+                lines_key=lines_key,
+            )
+
         collect_diags = self.candidate_connections_output is not None
 
         def _build_diagnostics(
@@ -3962,6 +3982,7 @@ class FillLineGaps:
                 dangle_parent=dangle_parent,
                 topology=topology,
                 collect_diags=collect_diags,
+                dist_to_parent_line_by_dangle=dist_to_parent_line_by_dangle,
             )
         )
 
@@ -4233,6 +4254,9 @@ class FillLineGaps:
         dangle_parent: dict[DangleOid, ParentId],
         topology: TopologyModel,
         collect_diags: bool,
+        dist_to_parent_line_by_dangle: Optional[
+            dict[DangleOid, dict[ParentId, float]]
+        ] = None,
     ) -> tuple[
         dict[DangleOid, _DangleProposal],
         _NormZByDangle,
@@ -4314,16 +4338,14 @@ class FillLineGaps:
                 if _d_xy is not None:
                     _dangle_xys_by_parent.setdefault(int(_d_parent), []).append(_d_xy)
 
-            # Per-dangle parent-line distance lookup used by the dangle-pair
-            # connector-diff distance gate. Only built when the threshold is
-            # set; otherwise the metric ladder skips the gate entirely.
-            dist_to_parent_line_by_id: Optional[dict[ParentId, float]] = None
-            if self.connector_angle_diff_required_above_meters is not None:
-                dist_to_parent_line_by_id = {
-                    int(c.near_fid): float(c.near_dist)
-                    for c in legal_rows
-                    if c.near_fc_key == lines_key
-                }
+            # Per-dangle slice of the global parent-line distance lookup; the
+            # caller already chose to materialise the global table only when
+            # connector_angle_diff_required_above_meters is set.
+            dist_to_parent_line_by_id = (
+                dist_to_parent_line_by_dangle.get(dangle_oid)
+                if dist_to_parent_line_by_dangle is not None
+                else None
+            )
 
             scored_candidates: list[_ScoredCandidateItem] = []
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -794,6 +794,81 @@ class FillLineGaps:
                 return cand
         return None
 
+    def _find_best_dangle_candidate_to_parent(
+        self,
+        *,
+        candidates_sorted: list[dict],
+        dangles_fc_key: str,
+        dangle_parent: dict[int, int],
+        target_parent_id: int,
+        dangle_tol: float,
+    ) -> Optional[dict]:
+        """
+        From A's candidate rows, find the closest dangle feature that belongs to target_parent_id.
+        This handles "target parent has 2 dangles" correctly by selecting the closest.
+        """
+        best = None
+        best_dist = float("inf")
+
+        for cand in candidates_sorted:
+            if cand["near_fc_key"] != dangles_fc_key:
+                continue
+
+            other_dangle_oid = int(cand["near_fid"])
+            other_parent = dangle_parent.get(other_dangle_oid)
+            if other_parent is None:
+                continue
+            if int(other_parent) != int(target_parent_id):
+                continue
+
+            dist = float(cand["near_dist"])
+            if dist <= float(dangle_tol) and dist < best_dist:
+                best = cand
+                best_dist = dist
+
+        return best
+
+    def _best_dangle_for_parent_towards_target_parent(
+        self,
+        *,
+        parent_id: int,
+        target_parent_id: int,
+        parent_to_dangles: dict[int, list[int]],
+        per_dangle: dict[int, dict],
+    ) -> int | None:
+        """
+        Choose the dangle on `parent_id` that is most suitable for pairing with `target_parent_id`.
+
+        Rule:
+        - Only consider dangles whose pair_token_parent == target_parent_id
+        - Pick the one with the smallest first_legal near_dist
+        """
+        dangles = parent_to_dangles.get(int(parent_id), [])
+        if not dangles:
+            return None
+
+        best_dangle = None
+        best_dist = float("inf")
+
+        for d_oid in dangles:
+            info = per_dangle.get(int(d_oid))
+            if not info:
+                continue
+
+            if int(info.get("pair_token_parent") or -1) != int(target_parent_id):
+                continue
+
+            first_legal = info.get("first_legal")
+            if not first_legal:
+                continue
+
+            dist = float(first_legal.get("near_dist", float("inf")))
+            if dist < best_dist:
+                best_dist = dist
+                best_dangle = int(d_oid)
+
+        return best_dangle
+
     def _find_specific_dangle_candidate(
         self,
         *,
@@ -803,17 +878,51 @@ class FillLineGaps:
         dangle_tol: float,
     ) -> Optional[dict]:
         """
-        Find the row that explicitly targets the other *dangle* (not its line),
-        within dangle_tol (custom dangle tolerance).
+        Find candidate row that targets a specific dangle OID (within dangle_tol).
         """
         for cand in candidates_sorted:
             if cand["near_fc_key"] != dangles_fc_key:
                 continue
             if int(cand["near_fid"]) != int(other_dangle_oid):
                 continue
-            if float(cand["near_dist"]) <= float(dangle_tol):
+
+            dist = float(cand["near_dist"])
+            if dist <= float(dangle_tol):
                 return cand
         return None
+
+    def _best_dangle_for_parent(
+        self,
+        *,
+        parent_id: int,
+        parent_to_dangles: dict[int, list[int]],
+        per_dangle: dict[int, dict],
+    ) -> int | None:
+        """
+        Choose which dangle (of possibly many on the same parent line) should represent
+        this parent for default / non-pair behavior.
+
+        Rule: choose the dangle whose first_legal candidate is closest (smallest near_dist).
+        """
+        dangles = parent_to_dangles.get(int(parent_id), [])
+        if not dangles:
+            return None
+
+        best = None
+        best_dist = float("inf")
+        for d_oid in dangles:
+            info = per_dangle.get(int(d_oid))
+            if not info:
+                continue
+            cand = info.get("first_legal")
+            if not cand:
+                continue
+            dist = float(cand.get("near_dist", float("inf")))
+            if dist < best_dist:
+                best_dist = dist
+                best = int(d_oid)
+
+        return best
 
     def _build_component_ids(
         self, *, adjacency: dict[int, set[int]], nodes: set[int]
@@ -969,10 +1078,9 @@ class FillLineGaps:
         if not per_dangle:
             return {}
 
-        # Helper: parent -> dangle oid (assumes one dangle per line; if not, last wins)
-        parent_to_dangle: dict[int, int] = {}
+        parent_to_dangles: dict[int, list[int]] = {}
         for d_oid, info in per_dangle.items():
-            parent_to_dangle[int(info["parent_id"])] = int(d_oid)
+            parent_to_dangles.setdefault(int(info["parent_id"]), []).append(int(d_oid))
 
         # ----------------------------
         # Phase 2: decide moves with pair logic + defer logic
@@ -981,18 +1089,33 @@ class FillLineGaps:
         deferred_by_parent: dict[int, dict] = {}
         visited_pairs: set[tuple[int, int]] = set()
 
-        for d_oid, info in per_dangle.items():
-            a_parent = int(info["parent_id"])
+        all_parents = sorted(parent_to_dangles.keys())
+
+        for a_parent in all_parents:
+            a_parent = int(a_parent)
             if a_parent in decided_by_parent or a_parent in deferred_by_parent:
                 continue
 
-            token_parent = info["pair_token_parent"]
+            a_dangle = self._best_dangle_for_parent(
+                parent_id=a_parent,
+                parent_to_dangles=parent_to_dangles,
+                per_dangle=per_dangle,
+            )
+            if a_dangle is None:
+                continue
+
+            info = per_dangle.get(int(a_dangle))
+            if not info:
+                continue
+
+            token_parent = info.get("pair_token_parent")
+
             if token_parent is None:
                 chosen = info["first_legal"]
-                dx, dy = dangle_xy[int(d_oid)]
+                dx, dy = dangle_xy[int(a_dangle)]
                 decided_by_parent[a_parent] = self._make_plan_entry(
                     parent_id=a_parent,
-                    dangle_oid=int(d_oid),
+                    dangle_oid=int(a_dangle),
                     dangle_x=dx,
                     dangle_y=dy,
                     chosen=chosen,
@@ -1001,12 +1124,14 @@ class FillLineGaps:
                 continue
 
             b_parent = int(token_parent)
-            if b_parent == a_parent:
+            # If the other parent doesn't have any dangles in this run, treat as normal
+            # (this is equivalent to your old "b_dangle is None => normal" behavior)
+            if int(b_parent) not in parent_to_dangles:
                 chosen = info["first_legal"]
-                dx, dy = dangle_xy[int(d_oid)]
+                dx, dy = dangle_xy[int(a_dangle)]
                 decided_by_parent[a_parent] = self._make_plan_entry(
                     parent_id=a_parent,
-                    dangle_oid=int(d_oid),
+                    dangle_oid=int(a_dangle),
                     dangle_x=dx,
                     dangle_y=dy,
                     chosen=chosen,
@@ -1014,32 +1139,25 @@ class FillLineGaps:
                 )
                 continue
 
-            # If the other parent doesn't have a dangle in this run, treat as normal
-            b_dangle = parent_to_dangle.get(b_parent)
+            # A already points to B (via A's representative dangle).
+            # Now find which of B's dangles (if any) points back to A.
+            b_dangle = self._best_dangle_for_parent_towards_target_parent(
+                parent_id=int(b_parent),
+                target_parent_id=int(a_parent),
+                parent_to_dangles=parent_to_dangles,
+                per_dangle=per_dangle,
+            )
+
+            # If B has dangles, but none of them "want A", A must be deferred
             if b_dangle is None:
-                chosen = info["first_legal"]
-                dx, dy = dangle_xy[int(d_oid)]
-                decided_by_parent[a_parent] = self._make_plan_entry(
-                    parent_id=a_parent,
-                    dangle_oid=int(d_oid),
-                    dangle_x=dx,
-                    dangle_y=dy,
-                    chosen=chosen,
-                    gap_source=self.GAP_SOURCE_DEFAULT,
-                )
-                continue
-
-            # Determine if mutual pair: B's closest legal token points back to A
-            b_info = per_dangle.get(int(b_dangle))
-            if not b_info or int(b_info.get("pair_token_parent") or -1) != int(
-                a_parent
-            ):
                 deferred_by_parent[a_parent] = {
                     "parent_id": a_parent,
-                    "dangle_oid": int(d_oid),
+                    "dangle_oid": int(a_dangle),
                     "forced_target_parent": int(b_parent),
                 }
                 continue
+
+            b_info = per_dangle[int(b_dangle)]
 
             # Mutual pair
             pair_key = tuple(sorted((a_parent, b_parent)))
@@ -1055,10 +1173,10 @@ class FillLineGaps:
             ):
                 # Fall back to normal for each (still mark as pair for symmetric skip)
                 for parent, dangle in [
-                    (a_parent, int(d_oid)),
+                    (a_parent, int(a_dangle)),
                     (b_parent, int(b_dangle)),
                 ]:
-                    ii = per_dangle[dangle]
+                    ii = per_dangle[int(dangle)]
                     chosen = ii["first_legal"]
                     dx, dy = dangle_xy[int(dangle)]
                     decided_by_parent[parent] = self._make_plan_entry(
@@ -1079,19 +1197,40 @@ class FillLineGaps:
             # - BUT the parent lines must be within base_tol (and legal)
             # ----------------------------
 
-            # (1) Explicit dangle->dangle rows (within custom dangle tolerance)
+            # (1) Prefer snapping specifically to the chosen pairing endpoints
             a_to_b_dangle = self._find_specific_dangle_candidate(
                 candidates_sorted=info["rows"],
                 dangles_fc_key=dangles_key,
-                other_dangle_oid=int(b_dangle),
+                other_dangle_oid=int(b_dangle),  # chosen B endpoint that points to A
                 dangle_tol=float(dangle_tol),
             )
+
             b_to_a_dangle = self._find_specific_dangle_candidate(
                 candidates_sorted=b_info["rows"],
                 dangles_fc_key=dangles_key,
-                other_dangle_oid=int(d_oid),
+                other_dangle_oid=int(a_dangle),  # chosen A endpoint
                 dangle_tol=float(dangle_tol),
             )
+
+            # Optional fallback: allow snapping to the closest endpoint on the parent if the
+            # exact endpoint row isn't present in the near table output
+            if a_to_b_dangle is None:
+                a_to_b_dangle = self._find_best_dangle_candidate_to_parent(
+                    candidates_sorted=info["rows"],
+                    dangles_fc_key=dangles_key,
+                    dangle_parent=dangle_parent,
+                    target_parent_id=int(b_parent),
+                    dangle_tol=float(dangle_tol),
+                )
+
+            if b_to_a_dangle is None:
+                b_to_a_dangle = self._find_best_dangle_candidate_to_parent(
+                    candidates_sorted=b_info["rows"],
+                    dangles_fc_key=dangles_key,
+                    dangle_parent=dangle_parent,
+                    target_parent_id=int(a_parent),
+                    dangle_tol=float(dangle_tol),
+                )
 
             # (2) Explicit parent-line proximity rows (must be within base tolerance)
             a_to_b_line = self._find_specific_line_candidate(
@@ -1156,7 +1295,7 @@ class FillLineGaps:
 
             # Write entries (still need symmetric skip: only one moves)
             for parent, dangle, chosen, source in [
-                (a_parent, int(d_oid), a_chosen, a_source),
+                (a_parent, int(a_dangle), a_chosen, a_source),
                 (b_parent, int(b_dangle), b_chosen, b_source),
             ]:
                 dx, dy = dangle_xy[int(dangle)]

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -719,28 +719,92 @@ class TopologyBuilder:
 
 
 @dataclass(frozen=True)
-class Proposal:
-    """
-    One best-fit legal candidate per dangle (no fallback).
-    """
+class _CandidateContext:
+    """Fixed metadata for a dangle winner; carried unchanged across scope promotions."""
+    # Topology routing
+    dangle_oid:        int
+    src_parent_id:     int
+    src_node:          "EntityKey"
+    tgt_node:          "EntityKey"
+    pair_key:          "tuple[EntityKey, EntityKey]"
+    target_parent_id:  Optional[int]
+    target_dangle_oid: Optional[int]
+    near_fc_key:       str
+    near_fid:          int
+    # Geometry
+    dangle_x:          float
+    dangle_y:          float
+    near_x:            float
+    near_y:            float
+    raw_distance:      float
+    bonus_applied:     bool
+    # Scoring inputs (fixed; needed for diagnostics and score recomputation)
+    start_z:           Optional[float]   # Z at source dangle endpoint
+    end_z:             Optional[float]   # Z at target near-point
+    norm_dist:         float             # raw_distance / gap_tolerance_meters
+    assess:            Optional["AngleAssessment"]
 
-    dangle_oid: int
-    src_parent_id: int
-    src_node: EntityKey
-    tgt_node: EntityKey
-    chosen: dict  # the chosen candidate row dict
 
-    raw_distance: float
-    best_fit_score: float
-    bonus_applied: bool
+@dataclass(frozen=True)
+class _ProposalScore:
+    """Readable replacement for the opaque score tuple."""
+    composite:  float            # weighted best-fit score (primary sort key)
+    bonus_rank: int              # 0 = bonus applied, 1 = no bonus
+    norm_dist:  float            # effective distance component [0, 1]
+    norm_angle: Optional[float]  # angle component [0, 1]; None if unavailable
+    norm_z:     Optional[float]  # Z component at current scope; None if unavailable
 
-    # (effective_dist, bonus_rank, raw_dist, src_parent, dangle_oid, near_fc_key, near_fid)
-    # bonus_rank: 0 when edge-case bonus applied, else 1
-    score: tuple[float, int, float, int, int, str, int]
 
-    pair_key: tuple[EntityKey, EntityKey]  # unordered network pair
-    target_parent_id: Optional[int]  # only for line/dangle targets (ORIGINAL_ID space)
-    target_dangle_oid: Optional[int]  # only if chosen is a dangle target
+@dataclass(frozen=True)
+class _DangleProposal:
+    """Step-1B winner; Z normalized within its dangle's candidate set."""
+    ctx:   "_CandidateContext"
+    score: "_ProposalScore"      # score.norm_z = dangle_norm_z
+
+    def sort_key(self) -> tuple:
+        c = self.ctx
+        return (self.score.composite, self.score.bonus_rank,
+                c.raw_distance, c.src_parent_id, c.dangle_oid, c.near_fc_key, c.near_fid)
+
+
+@dataclass(frozen=True)
+class _NetworkProposal:
+    """Stage-A candidate; Z normalized within its pair_key group."""
+    ctx:           "_CandidateContext"
+    dangle_norm_z: Optional[float]   # carried from _DangleProposal.score.norm_z
+    score:         "_ProposalScore"  # score.norm_z = network_norm_z
+
+    @classmethod
+    def from_dangle(
+        cls, d: "_DangleProposal", score: "_ProposalScore"
+    ) -> "_NetworkProposal":
+        return cls(ctx=d.ctx, dangle_norm_z=d.score.norm_z, score=score)
+
+    def sort_key(self) -> tuple:
+        c = self.ctx
+        return (self.score.composite, self.score.bonus_rank,
+                c.raw_distance, c.src_parent_id, c.dangle_oid, c.near_fc_key, c.near_fid)
+
+
+@dataclass(frozen=True)
+class _GlobalProposal:
+    """Stage-B candidate; Z normalized across all Stage-A winners."""
+    ctx:            "_CandidateContext"
+    dangle_norm_z:  Optional[float]
+    network_norm_z: Optional[float]
+    score:          "_ProposalScore"  # score.norm_z = global_norm_z
+
+    @classmethod
+    def from_network(
+        cls, n: "_NetworkProposal", score: "_ProposalScore"
+    ) -> "_GlobalProposal":
+        return cls(ctx=n.ctx, dangle_norm_z=n.dangle_norm_z,
+                   network_norm_z=n.score.norm_z, score=score)
+
+    def sort_key(self) -> tuple:
+        c = self.ctx
+        return (self.score.composite, self.score.bonus_rank,
+                c.raw_distance, c.src_parent_id, c.dangle_oid, c.near_fc_key, c.near_fid)
 
 
 @dataclass(frozen=True)
@@ -749,16 +813,15 @@ class DeferredCapture:
     Original proposal metadata captured when a proposal is marked deferred.
 
     Carries both the routing information (which dangle, which forced target) and
-    the original selection metadata (Proposal + AngleAssessment) from the main
-    plan phase.  The geometry is resolved later from post-pass-1 line positions,
-    but the metadata here answers *why* the connection was chosen.
+    the original _DangleProposal from the main plan phase.  The geometry is
+    resolved later from post-pass-1 line positions, but the metadata here
+    answers *why* the connection was chosen.
     """
 
     parent_id: int
     dangle_oid: int
     forced_target_parent: int
-    proposal: "Proposal"
-    assess: "AngleAssessment"
+    proposal: "_DangleProposal"
 
 
 @dataclass(frozen=True)
@@ -824,9 +887,11 @@ class CandidateDiagnostic:
     assess: Optional[AngleAssessment]
     target_parent_id: Optional[int]
     final_gap_source: Optional[str] # gap_source value for applied_to_output rows; None otherwise
-    start_z: Optional[float] = None # Z at the dangle point (candidate start); None when no rasters
-    end_z: Optional[float] = None   # Z at the near point (candidate end);   None when no rasters
-    norm_z: Optional[float] = None  # Per-dangle-normalised Z score [0,1]; None for illegals/no rasters
+    start_z:         Optional[float] = None  # Z at the dangle point (candidate start); None when no rasters
+    end_z:           Optional[float] = None  # Z at the near point (candidate end); None when no rasters
+    dangle_norm_z:   Optional[float] = None  # Z normalized within dangle candidate set; None for illegals
+    network_norm_z:  Optional[float] = None  # Z normalized within pair_key group; None for illegals/deferred
+    global_norm_z:   Optional[float] = None  # Z normalized across all Stage-A winners; None unless Stage-B reached
 
 
 class FillLineGaps:
@@ -1239,6 +1304,26 @@ class FillLineGaps:
         )
 
         return raw_distance, effective_distance, bool(bonus_applied), score
+
+    @staticmethod
+    def _normalize_z_within(
+        end_z_values: "list[Optional[float]]",
+        target_end_z: Optional[float],
+    ) -> Optional[float]:
+        """
+        Normalize target_end_z within the range of end_z_values.
+        Returns None when fewer than 2 valid values exist, range is flat, or target is None.
+        """
+        if target_end_z is None:
+            return None
+        valid = [z for z in end_z_values if z is not None]
+        if len(valid) < 2:
+            return None
+        lo = min(valid)
+        hi = max(valid)
+        if hi == lo:
+            return None
+        return (target_end_z - lo) / (hi - lo)
 
     def _compute_best_fit_score(
         self,
@@ -2589,10 +2674,11 @@ class FillLineGaps:
 
         # (dangle_oid, parent_id, cand, reason) — failed step-1A legality
         _step1a_illegal: list[tuple[int, int, dict, str]] = []
-        # (dangle_oid, parent_id, cand, assess, reason) — passed step-1A but blocked in step-1B
-        _step1b_illegal: list[tuple[int, int, dict, AngleAssessment, str]] = []
-        # (dangle_oid, parent_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner, score_tuple)
-        _step1b_scored: list[tuple[int, int, dict, AngleAssessment, float, float, bool, bool, tuple]] = []
+        # (dangle_oid, parent_id, cand, assess, reason, start_z, end_z) — blocked in step-1B
+        _step1b_illegal: list[tuple[int, int, dict, AngleAssessment, str, Optional[float], Optional[float]]] = []
+        # (dangle_oid, parent_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner,
+        #  score_tuple, norm_z, start_z, end_z)
+        _step1b_scored: list[tuple] = []
 
         # Pipeline stage fate sets — populated as _build_plan progresses;
         # _assemble_diagnostics captures them by reference so early-return calls
@@ -2602,6 +2688,14 @@ class FillLineGaps:
         stage_b_rejected_oids: set[int] = set()    # Stage-A winners dropped by Kruskal
         accepted_dangle_oids: set[int] = set()     # proposals that made it into the main plan
         gap_source_by_dangle: dict[int, str] = {}  # gap_source for accepted main-plan candidates
+
+        # Z normalization dicts — keyed by dangle_oid; captured by reference in _assemble_diagnostics.
+        # dangle_norm_z_by_dangle: winner's per-dangle norm_z (same as sc_norm_z for winner rows)
+        # network_norm_z_by_dangle: populated during Pass-2 for all active proposals
+        # global_norm_z_by_dangle: populated during Pass-3 for Stage-A winners
+        dangle_norm_z_by_dangle:  dict[int, Optional[float]] = {}
+        network_norm_z_by_dangle: dict[int, Optional[float]] = {}
+        global_norm_z_by_dangle:  dict[int, Optional[float]] = {}
 
         def _assemble_diagnostics() -> list[CandidateDiagnostic]:
             if not collect_diags:
@@ -2621,7 +2715,7 @@ class FillLineGaps:
                 )
                 return sz, ez
 
-            # Step-1A illegals: angle never computed for these
+            # Step-1A illegals: angle never computed; z values looked up here
             for d_oid, p_id, cand, reason in _step1a_illegal:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
@@ -2649,15 +2743,16 @@ class FillLineGaps:
                     final_gap_source=None,
                     start_z=_sz,
                     end_z=_ez,
-                    norm_z=None,
+                    dangle_norm_z=None,
+                    network_norm_z=None,
+                    global_norm_z=None,
                 ))
 
-            # Step-1B angle-blocked illegals: angle computed
-            for d_oid, p_id, cand, assess, reason in _step1b_illegal:
+            # Step-1B angle-blocked illegals: z values carried in tuple
+            for d_oid, p_id, cand, assess, reason, _sz, _ez in _step1b_illegal:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
                     continue
-                _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
                 result.append(CandidateDiagnostic(
                     parent_id=p_id,
                     dangle_oid=d_oid,
@@ -2680,7 +2775,9 @@ class FillLineGaps:
                     final_gap_source=None,
                     start_z=_sz,
                     end_z=_ez,
-                    norm_z=None,
+                    dangle_norm_z=None,
+                    network_norm_z=None,
+                    global_norm_z=None,
                 ))
 
             # Compute per-dangle rank for scored candidates (1 = local winner)
@@ -2695,9 +2792,10 @@ class FillLineGaps:
                     cand = entry[2]
                     rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = rank
 
-            # Step-1B scored candidates
+            # Step-1B scored candidates; z values carried in tuple
             for (
-                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner, _score, sc_norm_z
+                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus,
+                is_local_winner, _score, sc_norm_z, sc_start_z, sc_end_z,
             ) in _step1b_scored:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
@@ -2708,30 +2806,41 @@ class FillLineGaps:
                     status = "legal_not_selected"
                     reason = "outscored_within_dangle"
                     final_gs: Optional[str] = None
+                    net_nz: Optional[float] = None
+                    glob_nz: Optional[float] = None
                 elif int(d_oid) in deferred_dangles:
                     status = "selected_for_dangle"
                     reason = "deferred"
                     final_gs = None
+                    net_nz = None
+                    glob_nz = None
                 elif int(d_oid) in stage_a_loser_oids:
                     status = "selected_for_dangle"
                     reason = "lost_pair_competition"
                     final_gs = None
+                    net_nz = network_norm_z_by_dangle.get(int(d_oid))
+                    glob_nz = None
                 elif int(d_oid) in stage_b_rejected_oids:
                     status = "selected_for_dangle"
                     reason = "lost_cycle_prevention"
                     final_gs = None
+                    net_nz = network_norm_z_by_dangle.get(int(d_oid))
+                    glob_nz = global_norm_z_by_dangle.get(int(d_oid))
                 elif int(d_oid) in accepted_dangle_oids:
                     status = "applied_to_output"
                     reason = "applied_main"
                     final_gs = gap_source_by_dangle.get(int(d_oid))
+                    net_nz = network_norm_z_by_dangle.get(int(d_oid))
+                    glob_nz = global_norm_z_by_dangle.get(int(d_oid))
                 else:
                     # Local winner that didn't reach proposal construction
                     # (e.g. target dangle had no resolvable parent)
                     status = "selected_for_dangle"
                     reason = None
                     final_gs = None
+                    net_nz = None
+                    glob_nz = None
 
-                _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
                 result.append(CandidateDiagnostic(
                     parent_id=p_id,
                     dangle_oid=d_oid,
@@ -2752,9 +2861,11 @@ class FillLineGaps:
                         cand, dangle_parent, dangles_key, lines_key
                     ),
                     final_gap_source=final_gs,
-                    start_z=_sz,
-                    end_z=_ez,
-                    norm_z=sc_norm_z,
+                    start_z=sc_start_z,
+                    end_z=sc_end_z,
+                    dangle_norm_z=sc_norm_z,
+                    network_norm_z=net_nz,
+                    global_norm_z=glob_nz,
                 ))
             return result
 
@@ -2919,8 +3030,7 @@ class FillLineGaps:
         # ----------------------------
         # Step 1B: choose exactly ONE proposal per dangle using angle-aware scoring
         # ----------------------------
-        proposals_by_dangle: dict[int, Proposal] = {}
-        assess_by_dangle: dict[int, AngleAssessment] = {}
+        _dangle_proposals: dict[int, _DangleProposal] = {}
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             dangle_oid = int(dangle_oid)
@@ -2954,13 +3064,15 @@ class FillLineGaps:
                     self._raster_handles, float(d_x), float(d_y)
                 )
 
-            # Pre-scan end_z for per-dangle normalization (needed for Z weight in
-            # best-fit score). Only done when Z weight is active.
+            # Pre-scan end_z.  Run when Z scoring is active OR when diagnostic
+            # output is requested so z values are available for all candidate rows.
             end_z_by_cand_index: dict[int, Optional[float]] = {}
             z_score_min: Optional[float] = None
             z_score_max: Optional[float] = None
 
-            if self._raster_handles and float(self.best_fit_weights.z) > 0.0:
+            if self._raster_handles and (
+                float(self.best_fit_weights.z) > 0.0 or collect_diags
+            ):
                 for _i, _c in enumerate(legal_rows):
                     _ez = geometry_tools.local_z_at_xy(
                         self._raster_handles,
@@ -2969,10 +3081,11 @@ class FillLineGaps:
                     )
                     end_z_by_cand_index[_i] = _ez
 
-                _valid_z = [z for z in end_z_by_cand_index.values() if z is not None]
-                if _valid_z:
-                    z_score_min = min(_valid_z)
-                    z_score_max = max(_valid_z)
+                if float(self.best_fit_weights.z) > 0.0:
+                    _valid_z = [z for z in end_z_by_cand_index.values() if z is not None]
+                    if _valid_z:
+                        z_score_min = min(_valid_z)
+                        z_score_max = max(_valid_z)
 
             # Parent IDs of target-dangle candidates for this source dangle.
             # A line candidate to one of these parents represents the same
@@ -2985,17 +3098,8 @@ class FillLineGaps:
                     if _p is not None:
                         _dangle_target_parents.add(int(_p))
 
-            scored_candidates: list[
-                tuple[
-                    tuple[float, int, float, int, int, str, int],  # score tuple
-                    dict,  # candidate
-                    float,  # raw_distance
-                    float,  # effective_distance_for_scoring
-                    bool,  # bonus_applied
-                    "AngleAssessment",  # assess for winning candidate metadata
-                    Optional[float],  # norm_z
-                ]
-            ] = []
+            # (_ProposalScore, cand, raw_dist, best_fit, bonus, assess, norm_z, end_z)
+            scored_candidates: list[tuple] = []
 
             for _cand_idx, cand in enumerate(legal_rows):
                 assess = self._assess_angle(
@@ -3014,11 +3118,14 @@ class FillLineGaps:
                     dangle_target_parents=_dangle_target_parents,
                 )
 
+                _cand_end_z: Optional[float] = end_z_by_cand_index.get(_cand_idx)
+
                 # 1) Candidate blocking (angle_block_threshold_degrees)
                 if assess.blocks:
                     if collect_diags:
                         _step1b_illegal.append(
-                            (dangle_oid, parent_id, cand, assess, "blocked_by_angle")
+                            (dangle_oid, parent_id, cand, assess, "blocked_by_angle",
+                             start_z, _cand_end_z)
                         )
                     continue
 
@@ -3034,36 +3141,29 @@ class FillLineGaps:
                     # Candidate is only legal due to expanded tolerance; angle disallows it
                     if collect_diags:
                         _step1b_illegal.append(
-                            (
-                                dangle_oid,
-                                parent_id,
-                                cand,
-                                assess,
-                                "expanded_dangle_angle_disallowed",
-                            )
+                            (dangle_oid, parent_id, cand, assess,
+                             "expanded_dangle_angle_disallowed",
+                             start_z, _cand_end_z)
                         )
                     continue
 
                 # 3) Z drop gate (z_drop_threshold)
                 if self.z_drop_threshold is not None and start_z is not None:
-                    _end_z = end_z_by_cand_index.get(
-                        _cand_idx,
-                        geometry_tools.local_z_at_xy(
+                    _end_z_gate = (
+                        _cand_end_z
+                        if _cand_end_z is not None
+                        else geometry_tools.local_z_at_xy(
                             self._raster_handles,
                             float(cand["near_x"]),
                             float(cand["near_y"]),
-                        ),
+                        )
                     )
-                    if _end_z is not None and (_end_z - start_z) > self.z_drop_threshold:
+                    if _end_z_gate is not None and (_end_z_gate - start_z) > self.z_drop_threshold:
                         if collect_diags:
                             _step1b_illegal.append(
-                                (
-                                    dangle_oid,
-                                    parent_id,
-                                    cand,
-                                    assess,
-                                    "blocked_by_z_drop",
-                                )
+                                (dangle_oid, parent_id, cand, assess,
+                                 "blocked_by_z_drop",
+                                 start_z, _cand_end_z)
                             )
                         continue
 
@@ -3075,7 +3175,7 @@ class FillLineGaps:
                         assess.allow_extra_dangle
                     )
 
-                raw_distance, effective_distance, bonus_applied, score = (
+                raw_distance, effective_distance, bonus_applied, _score_unused = (
                     self._candidate_score_details(
                         dangle_oid=dangle_oid,
                         parent_id=parent_id,
@@ -3086,9 +3186,11 @@ class FillLineGaps:
                         bonus_allowed=bool(bonus_allowed),
                     )
                 )
+                bonus_rank = 0 if bonus_applied else 1
 
-                # 5) Normalized weighted composite score
+                # 5) Normalized weighted composite score (dangle scope)
                 _tol = float(self.gap_tolerance_meters) or 1.0
+                _eff_norm_dist = float(effective_distance) / _tol
 
                 _norm_z: Optional[float] = None
                 if z_score_min is not None and z_score_max is not None:
@@ -3097,54 +3199,62 @@ class FillLineGaps:
                         if z_score_max > z_score_min:
                             _norm_z = (_ez - z_score_min) / (z_score_max - z_score_min)
                         else:
-                            _norm_z = 0.0
+                            _norm_z = None   # flat range: Z cannot discriminate
 
                 effective_for_scoring = self._compute_best_fit_score(
-                    norm_dist=float(effective_distance) / _tol,
+                    norm_dist=_eff_norm_dist,
                     assess=assess,
                     norm_z=_norm_z,
                 )
 
-                # Keep score tuple shape stable; only replace the first element
-                score_with_angle = (
-                    float(effective_for_scoring),
-                    int(score[1]),
-                    float(score[2]),
-                    int(score[3]),
-                    int(score[4]),
-                    str(score[5]),
-                    int(score[6]),
+                _norm_angle: Optional[float] = (
+                    float(assess.angle_metric_deg) / float(assess.angle_max_deg)
+                    if assess.angle_metric_deg is not None
+                    else None
+                )
+
+                dangle_score = _ProposalScore(
+                    composite=float(effective_for_scoring),
+                    bonus_rank=int(bonus_rank),
+                    norm_dist=_eff_norm_dist,
+                    norm_angle=_norm_angle,
+                    norm_z=_norm_z,
                 )
 
                 scored_candidates.append(
                     (
-                        score_with_angle,
+                        dangle_score,
                         cand,
                         float(raw_distance),
                         float(effective_for_scoring),
                         bool(bonus_applied),
                         assess,
                         _norm_z,
+                        end_z_by_cand_index.get(_cand_idx),   # per-candidate end_z
                     )
                 )
 
             if not scored_candidates:
                 continue
 
-            winner_item = min(scored_candidates, key=lambda item: item[0])
+            winner_item = min(
+                scored_candidates,
+                key=lambda item: (item[0].composite, item[0].bonus_rank, item[2]),
+            )
             (
-                score,
+                winner_dangle_score,
                 chosen,
                 raw_distance,
                 effective_distance_for_scoring,
                 bonus_applied,
                 chosen_assess,
-                _,
+                winner_norm_z,
+                winner_end_z,
             ) = winner_item
 
             if collect_diags:
                 for sc_tuple in scored_candidates:
-                    sc_score, sc_cand, sc_raw, sc_best_fit, sc_bonus, sc_assess, sc_norm_z = sc_tuple
+                    sc_score, sc_cand, sc_raw, sc_best_fit, sc_bonus, sc_assess, sc_norm_z, sc_end_z = sc_tuple
                     _step1b_scored.append((
                         dangle_oid,
                         parent_id,
@@ -3154,12 +3264,14 @@ class FillLineGaps:
                         float(sc_best_fit),
                         bool(sc_bonus),
                         sc_tuple is winner_item,
-                        sc_score,  # score tuple for per-dangle rank computation
-                        sc_norm_z,
+                        (sc_score.composite, sc_score.bonus_rank, sc_raw),  # for per-dangle rank
+                        sc_norm_z,               # dangle_norm_z for this candidate
+                        start_z,                 # fixed per dangle
+                        sc_end_z,                # per-candidate end_z
                     ))
 
             # ----------------------------
-            # Proposal construction (unchanged semantics)
+            # _DangleProposal construction
             # ----------------------------
             src_node = self._node_for_parent(parent_id=parent_id, topology=topology)
 
@@ -3194,24 +3306,34 @@ class FillLineGaps:
                 )
 
             pair_key = self._unordered_pair_key(src_node, tgt_node)
+            _tol_for_ctx = float(self.gap_tolerance_meters) or 1.0
 
-            proposals_by_dangle[dangle_oid] = Proposal(
+            ctx = _CandidateContext(
                 dangle_oid=dangle_oid,
                 src_parent_id=parent_id,
                 src_node=src_node,
                 tgt_node=tgt_node,
-                chosen=chosen,
-                raw_distance=float(raw_distance),
-                best_fit_score=float(effective_distance_for_scoring),
-                bonus_applied=bool(bonus_applied),
-                score=score,
                 pair_key=pair_key,
                 target_parent_id=target_parent_id,
                 target_dangle_oid=target_dangle_oid,
+                near_fc_key=ds_key,
+                near_fid=near_fid,
+                dangle_x=float(d_x),
+                dangle_y=float(d_y),
+                near_x=float(chosen["near_x"]),
+                near_y=float(chosen["near_y"]),
+                raw_distance=float(raw_distance),
+                bonus_applied=bool(bonus_applied),
+                start_z=start_z,
+                end_z=winner_end_z,
+                norm_dist=float(raw_distance) / _tol_for_ctx,
+                assess=chosen_assess,
             )
-            assess_by_dangle[dangle_oid] = chosen_assess
 
-        if not proposals_by_dangle:
+            _dangle_proposals[dangle_oid] = _DangleProposal(ctx=ctx, score=winner_dangle_score)
+            dangle_norm_z_by_dangle[dangle_oid] = winner_norm_z
+
+        if not _dangle_proposals:
             return {}, {}, _assemble_diagnostics()
 
         # ----------------------------
@@ -3223,18 +3345,18 @@ class FillLineGaps:
         parents_with_dangles_set = {int(v) for v in parents_with_dangles}
 
         outgoing_parent_targets: dict[int, set[int]] = {}
-        for p in proposals_by_dangle.values():
-            if p.target_parent_id is None:
+        for p in _dangle_proposals.values():
+            if p.ctx.target_parent_id is None:
                 continue
-            outgoing_parent_targets.setdefault(int(p.src_parent_id), set()).add(
-                int(p.target_parent_id)
+            outgoing_parent_targets.setdefault(int(p.ctx.src_parent_id), set()).add(
+                int(p.ctx.target_parent_id)
             )
 
         deferred_by_parent: dict[int, DeferredCapture] = {}
-        deferred_score_by_parent: dict[int, tuple] = {}
+        deferred_sort_key_by_parent: dict[int, tuple] = {}
 
-        for p in proposals_by_dangle.values():
-            b_parent = p.target_parent_id
+        for p in _dangle_proposals.values():
+            b_parent = p.ctx.target_parent_id
             if b_parent is None:
                 continue
             b_parent = int(b_parent)
@@ -3245,58 +3367,86 @@ class FillLineGaps:
 
             # No reciprocal proposal from B -> A (parent-id space)
             b_out = outgoing_parent_targets.get(b_parent, set())
-            if int(p.src_parent_id) in b_out:
+            if int(p.ctx.src_parent_id) in b_out:
                 continue
 
-            # Keep only one deferred per parent (deterministic: best score)
-            cur_best = deferred_score_by_parent.get(int(p.src_parent_id))
-            if cur_best is None or p.score < cur_best:
-                deferred_by_parent[int(p.src_parent_id)] = DeferredCapture(
-                    parent_id=int(p.src_parent_id),
-                    dangle_oid=int(p.dangle_oid),
+            # Keep only one deferred per parent (deterministic: best sort key)
+            cur_best = deferred_sort_key_by_parent.get(int(p.ctx.src_parent_id))
+            if cur_best is None or p.sort_key() < cur_best:
+                deferred_by_parent[int(p.ctx.src_parent_id)] = DeferredCapture(
+                    parent_id=int(p.ctx.src_parent_id),
+                    dangle_oid=int(p.ctx.dangle_oid),
                     forced_target_parent=int(b_parent),
                     proposal=p,
-                    assess=assess_by_dangle[int(p.dangle_oid)],
                 )
-                deferred_score_by_parent[int(p.src_parent_id)] = p.score
-                deferred_dangles.add(int(p.dangle_oid))
+                deferred_sort_key_by_parent[int(p.ctx.src_parent_id)] = p.sort_key()
+                deferred_dangles.add(int(p.ctx.dangle_oid))
 
         # Active proposals exclude deferred dangles (no fallback)
-        active: list[Proposal] = [
+        active: list[_DangleProposal] = [
             p
-            for d_oid, p in proposals_by_dangle.items()
+            for d_oid, p in _dangle_proposals.items()
             if int(d_oid) not in deferred_dangles
         ]
         if not active:
             return {}, deferred_by_parent, _assemble_diagnostics()
-        active_by_dangle = {int(p.dangle_oid): p for p in active}
+        active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
 
         dangle_mutual_oids: set[int] = set()
         for p in active:
-            if p.target_dangle_oid is None:
+            if p.ctx.target_dangle_oid is None:
                 continue
-            q = active_by_dangle.get(int(p.target_dangle_oid))
-            if q is None or q.target_dangle_oid is None:
+            q = active_by_dangle.get(int(p.ctx.target_dangle_oid))
+            if q is None or q.ctx.target_dangle_oid is None:
                 continue
-            if int(q.target_dangle_oid) == int(p.dangle_oid):
-                dangle_mutual_oids.add(int(p.dangle_oid))
-                dangle_mutual_oids.add(int(q.dangle_oid))
+            if int(q.ctx.target_dangle_oid) == int(p.ctx.dangle_oid):
+                dangle_mutual_oids.add(int(p.ctx.dangle_oid))
+                dangle_mutual_oids.add(int(q.ctx.dangle_oid))
 
         directed_network_edges: set[tuple[EntityKey, EntityKey]] = {
-            (p.src_node, p.tgt_node) for p in active
+            (p.ctx.src_node, p.ctx.tgt_node) for p in active
         }
 
         # ----------------------------
-        # Stage A: one winner per unordered network pair
+        # Pass 2: Network-scope Z normalization (before Stage A)
+        # Group active proposals by pair_key; normalize Z within each group.
         # ----------------------------
-        by_pair: dict[tuple[EntityKey, EntityKey], list[Proposal]] = {}
+        _by_pair_for_network: dict[tuple, list[_DangleProposal]] = {}
         for p in active:
-            by_pair.setdefault(p.pair_key, []).append(p)
+            _by_pair_for_network.setdefault(p.ctx.pair_key, []).append(p)
 
-        stage_a_winners: list[tuple[Proposal, str]] = []
+        network_proposals_by_dangle: dict[int, _NetworkProposal] = {}
+        for _pair_group in _by_pair_for_network.values():
+            _group_end_z = [p.ctx.end_z for p in _pair_group]
+            for p in _pair_group:
+                net_norm_z = self._normalize_z_within(_group_end_z, p.ctx.end_z)
+                net_score = _ProposalScore(
+                    composite=self._compute_best_fit_score(
+                        norm_dist=p.score.norm_dist,
+                        assess=p.ctx.assess,
+                        norm_z=net_norm_z,
+                    ),
+                    bonus_rank=p.score.bonus_rank,
+                    norm_dist=p.score.norm_dist,
+                    norm_angle=p.score.norm_angle,
+                    norm_z=net_norm_z,
+                )
+                network_proposals_by_dangle[int(p.ctx.dangle_oid)] = (
+                    _NetworkProposal.from_dangle(p, score=net_score)
+                )
+                network_norm_z_by_dangle[int(p.ctx.dangle_oid)] = net_norm_z
+
+        # ----------------------------
+        # Stage A: one winner per unordered network pair (using network-scoped scores)
+        # ----------------------------
+        by_pair: dict[tuple, list[_NetworkProposal]] = {}
+        for p in network_proposals_by_dangle.values():
+            by_pair.setdefault(p.ctx.pair_key, []).append(p)
+
+        _network_proposals: list[tuple[_NetworkProposal, str]] = []
         for pair_key in sorted(by_pair.keys()):
             group = by_pair[pair_key]
-            winner = min(group, key=lambda pr: pr.score)
+            winner = min(group, key=lambda pr: pr.sort_key())
 
             a_node, b_node = pair_key
             mutual_network = (a_node, b_node) in directed_network_edges and (
@@ -3305,8 +3455,8 @@ class FillLineGaps:
             ) in directed_network_edges
 
             if (
-                winner.target_dangle_oid is not None
-                and int(winner.dangle_oid) in dangle_mutual_oids
+                winner.ctx.target_dangle_oid is not None
+                and int(winner.ctx.dangle_oid) in dangle_mutual_oids
             ):
                 gap_source = self.GAP_SOURCE_PAIR_DANGLE
             elif mutual_network:
@@ -3314,21 +3464,44 @@ class FillLineGaps:
             else:
                 gap_source = self.GAP_SOURCE_DEFAULT
 
-            stage_a_winners.append((winner, str(gap_source)))
+            _network_proposals.append((winner, str(gap_source)))
 
         if collect_diags:
-            _stage_a_winner_oids = {int(prop.dangle_oid) for prop, _ in stage_a_winners}
+            _stage_a_winner_oids = {int(prop.ctx.dangle_oid) for prop, _ in _network_proposals}
             stage_a_loser_oids.update(
-                int(prop.dangle_oid)
-                for prop in active
-                if int(prop.dangle_oid) not in _stage_a_winner_oids
+                int(p.ctx.dangle_oid)
+                for p in network_proposals_by_dangle.values()
+                if int(p.ctx.dangle_oid) not in _stage_a_winner_oids
             )
+
+        # ----------------------------
+        # Pass 3: Global-scope Z normalization (before Stage B)
+        # Normalize Z across all Stage-A winners.
+        # ----------------------------
+        _all_end_z_global = [p.ctx.end_z for p, _ in _network_proposals]
+        _global_winners: list[tuple[_GlobalProposal, str]] = []
+        for n_prop, gap_source in _network_proposals:
+            glob_norm_z = self._normalize_z_within(_all_end_z_global, n_prop.ctx.end_z)
+            glob_score = _ProposalScore(
+                composite=self._compute_best_fit_score(
+                    norm_dist=n_prop.score.norm_dist,
+                    assess=n_prop.ctx.assess,
+                    norm_z=glob_norm_z,
+                ),
+                bonus_rank=n_prop.score.bonus_rank,
+                norm_dist=n_prop.score.norm_dist,
+                norm_angle=n_prop.score.norm_angle,
+                norm_z=glob_norm_z,
+            )
+            g_prop = _GlobalProposal.from_network(n_prop, score=glob_score)
+            _global_winners.append((g_prop, gap_source))
+            global_norm_z_by_dangle[int(n_prop.ctx.dangle_oid)] = glob_norm_z
 
         # ----------------------------
         # Stage B: Kruskal-style cycle prevention (component scopes only)
         # ----------------------------
         scope = topology.scope
-        accepted: list[tuple[Proposal, str]] = []
+        _global_proposals: list[tuple[_GlobalProposal, str]] = []
 
         if scope in (
             logic_config.ConnectivityScope.INPUT_LINES,
@@ -3347,28 +3520,28 @@ class FillLineGaps:
             for (ds_key, oid), cid in (topology.connectivity_id_by_optional or {}).items():
                 cand_ds_key = topo_to_cand_ds_key.get(ds_key, ds_key)
                 uf.union(("component", int(cid)), ("optional_candidate", str(cand_ds_key), int(oid)))
-            for prop, gap_source in sorted(stage_a_winners, key=lambda t: t[0].score):
-                if uf.find(prop.src_node) == uf.find(prop.tgt_node):
+            for prop, gap_source in sorted(_global_winners, key=lambda t: t[0].sort_key()):
+                if uf.find(prop.ctx.src_node) == uf.find(prop.ctx.tgt_node):
                     continue
-                uf.union(prop.src_node, prop.tgt_node)
-                accepted.append((prop, gap_source))
+                uf.union(prop.ctx.src_node, prop.ctx.tgt_node)
+                _global_proposals.append((prop, gap_source))
         else:
-            # NONE / DIRECT_CONNECTION: only Stage A
-            accepted = list(stage_a_winners)
+            # NONE / DIRECT_CONNECTION: only Stage A (already globally normalized)
+            _global_proposals = list(_global_winners)
 
-        if collect_diags and accepted:
-            _accepted_oids = {int(prop.dangle_oid) for prop, _ in accepted}
+        if collect_diags and _global_proposals:
+            _accepted_oids = {int(prop.ctx.dangle_oid) for prop, _ in _global_proposals}
             accepted_dangle_oids.update(_accepted_oids)
             stage_b_rejected_oids.update(
-                int(prop.dangle_oid)
-                for prop, _ in stage_a_winners
-                if int(prop.dangle_oid) not in _accepted_oids
+                int(prop.ctx.dangle_oid)
+                for prop, _ in _global_winners
+                if int(prop.ctx.dangle_oid) not in _accepted_oids
             )
             gap_source_by_dangle.update(
-                {int(prop.dangle_oid): str(gs) for prop, gs in accepted}
+                {int(prop.ctx.dangle_oid): str(gs) for prop, gs in _global_proposals}
             )
 
-        if not accepted:
+        if not _global_proposals:
             return {}, deferred_by_parent, _assemble_diagnostics()
 
         # ----------------------------
@@ -3376,25 +3549,25 @@ class FillLineGaps:
         # ----------------------------
         tmp: dict[int, list[tuple[tuple, dict]]] = {}
 
-        for prop, gap_source in sorted(accepted, key=lambda t: t[0].score):
-            xy = dangle_xy.get(int(prop.dangle_oid))
-            if xy is None:
-                continue
-            d_x, d_y = xy
-
+        for prop, gap_source in sorted(_global_proposals, key=lambda t: t[0].sort_key()):
             entry = self._make_plan_entry(
-                parent_id=int(prop.src_parent_id),
-                dangle_oid=int(prop.dangle_oid),
-                dangle_x=float(d_x),
-                dangle_y=float(d_y),
-                chosen=prop.chosen,
+                parent_id=int(prop.ctx.src_parent_id),
+                dangle_oid=int(prop.ctx.dangle_oid),
+                dangle_x=float(prop.ctx.dangle_x),
+                dangle_y=float(prop.ctx.dangle_y),
+                chosen={
+                    "near_x": float(prop.ctx.near_x),
+                    "near_y": float(prop.ctx.near_y),
+                    "near_fc_key": str(prop.ctx.near_fc_key),
+                    "near_fid": int(prop.ctx.near_fid),
+                },
                 gap_source=str(gap_source),
-                bonus_applied=prop.bonus_applied,
-                assess=assess_by_dangle.get(int(prop.dangle_oid)),
-                best_fit_score=prop.best_fit_score,
+                bonus_applied=prop.ctx.bonus_applied,
+                assess=prop.ctx.assess,
+                best_fit_score=prop.score.composite,
             )
 
-            tmp.setdefault(int(prop.src_parent_id), []).append((prop.score, entry))
+            tmp.setdefault(int(prop.ctx.src_parent_id), []).append((prop.sort_key(), entry))
 
         plan_by_parent: dict[int, list[dict]] = {}
         for pid, items in tmp.items():
@@ -3540,7 +3713,7 @@ class FillLineGaps:
 
         # Component scopes: greedy acceptance to prevent deferred candidates
         # from creating cycles among themselves, ordered by original score.
-        sorted_valid = sorted(valid, key=lambda t: t[0].proposal.score)
+        sorted_valid = sorted(valid, key=lambda t: t[0].proposal.sort_key())
         uf = _UnionFind()
         accepted: list[tuple[DeferredCapture, float, float]] = []
         for cap, nx, ny in sorted_valid:
@@ -3678,9 +3851,9 @@ class FillLineGaps:
                     "near_fid": cap.forced_target_parent,
                 },
                 gap_source=self.GAP_SOURCE_DEFERRED,
-                bonus_applied=cap.proposal.bonus_applied,
-                assess=cap.assess,
-                best_fit_score=cap.proposal.best_fit_score,
+                bonus_applied=cap.proposal.ctx.bonus_applied,
+                assess=cap.proposal.ctx.assess,
+                best_fit_score=cap.proposal.score.composite,
             )
 
         return out
@@ -3801,7 +3974,9 @@ class FillLineGaps:
         arcpy.management.AddField(fc_path, "status_reason", "TEXT", field_length=50)
         arcpy.management.AddField(fc_path, "start_z", "DOUBLE")
         arcpy.management.AddField(fc_path, "end_z", "DOUBLE")
-        arcpy.management.AddField(fc_path, "norm_z", "DOUBLE")
+        arcpy.management.AddField(fc_path, "dangle_norm_z", "DOUBLE")
+        arcpy.management.AddField(fc_path, "network_norm_z", "DOUBLE")
+        arcpy.management.AddField(fc_path, "global_norm_z", "DOUBLE")
 
     def _write_candidate_connections_output(
         self,
@@ -3834,7 +4009,9 @@ class FillLineGaps:
             "status_reason",
             "start_z",
             "end_z",
-            "norm_z",
+            "dangle_norm_z",
+            "network_norm_z",
+            "global_norm_z",
         ]
         with arcpy.da.InsertCursor(fc_path, fields) as cur:
             for d in diagnostics:
@@ -3865,7 +4042,9 @@ class FillLineGaps:
                     d.status_reason,
                     d.start_z,
                     d.end_z,
-                    d.norm_z,
+                    d.dangle_norm_z,
+                    d.network_norm_z,
+                    d.global_norm_z,
                 ))
 
     def _apply_plan(self, plan) -> None:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1751,6 +1751,37 @@ class FillLineGaps:
                 out[int(dangle_oid)] = (float(x), float(y))
         return out
 
+    def _directed_start_dangle_oids(
+        self,
+        *,
+        dangle_xy: dict[int, tuple[float, float]],
+        dangle_parent: dict[int, int],
+        polyline_by_parent: dict[int, Any],
+    ) -> set[int]:
+        """
+        Returns the set of dangle OIDs that sit at the start of their parent line.
+
+        In directed mode a gap-fill connector extended from a start-node dangle would
+        run antiparallel to the source line's digitization direction, breaking topology.
+        Only end-node dangles are valid sources.
+
+        Returns an empty set when source_direction_mode == UNDIRECTED.
+        """
+        if self.source_direction_mode == logic_config.SourceDirectionMode.UNDIRECTED:
+            return set()
+
+        start_oids: set[int] = set()
+        for dangle_oid, (x, y) in dangle_xy.items():
+            parent_id = dangle_parent.get(dangle_oid)
+            if parent_id is None:
+                continue
+            poly = polyline_by_parent.get(int(parent_id))
+            if poly is None:
+                continue
+            if self._xy_is_at_line_start(poly, x, y):
+                start_oids.add(dangle_oid)
+        return start_oids
+
     # ----------------------------
     # Illegal targets detection
     # ----------------------------
@@ -2845,6 +2876,14 @@ class FillLineGaps:
         if self.fill_gaps_on_self:
             line_like_ds_keys.add(lines_key)
 
+        # In directed mode, source dangles at a line's start node are invalid sources.
+        # polyline_by_parent is already built above; dangle_xy was built at the top.
+        directed_start_dangles = self._directed_start_dangle_oids(
+            dangle_xy=dangle_xy,
+            dangle_parent=dangle_parent,
+            polyline_by_parent=polyline_by_parent,
+        )
+
         # ----------------------------
         # Dangle filtering: collect legal candidates per dangle
         # ----------------------------
@@ -2860,6 +2899,7 @@ class FillLineGaps:
                 dangle_tol=dangle_tol,
                 topology=topology,
                 collect_diags=collect_diags,
+                directed_source_illegal_oids=directed_start_dangles,
             )
         )
 
@@ -3123,6 +3163,7 @@ class FillLineGaps:
         dangle_tol: float,
         topology: TopologyModel,
         collect_diags: bool,
+        directed_source_illegal_oids: set[int],
     ) -> tuple[_Grouped, dict[int, int], list[_Step1AIllegalEntry]]:
         """Dangle filtering: collect legal candidates per dangle.
 
@@ -3140,6 +3181,21 @@ class FillLineGaps:
             if parent_id is None:
                 continue
             parent_id = int(parent_id)
+
+            # In directed mode, start-node dangles cannot be gap-fill sources.
+            # A connector from a start node would run antiparallel to the source line.
+            if dangle_oid in directed_source_illegal_oids:
+                if collect_diags:
+                    for cand in candidates:
+                        if (
+                            str(cand["near_fc_key"]) == str(lines_key)
+                            and int(cand["near_fid"]) == int(parent_id)
+                        ):
+                            continue
+                        _step1a_illegal.append(
+                            (dangle_oid, parent_id, cand, "directed_start_node")
+                        )
+                continue
 
             rows = sorted(candidates, key=self._candidate_sort_key)
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 import math
 import os
@@ -27,13 +27,15 @@ class TopologyModel:
     scope: "ConnectivityScope"
 
     # Component modes only (INPUT_LINES / ONE_DEGREE / TRANSITIVE)
-    connectivity_id_by_parent: Optional[dict[int, int]]
+    # cid (connectivity_id) values stay as plain int — they live in topology space,
+    # not the dangle/parent id space; see ParentId / DangleOid aliases below.
+    connectivity_id_by_parent: Optional[dict[ParentId, int]]
     connectivity_id_by_optional: Optional[dict[OptionalKey, int]]
     entities_by_connectivity_id: Optional[dict[int, set[EntityKey]]]
 
     # DIRECT_CONNECTION only (required); allowed to be None otherwise
-    direct_neighbors_by_parent: Optional[dict[int, set[int]]]
-    direct_optionals_by_parent: Optional[dict[int, set[OptionalKey]]]
+    direct_neighbors_by_parent: Optional[dict[ParentId, set[ParentId]]]
+    direct_optionals_by_parent: Optional[dict[ParentId, set[OptionalKey]]]
 
 
 class EditOp(str, Enum):
@@ -64,14 +66,17 @@ class NearCandidate:
 
     near_fc_key_raw preserves the original dataset key before normalization; kept for
     debugging only.
+
+    near_fid is polymorphic (DangleOid when near_fc_key == dangles_key, ParentId when
+    near_fc_key == lines_key, external-dataset FID otherwise); stays as int.
     """
 
-    near_fc_key: str
+    near_fc_key: DatasetKey
     near_fid: int
     near_dist: float
     near_x: float
     near_y: float
-    near_fc_key_raw: str
+    near_fc_key_raw: DatasetKey
 
 
 @dataclass(frozen=True)
@@ -94,16 +99,16 @@ class PlanEntry:
     ``processed`` and _apply_pair_symmetric_skip / _recheck_resnap_crossings can
     flip ``skip``."""
 
-    dangle_oid: int
+    dangle_oid: DangleOid
     dangle_x: float
     dangle_y: float
     near_x: float
     near_y: float
-    chosen_near_fc_key: str
+    chosen_near_fc_key: DatasetKey
     chosen_near_fid: int
     gap_source: GapSource
     edit_op: EditOp
-    pair_parent: Optional[int] = None
+    pair_parent: Optional[ParentId] = None
     processed: bool = False
     skip: bool = False
     meta: Optional[PlanEntryMeta] = None
@@ -800,15 +805,15 @@ class _CandidateContext:
     """Fixed metadata for a dangle winner; carried unchanged across scope promotions."""
 
     # Topology routing
-    dangle_oid: int
-    src_parent_id: int
+    dangle_oid: DangleOid
+    src_parent_id: ParentId
     src_node: "EntityKey"
     tgt_node: "EntityKey"
     pair_key: "tuple[EntityKey, EntityKey]"
-    target_parent_id: Optional[int]
-    target_dangle_oid: Optional[int]
-    near_fc_key: str
-    near_fid: int
+    target_parent_id: Optional[ParentId]
+    target_dangle_oid: Optional[DangleOid]
+    near_fc_key: DatasetKey
+    near_fid: int  # polymorphic: DangleOid / ParentId / external FID
     # Geometry
     dangle_x: float
     dangle_y: float
@@ -820,7 +825,9 @@ class _CandidateContext:
     start_z: Optional[float]  # Z at source dangle endpoint
     end_z: Optional[float]  # Z at target near-point
     norm_dist: float  # raw_distance / gap_tolerance_meters
-    assess: Optional["AngleAssessment"]
+    # assess is always populated on constructed contexts — code paths that
+    # early-return before proposal construction never reach _CandidateContext.
+    assess: "AngleAssessment"
 
 
 @dataclass(frozen=True)
@@ -856,11 +863,16 @@ class _DangleProposal:
 
 @dataclass(frozen=True)
 class _ConnectionProposal:
-    """Stage-A candidate; Z normalized within its pair_key group."""
+    """Stage-A candidate; Z normalized within its pair_key group.
+
+    gap_source is stamped in _run_connection_selection; instances observed
+    downstream of selection have it non-None.
+    """
 
     ctx: "_CandidateContext"
     dangle_norm_z: Optional[float]  # carried from _DangleProposal.score.norm_z
     score: "_ProposalScore"  # score.norm_z = connection_norm_z
+    gap_source: Optional[GapSource] = None
 
     @classmethod
     def from_dangle(
@@ -889,16 +901,21 @@ class _GlobalProposal:
     dangle_norm_z: Optional[float]
     connection_norm_z: Optional[float]
     score: "_ProposalScore"  # score.norm_z = global_norm_z
+    gap_source: GapSource
 
     @classmethod
     def from_network(
         cls, n: "_ConnectionProposal", score: "_ProposalScore"
     ) -> "_GlobalProposal":
+        assert n.gap_source is not None, (
+            "_ConnectionProposal.gap_source must be stamped before promotion to Stage B"
+        )
         return cls(
             ctx=n.ctx,
             dangle_norm_z=n.dangle_norm_z,
             connection_norm_z=n.score.norm_z,
             score=score,
+            gap_source=n.gap_source,
         )
 
     def sort_key(self) -> tuple:
@@ -915,6 +932,18 @@ class _GlobalProposal:
 
 
 @dataclass(frozen=True)
+class AcceptedConnectorRaw:
+    """Raw geometry of an accepted Kruskal connection; used by the resnap
+    crossing re-check to re-trim connectors against post-apply geometry."""
+
+    dangle_oid: DangleOid
+    dangle_x: float
+    dangle_y: float
+    near_x: float
+    near_y: float
+
+
+@dataclass(frozen=True)
 class _ResnappedCapture:
     """
     Metadata for an accepted connection whose near-point may land on a segment
@@ -924,9 +953,9 @@ class _ResnappedCapture:
     using post-apply lines_copy geometry.
     """
 
-    parent_id: int
-    dangle_oid: int
-    forced_target_parent: int  # target_parent_id of the accepted connection
+    parent_id: ParentId
+    dangle_oid: DangleOid
+    forced_target_parent: ParentId  # target_parent_id of the accepted connection
     proposal: "_GlobalProposal"
     gap_source: GapSource
 
@@ -998,12 +1027,12 @@ class CandidateDiagnostic:
     deferred_scope is None and final_status repeats kruskal_scope.
     """
 
-    parent_id: int
-    dangle_oid: int
+    parent_id: ParentId
+    dangle_oid: DangleOid
     dangle_x: float
     dangle_y: float
-    near_fc_key: str
-    near_fid: int
+    near_fc_key: DatasetKey
+    near_fid: int  # polymorphic; see NearCandidate
     near_x: float
     near_y: float
     raw_distance: float
@@ -1018,7 +1047,7 @@ class CandidateDiagnostic:
     norm_dist: Optional[float]
     norm_angle: Optional[float]
     assess: Optional[AngleAssessment]
-    target_parent_id: Optional[int]
+    target_parent_id: Optional[ParentId]
     final_gap_source: Optional[str]
     start_z: Optional[float] = None
     end_z: Optional[float] = None
@@ -1027,20 +1056,21 @@ class CandidateDiagnostic:
 # ---------------------------------------------------------------------------
 # Pipeline type aliases
 # ---------------------------------------------------------------------------
-_DangleXYsByParent: TypeAlias = dict[int, list[tuple[float, float]]]
-_IllegalTargets: TypeAlias = dict[int, dict[str, set[int]]]
-_NormZByDangle: TypeAlias = dict[int, Optional[float]]
-_ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, GapSource]
-_GlobalWithSource: TypeAlias = tuple[_GlobalProposal, GapSource]
-# (dangle_oid, dangle_x, dangle_y, near_x, near_y)
-_AcceptedConnectorRaw: TypeAlias = tuple[int, float, float, float, float]
+# Semantic id families. Runtime unchanged; these are readability annotations.
+DangleOid: TypeAlias = int
+ParentId: TypeAlias = int  # ORIGINAL_ID space for lines_copy
+DatasetKey: TypeAlias = str
+
+_DangleXYsByParent: TypeAlias = dict[ParentId, list[tuple[float, float]]]
+_IllegalTargets: TypeAlias = dict[ParentId, dict[DatasetKey, set[int]]]
+_NormZByDangle: TypeAlias = dict[DangleOid, Optional[float]]
 
 
 class _CandidateIllegalA(NamedTuple):
     """Candidate rejected at Step 1A (distance/network/legality gate) before angle assessment."""
 
-    dangle_oid: int
-    parent_id: int
+    dangle_oid: DangleOid
+    parent_id: ParentId
     cand: NearCandidate
     reason: str
 
@@ -1048,8 +1078,8 @@ class _CandidateIllegalA(NamedTuple):
 class _CandidateIllegalB(NamedTuple):
     """Candidate rejected at Step 1B (angle/Z gate) after angle assessment."""
 
-    dangle_oid: int
-    parent_id: int
+    dangle_oid: DangleOid
+    parent_id: ParentId
     cand: NearCandidate
     assess: AngleAssessment
     reason: str
@@ -1060,8 +1090,8 @@ class _CandidateIllegalB(NamedTuple):
 class _CandidateScored(NamedTuple):
     """Candidate that survived all legality gates and received a composite score."""
 
-    dangle_oid: int
-    parent_id: int
+    dangle_oid: DangleOid
+    parent_id: ParentId
     cand: NearCandidate
     assess: AngleAssessment
     raw_distance: float
@@ -1076,6 +1106,26 @@ class _CandidateScored(NamedTuple):
     end_z: Optional[float]
 
 
+@dataclass(frozen=True)
+class _ScoredCandidateItem:
+    """One scored candidate row inside _select_dangle_proposals.
+
+    Collected per dangle; the `min(...)` winner is promoted to a _DangleProposal.
+    Replaces a positional 10-tuple.
+    """
+
+    score: "_ProposalScore"
+    cand: NearCandidate
+    raw_distance: float
+    effective_for_scoring: float
+    bonus_applied: bool
+    assess: AngleAssessment
+    norm_z: Optional[float]
+    norm_dist: float
+    norm_angle: Optional[float]
+    end_z: Optional[float]
+
+
 @dataclass
 class _DiagnosticsState:
     """All pipeline state collected during _build_plan for diagnostic assembly."""
@@ -1083,11 +1133,11 @@ class _DiagnosticsState:
     step1a_illegal: list[_CandidateIllegalA]
     step1b_illegal: list[_CandidateIllegalB]
     step1b_scored: list[_CandidateScored]
-    connection_loser_oids: set[int]
-    kruskal_rejected_oids: set[int]
-    kruskal_crossing_rejected_oids: set[int]
-    accepted_dangle_oids: set[int]
-    gap_source_by_dangle: dict[int, GapSource]
+    connection_loser_oids: set[DangleOid]
+    kruskal_rejected_oids: set[DangleOid]
+    kruskal_crossing_rejected_oids: set[DangleOid]
+    accepted_dangle_oids: set[DangleOid]
+    gap_source_by_dangle: dict[DangleOid, GapSource]
     dangle_norm_z_by_dangle: _NormZByDangle
     connection_norm_z_by_dangle: _NormZByDangle
     global_norm_z_by_dangle: _NormZByDangle
@@ -1095,7 +1145,7 @@ class _DiagnosticsState:
 
 # Per-parent plan: each parent line carries a list of planned edits, applied in
 # order by _apply_plan.
-PlanByParent: TypeAlias = dict[int, list[PlanEntry]]
+PlanByParent: TypeAlias = dict[ParentId, list[PlanEntry]]
 
 
 @dataclass(frozen=True)
@@ -1105,8 +1155,8 @@ class BuildPlanResult:
     plan_by_parent: PlanByParent
     resnap_captures: list["_ResnappedCapture"]
     diagnostics: list["CandidateDiagnostic"]
-    accepted_connector_raw: list[_AcceptedConnectorRaw]
-    kruskal_rank_by_dangle_oid: dict[int, int]
+    accepted_connector_raw: list[AcceptedConnectorRaw]
+    kruskal_rank_by_dangle_oid: dict[DangleOid, int]
 
     @classmethod
     def empty(cls, diagnostics: list["CandidateDiagnostic"]) -> "BuildPlanResult":
@@ -1285,9 +1335,10 @@ class FillLineGaps:
             return lines_key
         return near_fc_key
 
-    def _oid_to_original_id_lookup(self, fc: str) -> dict[int, int]:
+    def _oid_to_original_id_lookup(self, fc: str) -> dict[int, ParentId]:
+        # key is raw arcpy OID, value is ORIGINAL_ID (ParentId) space
         oid_field = arcpy.Describe(fc).OIDFieldName
-        out: dict[int, int] = {}
+        out: dict[int, ParentId] = {}
         with arcpy.da.SearchCursor(fc, [oid_field, self.ORIGINAL_ID]) as cur:
             for oid, original_id in cur:
                 out[int(oid)] = int(original_id)
@@ -1452,10 +1503,10 @@ class FillLineGaps:
     def _mutual_dangle_preference(
         self,
         *,
-        dangle_oid: int,
-        other_dangle_oid: int,
-        dangle_parent: dict[int, int],
-        best_line_parent_by_dangle: dict[int, int],
+        dangle_oid: DangleOid,
+        other_dangle_oid: DangleOid,
+        dangle_parent: dict[DangleOid, ParentId],
+        best_line_parent_by_dangle: dict[DangleOid, ParentId],
     ) -> bool:
         """
         True when source and target dangles mutually prefer each other's parent line:
@@ -1475,11 +1526,11 @@ class FillLineGaps:
     def _edge_case_bonus_applies(
         self,
         *,
-        dangle_oid: int,
+        dangle_oid: DangleOid,
         cand: NearCandidate,
-        dangles_fc_key: str,
-        dangle_parent: dict[int, int],
-        best_line_parent_by_dangle: dict[int, int],
+        dangles_fc_key: DatasetKey,
+        dangle_parent: dict[DangleOid, ParentId],
+        best_line_parent_by_dangle: dict[DangleOid, ParentId],
     ) -> bool:
         """
         Determines whether the edge-case distance bonus applies for a candidate.
@@ -1514,14 +1565,14 @@ class FillLineGaps:
     def _candidate_score_details(
         self,
         *,
-        dangle_oid: int,
-        parent_id: int,
+        dangle_oid: DangleOid,
+        parent_id: ParentId,
         cand: NearCandidate,
-        dangles_fc_key: str,
-        dangle_parent: dict[int, int],
-        best_line_parent_by_dangle: dict[int, int],
+        dangles_fc_key: DatasetKey,
+        dangle_parent: dict[DangleOid, ParentId],
+        best_line_parent_by_dangle: dict[DangleOid, ParentId],
         bonus_allowed: bool = True,
-    ) -> tuple[float, float, bool, tuple[float, int, float, int, int, str, int]]:
+    ) -> tuple[float, float, bool]:
         raw_distance = cand.near_dist
 
         bonus_applied = False
@@ -1541,19 +1592,7 @@ class FillLineGaps:
         else:
             effective_distance = raw_distance
 
-        bonus_rank = 0 if bonus_applied else 1
-
-        score = (
-            float(effective_distance),
-            int(bonus_rank),
-            float(raw_distance),
-            int(parent_id),
-            int(dangle_oid),
-            cand.near_fc_key,
-            cand.near_fid,
-        )
-
-        return raw_distance, effective_distance, bool(bonus_applied), score
+        return raw_distance, effective_distance, bool(bonus_applied)
 
     @staticmethod
     def _normalize_z_within(
@@ -1638,8 +1677,8 @@ class FillLineGaps:
             self.lines_copy, self.dangles, "DANGLE"
         )
 
-    def _build_polyline_by_parent_id(self) -> dict[int, Any]:
-        out: dict[int, Any] = {}
+    def _build_polyline_by_parent_id(self) -> dict[ParentId, Any]:
+        out: dict[ParentId, Any] = {}
         with arcpy.da.SearchCursor(
             self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"]
         ) as cur:
@@ -1901,9 +1940,9 @@ class FillLineGaps:
     # Dangle lookups
     # ----------------------------
 
-    def _build_dangle_parent_lookup(self, dangles_fc: str) -> dict[int, int]:
+    def _build_dangle_parent_lookup(self, dangles_fc: str) -> dict[DangleOid, ParentId]:
         oid_field = arcpy.Describe(dangles_fc).OIDFieldName
-        out: dict[int, int] = {}
+        out: dict[DangleOid, ParentId] = {}
         with arcpy.da.SearchCursor(dangles_fc, [oid_field, self.ORIGINAL_ID]) as cur:
             for dangle_oid, parent_id in cur:
                 out[int(dangle_oid)] = int(parent_id)
@@ -1911,9 +1950,9 @@ class FillLineGaps:
 
     def _build_dangle_xy_lookup(
         self, dangles_fc: str
-    ) -> dict[int, tuple[float, float]]:
+    ) -> dict[DangleOid, tuple[float, float]]:
         oid_field = arcpy.Describe(dangles_fc).OIDFieldName
-        out: dict[int, tuple[float, float]] = {}
+        out: dict[DangleOid, tuple[float, float]] = {}
         with arcpy.da.SearchCursor(dangles_fc, [oid_field, "SHAPE@XY"]) as cur:
             for dangle_oid, (x, y) in cur:
                 out[int(dangle_oid)] = (float(x), float(y))
@@ -1922,10 +1961,10 @@ class FillLineGaps:
     def _directed_start_dangle_oids(
         self,
         *,
-        dangle_xy: dict[int, tuple[float, float]],
-        dangle_parent: dict[int, int],
-        polyline_by_parent: dict[int, Any],
-    ) -> set[int]:
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        dangle_parent: dict[DangleOid, ParentId],
+        polyline_by_parent: dict[ParentId, Any],
+    ) -> set[DangleOid]:
         """
         Returns the set of dangle OIDs that sit at the start of their parent line.
 
@@ -2062,8 +2101,8 @@ class FillLineGaps:
     def _find_crossing_conflict_keys(
         self,
         *,
-        legal_rows_by_dangle: dict[int, list[NearCandidate]],
-        dangle_xy: dict[int, tuple[float, float]],
+        legal_rows_by_dangle: dict[DangleOid, list[NearCandidate]],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
         check_feature_layers: list[str],
         trim_distance: float,
         spatial_reference: Any,
@@ -2136,8 +2175,8 @@ class FillLineGaps:
     def _find_barrier_crossing_keys(
         self,
         *,
-        legal_rows_by_dangle: dict[int, list[NearCandidate]],
-        dangle_xy: dict[int, tuple[float, float]],
+        legal_rows_by_dangle: dict[DangleOid, list[NearCandidate]],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
         barrier_layers: list[str] | None,
         trim_distance: float,
         spatial_reference: Any,
@@ -2196,10 +2235,10 @@ class FillLineGaps:
     def detect_illegal_targets(
         self,
         *,
-        dangle_parent: dict[int, int],
+        dangle_parent: dict[DangleOid, ParentId],
         target_layers: list[str],
         topology: TopologyModel,
-    ) -> dict[int, dict[str, set[int]]]:
+    ) -> _IllegalTargets:
         """
         illegal[parent_id][dataset_key] -> set(objectid)
 
@@ -2210,7 +2249,7 @@ class FillLineGaps:
         Propagation:
         - Scope-dependent, using topology connectivity ids (not local BFS adjacency).
         """
-        illegal: dict[int, dict[str, set[int]]] = {}
+        illegal: _IllegalTargets = {}
 
         self._illegal_self_line(
             illegal=illegal,
@@ -2235,7 +2274,7 @@ class FillLineGaps:
     def _propagate_external_illegal_by_scope(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
+        illegal: _IllegalTargets,
         topology: TopologyModel,
     ) -> None:
         scope = topology.scope
@@ -2297,8 +2336,8 @@ class FillLineGaps:
     def _illegal_self_line(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
-        parent_ids: set[int],
+        illegal: _IllegalTargets,
+        parent_ids: set[ParentId],
     ) -> None:
         lines_key = self._dataset_key(self.lines_copy)
         for pid in parent_ids:
@@ -2307,10 +2346,10 @@ class FillLineGaps:
     def _illegal_connected_features(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
+        illegal: _IllegalTargets,
         target_layers: list[str],
-    ) -> dict[int, set[int]]:
-        adjacency: dict[int, set[int]] = {}
+    ) -> dict[ParentId, set[ParentId]]:
+        adjacency: dict[ParentId, set[ParentId]] = {}
 
         arcpy.management.FeatureVerticesToPoints(
             self.lines_copy, self.conn_endpoints, "BOTH_ENDS"
@@ -2402,9 +2441,9 @@ class FillLineGaps:
     def _is_illegal(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
-        parent_id: int,
-        target_fc_key: str,
+        illegal: _IllegalTargets,
+        parent_id: ParentId,
+        target_fc_key: DatasetKey,
         target_oid: int,
     ) -> bool:
         ds = illegal.get(int(parent_id))
@@ -2415,9 +2454,9 @@ class FillLineGaps:
     def _parents_share_illegal_target(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
-        a_parent: int,
-        b_parent: int,
+        illegal: _IllegalTargets,
+        a_parent: ParentId,
+        b_parent: ParentId,
     ) -> bool:
         """
         Your constraint: dangle-pairs must not share an illegal target object.
@@ -2442,8 +2481,8 @@ class FillLineGaps:
         self,
         *,
         candidates_sorted: list[NearCandidate],
-        lines_fc_keys: set[str],
-        other_parent_id: int,
+        lines_fc_keys: set[DatasetKey],
+        other_parent_id: ParentId,
         base_tol: float,
     ) -> Optional[NearCandidate]:
         """
@@ -2487,14 +2526,14 @@ class FillLineGaps:
         self,
         *,
         near_table: str,
-        dangles_fc_key: str,
-        lines_copy_key: str,
-        target_self_key: str,
-        lines_copy_oid_to_orig: dict[int, int],
-        target_self_oid_to_orig: dict[int, int],
-    ) -> dict[int, list[NearCandidate]]:
+        dangles_fc_key: DatasetKey,
+        lines_copy_key: DatasetKey,
+        target_self_key: DatasetKey,
+        lines_copy_oid_to_orig: dict[int, ParentId],
+        target_self_oid_to_orig: dict[int, ParentId],
+    ) -> dict[DangleOid, list[NearCandidate]]:
 
-        grouped: dict[int, list[NearCandidate]] = {}
+        grouped: dict[DangleOid, list[NearCandidate]] = {}
 
         # Canonical key for “input lines”
         lines_key = self._dataset_key(self.lines_copy)
@@ -2557,12 +2596,12 @@ class FillLineGaps:
     def _candidate_is_legal(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
-        dangle_parent: dict[int, int],
-        dangles_fc_key: str,
-        lines_fc_key: str,
-        line_like_ds_keys: set[str],
-        parent_id: int,
+        illegal: _IllegalTargets,
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_fc_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+        line_like_ds_keys: set[DatasetKey],
+        parent_id: ParentId,
         cand: NearCandidate,
         base_tol: float,
         dangle_candidate_tol: float,
@@ -2633,12 +2672,12 @@ class FillLineGaps:
     def _candidate_rejection_reason(
         self,
         *,
-        illegal: dict[int, dict[str, set[int]]],
-        dangle_parent: dict[int, int],
-        dangles_fc_key: str,
-        lines_fc_key: str,
-        line_like_ds_keys: set[str],
-        parent_id: int,
+        illegal: _IllegalTargets,
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_fc_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+        line_like_ds_keys: set[DatasetKey],
+        parent_id: ParentId,
         cand: NearCandidate,
         base_tol: float,
         dangle_candidate_tol: float,
@@ -2690,10 +2729,10 @@ class FillLineGaps:
     def _resolve_target_parent_id(
         self,
         cand: NearCandidate,
-        dangle_parent: dict[int, int],
-        dangles_fc_key: str,
-        lines_fc_key: str,
-    ) -> Optional[int]:
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_fc_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+    ) -> Optional[ParentId]:
         """Return the target parent original ID for a candidate, or None for external targets."""
         ds_key = cand.near_fc_key
         near_fid = cand.near_fid
@@ -2706,18 +2745,18 @@ class FillLineGaps:
     def _assess_angle(
         self,
         *,
-        src_parent_id: int,
+        src_parent_id: ParentId,
         dangle_x: float,
         dangle_y: float,
         src_angle_deg: Optional[float],
         cand: NearCandidate,
-        dangles_fc_key: str,
-        lines_fc_key: str,
-        dangle_parent: dict[int, int],
-        dangle_xy: dict[int, tuple[float, float]],
-        polyline_by_parent: dict[int, Any],
-        polyline_by_external: dict[str, dict[int, Any]],
-        is_external_line_like: dict[str, bool],
+        dangles_fc_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+        dangle_parent: dict[DangleOid, ParentId],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        polyline_by_parent: dict[ParentId, Any],
+        polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        is_external_line_like: dict[DatasetKey, bool],
         dangle_xys_by_parent: Optional[_DangleXYsByParent] = None,
     ) -> AngleAssessment:
         ds_key = cand.near_fc_key
@@ -2975,11 +3014,11 @@ class FillLineGaps:
     def _pair_token_from_candidate(
         self,
         *,
-        dangle_parent: dict[int, int],
-        dangles_fc_key: str,
-        lines_fc_keys: set[str],
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_fc_key: DatasetKey,
+        lines_fc_keys: set[DatasetKey],
         cand: NearCandidate,
-    ) -> Optional[int]:
+    ) -> Optional[ParentId]:
         """
         Returns the *other parent line id* if this candidate represents “the other side”
         of a potential dangle pair (either via dangle feature or via line feature).
@@ -3000,11 +3039,11 @@ class FillLineGaps:
         self,
         *,
         candidates_sorted: list[NearCandidate],
-        illegal: dict[int, dict[str, set[int]]],
-        dangle_parent: dict[int, int],
-        dangles_fc_key: str,
-        lines_fc_key: str,
-        parent_id: int,
+        illegal: _IllegalTargets,
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_fc_key: DatasetKey,
+        lines_fc_key: DatasetKey,
+        parent_id: ParentId,
         base_tol: float,
         topology: TopologyModel | None = None,
     ) -> Optional[NearCandidate]:
@@ -3028,9 +3067,9 @@ class FillLineGaps:
         self,
         *,
         candidates_sorted: list[NearCandidate],
-        dangles_fc_key: str,
-        dangle_parent: dict[int, int],
-        target_parent_id: int,
+        dangles_fc_key: DatasetKey,
+        dangle_parent: dict[DangleOid, ParentId],
+        target_parent_id: ParentId,
         dangle_tol: float,
     ) -> Optional[NearCandidate]:
         """
@@ -3061,11 +3100,11 @@ class FillLineGaps:
     def _best_dangle_for_parent_towards_target_parent(
         self,
         *,
-        parent_id: int,
-        target_parent_id: int,
-        parent_to_dangles: dict[int, list[int]],
-        per_dangle: dict[int, dict],
-    ) -> int | None:
+        parent_id: ParentId,
+        target_parent_id: ParentId,
+        parent_to_dangles: dict[ParentId, list[DangleOid]],
+        per_dangle: dict[DangleOid, dict],
+    ) -> DangleOid | None:
         """
         Choose the dangle on `parent_id` that is most suitable for pairing with `target_parent_id`.
 
@@ -3103,8 +3142,8 @@ class FillLineGaps:
         self,
         *,
         candidates_sorted: list[NearCandidate],
-        dangles_fc_key: str,
-        other_dangle_oid: int,
+        dangles_fc_key: DatasetKey,
+        other_dangle_oid: DangleOid,
         dangle_tol: float,
     ) -> Optional[NearCandidate]:
         """
@@ -3124,10 +3163,10 @@ class FillLineGaps:
     def _best_dangle_for_parent(
         self,
         *,
-        parent_id: int,
-        parent_to_dangles: dict[int, list[int]],
-        per_dangle: dict[int, dict],
-    ) -> int | None:
+        parent_id: ParentId,
+        parent_to_dangles: dict[ParentId, list[DangleOid]],
+        per_dangle: dict[DangleOid, dict],
+    ) -> DangleOid | None:
         """
         Choose which dangle (of possibly many on the same parent line) should represent
         this parent for default / non-pair behavior.
@@ -3257,8 +3296,8 @@ class FillLineGaps:
 
         # External polyline caches and line-type map, keyed by dataset_key(layer).
         # Built before candidate filtering so line_like_ds_keys is available.
-        polyline_by_external: dict[str, dict[int, Any]] = {}
-        is_external_line_like: dict[str, bool] = {}
+        polyline_by_external: dict[DatasetKey, dict[int, Any]] = {}
+        is_external_line_like: dict[DatasetKey, bool] = {}
 
         line_keys = (
             self._line_dataset_keys()
@@ -3287,10 +3326,10 @@ class FillLineGaps:
         # ds_keys for line-like targets that receive the expanded tolerance.
         # Self-lines are included only when fill_gaps_on_self is active (otherwise no
         # candidates with lines_key appear in the near table anyway).
-        line_like_external_ds_keys: set[str] = {
+        line_like_external_ds_keys: set[DatasetKey] = {
             ds_key for ds_key, is_line in is_external_line_like.items() if is_line
         }
-        line_like_ds_keys: set[str] = line_like_external_ds_keys.copy()
+        line_like_ds_keys: set[DatasetKey] = line_like_external_ds_keys.copy()
         if self.fill_gaps_on_self:
             line_like_ds_keys.add(lines_key)
 
@@ -3425,7 +3464,7 @@ class FillLineGaps:
         # Best line parent per dangle (angle-aware)
         # Used by edge-case bonus detection.
         # ----------------------------
-        best_line_parent_by_dangle: dict[int, int] = {}
+        best_line_parent_by_dangle: dict[DangleOid, ParentId] = {}
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             parent_id = int(parent_id_by_dangle[dangle_oid])
@@ -3688,24 +3727,24 @@ class FillLineGaps:
     def _filter_legal_candidates(
         self,
         *,
-        grouped: dict[int, list[NearCandidate]],
-        dangle_parent: dict[int, int],
+        grouped: dict[DangleOid, list[NearCandidate]],
+        dangle_parent: dict[DangleOid, ParentId],
         illegal: _IllegalTargets,
-        dangles_key: str,
-        lines_key: str,
-        line_like_ds_keys: set[str],
+        dangles_key: DatasetKey,
+        lines_key: DatasetKey,
+        line_like_ds_keys: set[DatasetKey],
         base_tol: float,
         dangle_tol: float,
         topology: TopologyModel,
         collect_diags: bool,
-        directed_source_illegal_oids: set[int],
-    ) -> tuple[dict[int, list[NearCandidate]], dict[int, int], list[_CandidateIllegalA]]:
+        directed_source_illegal_oids: set[DangleOid],
+    ) -> tuple[dict[DangleOid, list[NearCandidate]], dict[DangleOid, ParentId], list[_CandidateIllegalA]]:
         """Dangle filtering: collect legal candidates per dangle.
 
         Returns (legal_rows_by_dangle, parent_id_by_dangle, step1a_illegal).
         """
-        legal_rows_by_dangle: dict[int, list[NearCandidate]] = {}
-        parent_id_by_dangle: dict[int, int] = {}
+        legal_rows_by_dangle: dict[DangleOid, list[NearCandidate]] = {}
+        parent_id_by_dangle: dict[DangleOid, ParentId] = {}
         _step1a_illegal: list[_CandidateIllegalA] = []
 
         for dangle_oid in sorted(grouped.keys()):
@@ -3777,23 +3816,23 @@ class FillLineGaps:
     def _select_dangle_proposals(
         self,
         *,
-        legal_rows_by_dangle: dict[int, list[NearCandidate]],
-        parent_id_by_dangle: dict[int, int],
-        dangle_xy: dict[int, tuple[float, float]],
-        dangles_key: str,
-        lines_key: str,
-        line_like_ds_keys: set[str],
-        line_like_external_ds_keys: set[str],
+        legal_rows_by_dangle: dict[DangleOid, list[NearCandidate]],
+        parent_id_by_dangle: dict[DangleOid, ParentId],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        dangles_key: DatasetKey,
+        lines_key: DatasetKey,
+        line_like_ds_keys: set[DatasetKey],
+        line_like_external_ds_keys: set[DatasetKey],
         base_tol: float,
-        polyline_by_parent: dict[int, Any],
-        polyline_by_external: dict[str, dict[int, Any]],
-        is_external_line_like: dict[str, bool],
-        best_line_parent_by_dangle: dict[int, int],
-        dangle_parent: dict[int, int],
+        polyline_by_parent: dict[ParentId, Any],
+        polyline_by_external: dict[DatasetKey, dict[int, Any]],
+        is_external_line_like: dict[DatasetKey, bool],
+        best_line_parent_by_dangle: dict[DangleOid, ParentId],
+        dangle_parent: dict[DangleOid, ParentId],
         topology: TopologyModel,
         collect_diags: bool,
     ) -> tuple[
-        dict[int, _DangleProposal],
+        dict[DangleOid, _DangleProposal],
         _NormZByDangle,
         list[_CandidateIllegalB],
         list[_CandidateScored],
@@ -3802,8 +3841,8 @@ class FillLineGaps:
 
         Returns (_dangle_proposals, dangle_norm_z_by_dangle, step1b_illegal, step1b_scored).
         """
-        _dangle_proposals: dict[int, _DangleProposal] = {}
-        dangle_norm_z_by_dangle: dict[int, Optional[float]] = {}
+        _dangle_proposals: dict[DangleOid, _DangleProposal] = {}
+        dangle_norm_z_by_dangle: _NormZByDangle = {}
         _step1b_illegal: list[_CandidateIllegalB] = []
         _step1b_scored: list[_CandidateScored] = []
 
@@ -3873,8 +3912,7 @@ class FillLineGaps:
                 if _d_xy is not None:
                     _dangle_xys_by_parent.setdefault(int(_d_parent), []).append(_d_xy)
 
-            # (_ProposalScore, cand, raw_dist, best_fit, bonus, assess, norm_z, end_z)
-            scored_candidates: list[tuple[Any, ...]] = []
+            scored_candidates: list[_ScoredCandidateItem] = []
 
             for _cand_idx, cand in enumerate(legal_rows):
                 assess = self._assess_angle(
@@ -3951,7 +3989,7 @@ class FillLineGaps:
                         assess.allow_extra_dangle
                     )
 
-                raw_distance, effective_distance, bonus_applied, _score_unused = (
+                raw_distance, effective_distance, bonus_applied = (
                     self._candidate_score_details(
                         dangle_oid=dangle_oid,
                         parent_id=parent_id,
@@ -3998,17 +4036,17 @@ class FillLineGaps:
                 )
 
                 scored_candidates.append(
-                    (
-                        dangle_score,
-                        cand,
-                        float(raw_distance),
-                        float(effective_for_scoring),
-                        bool(bonus_applied),
-                        assess,
-                        _norm_z,
-                        _eff_norm_dist,
-                        _norm_angle,
-                        end_z_by_cand_index.get(_cand_idx),  # per-candidate end_z
+                    _ScoredCandidateItem(
+                        score=dangle_score,
+                        cand=cand,
+                        raw_distance=float(raw_distance),
+                        effective_for_scoring=float(effective_for_scoring),
+                        bonus_applied=bool(bonus_applied),
+                        assess=assess,
+                        norm_z=_norm_z,
+                        norm_dist=_eff_norm_dist,
+                        norm_angle=_norm_angle,
+                        end_z=end_z_by_cand_index.get(_cand_idx),
                     )
                 )
 
@@ -4017,51 +4055,38 @@ class FillLineGaps:
 
             winner_item = min(
                 scored_candidates,
-                key=lambda item: (item[0].composite, item[0].bonus_rank, item[2]),
+                key=lambda item: (item.score.composite, item.score.bonus_rank, item.raw_distance),
             )
-            (
-                winner_dangle_score,
-                chosen,
-                raw_distance,
-                effective_distance_for_scoring,
-                bonus_applied,
-                chosen_assess,
-                winner_norm_z,
-                _winner_norm_dist,
-                _winner_norm_angle,
-                winner_end_z,
-            ) = winner_item
+            winner_dangle_score = winner_item.score
+            chosen = winner_item.cand
+            raw_distance = winner_item.raw_distance
+            bonus_applied = winner_item.bonus_applied
+            chosen_assess = winner_item.assess
+            winner_norm_z = winner_item.norm_z
+            winner_end_z = winner_item.end_z
 
             if collect_diags:
-                for sc_tuple in scored_candidates:
-                    (
-                        sc_score,
-                        sc_cand,
-                        sc_raw,
-                        sc_best_fit,
-                        sc_bonus,
-                        sc_assess,
-                        sc_norm_z,
-                        sc_norm_dist,
-                        sc_norm_angle,
-                        sc_end_z,
-                    ) = sc_tuple
+                for sc_item in scored_candidates:
                     _step1b_scored.append(
                         _CandidateScored(
                             dangle_oid=dangle_oid,
                             parent_id=parent_id,
-                            cand=sc_cand,
-                            assess=sc_assess,
-                            raw_distance=float(sc_raw),
-                            best_fit=float(sc_best_fit),
-                            bonus=bool(sc_bonus),
-                            is_local_winner=sc_tuple is winner_item,
-                            score_tuple=(sc_score.composite, sc_score.bonus_rank, sc_raw),
-                            norm_dist=float(sc_norm_dist),
-                            norm_angle=sc_norm_angle,
-                            dangle_norm_z=sc_norm_z,
+                            cand=sc_item.cand,
+                            assess=sc_item.assess,
+                            raw_distance=float(sc_item.raw_distance),
+                            best_fit=float(sc_item.effective_for_scoring),
+                            bonus=bool(sc_item.bonus_applied),
+                            is_local_winner=sc_item is winner_item,
+                            score_tuple=(
+                                sc_item.score.composite,
+                                sc_item.score.bonus_rank,
+                                sc_item.raw_distance,
+                            ),
+                            norm_dist=float(sc_item.norm_dist),
+                            norm_angle=sc_item.norm_angle,
+                            dangle_norm_z=sc_item.norm_z,
                             start_z=start_z,
-                            end_z=sc_end_z,
+                            end_z=sc_item.end_z,
                         )
                     )
 
@@ -4139,8 +4164,8 @@ class FillLineGaps:
 
     def _run_connection_normalization(
         self,
-        dangle_proposals: dict[int, _DangleProposal],
-    ) -> tuple[dict[int, _ConnectionProposal], _NormZByDangle]:
+        dangle_proposals: dict[DangleOid, _DangleProposal],
+    ) -> tuple[dict[DangleOid, _ConnectionProposal], _NormZByDangle]:
         """Connection normalization: re-normalize Z within each undirected A↔B connection group.
 
         Returns (connection_proposals_by_dangle, connection_norm_z_by_dangle).
@@ -4150,8 +4175,8 @@ class FillLineGaps:
         for p in active:
             _by_connection_for_normalization.setdefault(p.ctx.pair_key, []).append(p)
 
-        connection_proposals_by_dangle: dict[int, _ConnectionProposal] = {}
-        connection_norm_z_by_dangle: dict[int, Optional[float]] = {}
+        connection_proposals_by_dangle: dict[DangleOid, _ConnectionProposal] = {}
+        connection_norm_z_by_dangle: _NormZByDangle = {}
         for _pair_group in _by_connection_for_normalization.values():
             _group_end_z = [p.ctx.end_z for p in _pair_group]
             for p in _pair_group:
@@ -4177,12 +4202,15 @@ class FillLineGaps:
     def _run_connection_selection(
         self,
         *,
-        connection_proposals_by_dangle: dict[int, _ConnectionProposal],
+        connection_proposals_by_dangle: dict[DangleOid, _ConnectionProposal],
         directed_edges: set[tuple[EntityKey, EntityKey]],
-        dangle_mutual_oids: set[int],
+        dangle_mutual_oids: set[DangleOid],
         collect_diags: bool,
-    ) -> tuple[list[_ConnectionWithSource], set[int]]:
+    ) -> tuple[list[_ConnectionProposal], set[DangleOid]]:
         """Connection selection: one winner per undirected connection.
+
+        Stamps the authoritative gap_source onto each winner via dataclasses.replace
+        before returning; all returned proposals have gap_source non-None.
 
         Returns (_connection_proposals, connection_loser_oids).
         """
@@ -4190,7 +4218,7 @@ class FillLineGaps:
         for p in connection_proposals_by_dangle.values():
             by_connection.setdefault(p.ctx.pair_key, []).append(p)
 
-        _connection_proposals: list[_ConnectionWithSource] = []
+        _connection_proposals: list[_ConnectionProposal] = []
         for pair_key in sorted(by_connection.keys()):
             group = by_connection[pair_key]
             winner = min(group, key=lambda pr: pr.sort_key())
@@ -4211,12 +4239,12 @@ class FillLineGaps:
             else:
                 gap_source = GapSource.DEFAULT
 
-            _connection_proposals.append((winner, gap_source))
+            _connection_proposals.append(replace(winner, gap_source=gap_source))
 
-        connection_loser_oids: set[int] = set()
+        connection_loser_oids: set[DangleOid] = set()
         if collect_diags:
             _stage_a_winner_oids = {
-                int(prop.ctx.dangle_oid) for prop, _ in _connection_proposals
+                int(prop.ctx.dangle_oid) for prop in _connection_proposals
             }
             connection_loser_oids.update(
                 int(p.ctx.dangle_oid)
@@ -4228,16 +4256,16 @@ class FillLineGaps:
 
     def _run_global_normalization(
         self,
-        connection_proposals: list[_ConnectionWithSource],
-    ) -> tuple[list[_GlobalWithSource], _NormZByDangle]:
+        connection_proposals: list[_ConnectionProposal],
+    ) -> tuple[list[_GlobalProposal], _NormZByDangle]:
         """Global normalization: re-normalize Z across all connection winners.
 
         Returns (_global_winners, global_norm_z_by_dangle).
         """
-        _all_end_z_global = [p.ctx.end_z for p, _ in connection_proposals]
-        _global_winners: list[_GlobalWithSource] = []
-        global_norm_z_by_dangle: dict[int, Optional[float]] = {}
-        for n_prop, gap_source in connection_proposals:
+        _all_end_z_global = [p.ctx.end_z for p in connection_proposals]
+        _global_winners: list[_GlobalProposal] = []
+        global_norm_z_by_dangle: _NormZByDangle = {}
+        for n_prop in connection_proposals:
             glob_norm_z = self._normalize_z_within(_all_end_z_global, n_prop.ctx.end_z)
             glob_score = _ProposalScore(
                 composite=self._compute_best_fit_score(
@@ -4251,7 +4279,7 @@ class FillLineGaps:
                 norm_z=glob_norm_z,
             )
             g_prop = _GlobalProposal.from_network(n_prop, score=glob_score)
-            _global_winners.append((g_prop, gap_source))
+            _global_winners.append(g_prop)
             global_norm_z_by_dangle[int(n_prop.ctx.dangle_oid)] = glob_norm_z
 
         return _global_winners, global_norm_z_by_dangle
@@ -4259,21 +4287,21 @@ class FillLineGaps:
     def _run_kruskal(
         self,
         *,
-        global_winners: list[_GlobalWithSource],
+        global_winners: list[_GlobalProposal],
         topology: TopologyModel,
         collect_diags: bool,
         trimmed_connector_cache: dict[tuple[int, str, int], Any],
         crossing_spatial_reference: Any,  # arcpy.SpatialReference | None
     ) -> tuple[
-        list[_GlobalWithSource],
-        set[int],  # accepted_dangle_oids
-        set[int],  # kruskal_rejected_oids (cycle-based)
-        set[int],  # kruskal_crossing_rejected_oids
-        dict[int, GapSource],  # gap_source_by_dangle
+        list[_GlobalProposal],
+        set[DangleOid],  # accepted_dangle_oids
+        set[DangleOid],  # kruskal_rejected_oids (cycle-based)
+        set[DangleOid],  # kruskal_crossing_rejected_oids
+        dict[DangleOid, GapSource],  # gap_source_by_dangle
         list[
-            _AcceptedConnectorRaw
+            AcceptedConnectorRaw
         ],  # accepted_connector_raw (for resnap crossing re-check)
-        dict[int, int],  # kruskal_rank_by_dangle_oid
+        dict[DangleOid, int],  # kruskal_rank_by_dangle_oid
     ]:
         """Global selection: Kruskal cycle prevention across accepted connections.
 
@@ -4305,18 +4333,18 @@ class FillLineGaps:
         """
         reject_crossing = crossing_spatial_reference is not None
         scope = topology.scope
-        _global_proposals: list[_GlobalWithSource] = []
-        kruskal_crossing_rejected_oids: set[int] = set()
+        _global_proposals: list[_GlobalProposal] = []
+        kruskal_crossing_rejected_oids: set[DangleOid] = set()
         accepted_keys: set[tuple[int, str, int]] = set()
-        accepted_connector_raw: list[_AcceptedConnectorRaw] = []
-        kruskal_rank_by_dangle_oid: dict[int, int] = {}
+        accepted_connector_raw: list[AcceptedConnectorRaw] = []
+        kruskal_rank_by_dangle_oid: dict[DangleOid, int] = {}
         rank_counter = 0
 
         # --- Pre-loop: build candidate-vs-candidate conflict lookup ---
         conflict_lookup: dict[tuple[int, str, int], set[tuple[int, str, int]]] = {}
         if reject_crossing:
             _kruskal_cands: list[tuple[tuple[int, str, int], Any]] = []
-            for prop, _ in global_winners:
+            for prop in global_winners:
                 _key = (
                     int(prop.ctx.dangle_oid),
                     str(prop.ctx.near_fc_key),
@@ -4345,9 +4373,9 @@ class FillLineGaps:
                             conflict_lookup.setdefault(_key_in, set()).add(_key_near)
                 arcpy.management.Delete(_kruskal_fc)
 
-        def _accept(prop: _GlobalProposal, gap_source: GapSource) -> None:
+        def _accept(prop: _GlobalProposal) -> None:
             nonlocal rank_counter
-            _global_proposals.append((prop, gap_source))
+            _global_proposals.append(prop)
             if reject_crossing:
                 rank_counter += 1
                 d_oid = int(prop.ctx.dangle_oid)
@@ -4355,12 +4383,12 @@ class FillLineGaps:
                 _key = (d_oid, str(prop.ctx.near_fc_key), int(prop.ctx.near_fid))
                 accepted_keys.add(_key)
                 accepted_connector_raw.append(
-                    (
-                        d_oid,
-                        float(prop.ctx.dangle_x),
-                        float(prop.ctx.dangle_y),
-                        float(prop.ctx.near_x),
-                        float(prop.ctx.near_y),
+                    AcceptedConnectorRaw(
+                        dangle_oid=d_oid,
+                        dangle_x=float(prop.ctx.dangle_x),
+                        dangle_y=float(prop.ctx.dangle_y),
+                        near_x=float(prop.ctx.near_x),
+                        near_y=float(prop.ctx.near_y),
                     )
                 )
 
@@ -4398,40 +4426,36 @@ class FillLineGaps:
                     ("component", int(cid)),
                     ("optional_candidate", str(cand_ds_key), int(oid)),
                 )
-            for prop, gap_source in sorted(
-                global_winners, key=lambda t: t[0].sort_key()
-            ):
+            for prop in sorted(global_winners, key=lambda p: p.sort_key()):
                 if uf.find(prop.ctx.src_node) == uf.find(prop.ctx.tgt_node):
                     continue
                 if _crossing_blocked(prop):
                     kruskal_crossing_rejected_oids.add(int(prop.ctx.dangle_oid))
                     continue
                 uf.union(prop.ctx.src_node, prop.ctx.tgt_node)
-                _accept(prop, gap_source)
+                _accept(prop)
         else:
             # NONE / DIRECT_CONNECTION: no cycle check, crossing check only.
-            for prop, gap_source in sorted(
-                global_winners, key=lambda t: t[0].sort_key()
-            ):
+            for prop in sorted(global_winners, key=lambda p: p.sort_key()):
                 if _crossing_blocked(prop):
                     kruskal_crossing_rejected_oids.add(int(prop.ctx.dangle_oid))
                     continue
-                _accept(prop, gap_source)
+                _accept(prop)
 
-        accepted_dangle_oids: set[int] = set()
-        kruskal_rejected_oids: set[int] = set()
-        gap_source_by_dangle: dict[int, GapSource] = {}
+        accepted_dangle_oids: set[DangleOid] = set()
+        kruskal_rejected_oids: set[DangleOid] = set()
+        gap_source_by_dangle: dict[DangleOid, GapSource] = {}
         if collect_diags and _global_proposals:
-            _accepted_oids = {int(prop.ctx.dangle_oid) for prop, _ in _global_proposals}
+            _accepted_oids = {int(prop.ctx.dangle_oid) for prop in _global_proposals}
             accepted_dangle_oids.update(_accepted_oids)
             kruskal_rejected_oids.update(
                 int(prop.ctx.dangle_oid)
-                for prop, _ in global_winners
+                for prop in global_winners
                 if int(prop.ctx.dangle_oid) not in _accepted_oids
                 and int(prop.ctx.dangle_oid) not in kruskal_crossing_rejected_oids
             )
             gap_source_by_dangle.update(
-                {int(prop.ctx.dangle_oid): gs for prop, gs in _global_proposals}
+                {int(prop.ctx.dangle_oid): prop.gap_source for prop in _global_proposals}
             )
 
         return (
@@ -4446,7 +4470,7 @@ class FillLineGaps:
 
     def _identify_resnap_captures(
         self,
-        global_proposals: list[_GlobalWithSource],
+        global_proposals: list[_GlobalProposal],
     ) -> list[_ResnappedCapture]:
         """Identify connections whose near-point may need re-resolving after snap.
 
@@ -4457,13 +4481,13 @@ class FillLineGaps:
           3. A's near-point lies on B's last segment — checked in _resnap_connections
              using post-apply geometry (this block is a cheap pre-filter only).
         """
-        snap_source_parents: set[int] = {
+        snap_source_parents: set[ParentId] = {
             int(prop.ctx.src_parent_id)
-            for prop, gap_source in global_proposals
-            if gap_source is GapSource.PAIR_DANGLE
+            for prop in global_proposals
+            if prop.gap_source is GapSource.PAIR_DANGLE
         }
         resnap_captures: list[_ResnappedCapture] = []
-        for prop, gap_source in global_proposals:
+        for prop in global_proposals:
             tp = prop.ctx.target_parent_id
             if tp is None or int(tp) not in snap_source_parents:
                 continue
@@ -4473,7 +4497,7 @@ class FillLineGaps:
                     dangle_oid=int(prop.ctx.dangle_oid),
                     forced_target_parent=int(tp),
                     proposal=prop,
-                    gap_source=gap_source,
+                    gap_source=prop.gap_source,
                 )
             )
         return resnap_captures
@@ -4481,12 +4505,12 @@ class FillLineGaps:
     def _recheck_resnap_crossings(
         self,
         *,
-        resnap_plan: dict[int, PlanEntry],
-        accepted_connector_raw: list[_AcceptedConnectorRaw],
-        kruskal_rank_by_dangle_oid: dict[int, int],
+        resnap_plan: dict[ParentId, PlanEntry],
+        accepted_connector_raw: list[AcceptedConnectorRaw],
+        kruskal_rank_by_dangle_oid: dict[DangleOid, int],
         trim_distance: float,
         spatial_reference: Any,
-    ) -> tuple[dict[int, PlanEntry], set[int], set[int], set[int]]:
+    ) -> tuple[dict[ParentId, PlanEntry], set[DangleOid], set[DangleOid], set[DangleOid]]:
         """Re-check resnap captures against accepted connector geometries.
 
         Called after _resnap_connections resolves final geometry for deferred
@@ -4531,17 +4555,17 @@ class FillLineGaps:
 
         # Build trimmed accepted connectors: key = dangle_oid.
         accepted_cands: list[tuple[Any, Any]] = []
-        for acc_doid, ax, ay, bx, by in accepted_connector_raw:
+        for acc in accepted_connector_raw:
             trimmed = self._build_trimmed_connector(
-                from_x=ax,
-                from_y=ay,
-                to_x=bx,
-                to_y=by,
+                from_x=acc.dangle_x,
+                from_y=acc.dangle_y,
+                to_x=acc.near_x,
+                to_y=acc.near_y,
                 trim_distance=trim_distance,
                 spatial_reference=spatial_reference,
             )
             if trimmed is not None:
-                accepted_cands.append((acc_doid, trimmed))
+                accepted_cands.append((acc.dangle_oid, trimmed))
 
         if not accepted_cands:
             return resnap_plan, set(), set(), set()
@@ -4561,7 +4585,7 @@ class FillLineGaps:
         )
 
         # {parent_id: set of conflicting accepted dangle_oids}
-        conflicts_by_parent: dict[int, set[int]] = {}
+        conflicts_by_parent: dict[ParentId, set[DangleOid]] = {}
         for rsnp_oid, acc_oids in self._find_crossing_pairs(
             _resnap_fc, [_accepted_fc]
         ).items():
@@ -4576,9 +4600,9 @@ class FillLineGaps:
         arcpy.management.Delete(_resnap_fc)
         arcpy.management.Delete(_accepted_fc)
 
-        resnap_crossing_rejected_oids: set[int] = set()
-        resnap_crossing_displaced_oids: set[int] = set()
-        resnap_crossing_winner_oids: set[int] = set()
+        resnap_crossing_rejected_oids: set[DangleOid] = set()
+        resnap_crossing_displaced_oids: set[DangleOid] = set()
+        resnap_crossing_winner_oids: set[DangleOid] = set()
 
         for parent_id, entry in resnap_plan.items():
             if entry.skip:
@@ -4613,12 +4637,12 @@ class FillLineGaps:
 
     def _assemble_plan_entries(
         self,
-        global_proposals: list[_GlobalWithSource],
+        global_proposals: list[_GlobalProposal],
     ) -> PlanByParent:
         """Assemble plan_by_parent from accepted global proposals."""
-        tmp: dict[int, list[tuple[tuple[Any, ...], PlanEntry]]] = {}
+        tmp: dict[ParentId, list[tuple[tuple[Any, ...], PlanEntry]]] = {}
 
-        for prop, gap_source in sorted(global_proposals, key=lambda t: t[0].sort_key()):
+        for prop in sorted(global_proposals, key=lambda p: p.sort_key()):
             # near_dist is filled from prop.ctx.raw_distance so the NearCandidate is
             # self-consistent; near_fc_key_raw is unused downstream so we reuse the
             # normalized key.
@@ -4636,7 +4660,7 @@ class FillLineGaps:
                 dangle_x=float(prop.ctx.dangle_x),
                 dangle_y=float(prop.ctx.dangle_y),
                 chosen=chosen,
-                gap_source=gap_source,
+                gap_source=prop.gap_source,
                 bonus_applied=prop.ctx.bonus_applied,
                 assess=prop.ctx.assess,
                 best_fit_score=prop.score.composite,
@@ -4657,12 +4681,12 @@ class FillLineGaps:
     def _make_base_diag_fields(
         self,
         cand: NearCandidate,
-        dangle_oid: int,
-        parent_id: int,
+        dangle_oid: DangleOid,
+        parent_id: ParentId,
         xy: tuple[float, float],
-        dangle_parent: dict[int, int],
-        dangles_key: str,
-        lines_key: str,
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_key: DatasetKey,
+        lines_key: DatasetKey,
     ) -> dict:
         """Return the identity fields shared by all three diagnostic assembly branches."""
         return dict(
@@ -4685,10 +4709,10 @@ class FillLineGaps:
         *,
         collect_diags: bool,
         state: _DiagnosticsState,
-        dangle_xy: dict[int, tuple[float, float]],
-        dangle_parent: dict[int, int],
-        dangles_key: str,
-        lines_key: str,
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        dangle_parent: dict[DangleOid, ParentId],
+        dangles_key: DatasetKey,
+        lines_key: DatasetKey,
     ) -> list[CandidateDiagnostic]:
         """Assemble CandidateDiagnostic records from all pipeline state collected during _build_plan."""
         if not collect_diags:
@@ -4933,8 +4957,8 @@ class FillLineGaps:
         *,
         captures: "list[_ResnappedCapture]",
         dangles_fc: str,
-        snap_source_dangle_xy: "dict[int, tuple[float, float]]",
-    ) -> dict[int, PlanEntry]:
+        snap_source_dangle_xy: "dict[ParentId, tuple[float, float]]",
+    ) -> dict[ParentId, PlanEntry]:
         """
         Re-resolve the near-point for connections whose target line endpoint moved
         during _apply_plan (SNAP operations).
@@ -4955,7 +4979,7 @@ class FillLineGaps:
             f"{arcpy.AddFieldDelimiters(self.lines_copy, self.ORIGINAL_ID)}"
             f" IN ({','.join(map(str, sorted(forced_target_parents)))})"
         )
-        v_prev_by_parent: dict[int, tuple[float, float]] = {}
+        v_prev_by_parent: dict[ParentId, tuple[float, float]] = {}
         with arcpy.da.SearchCursor(
             self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"], where_l
         ) as cur:
@@ -5024,7 +5048,7 @@ class FillLineGaps:
         arcpy.management.MakeFeatureLayer(self.lines_copy, resnap_lines_lyr, where_l2)
 
         lines_oid_field = arcpy.Describe(resnap_lines_lyr).OIDFieldName
-        near_oid_to_parent: dict[int, int] = {}
+        near_oid_to_parent: dict[int, ParentId] = {}  # key is raw arcpy OID
         with arcpy.da.SearchCursor(
             resnap_lines_lyr, [lines_oid_field, self.ORIGINAL_ID]
         ) as cur:
@@ -5073,7 +5097,7 @@ class FillLineGaps:
         # --- 4. Build updated plan entries ---
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc)
         lines_key = self._dataset_key(self.lines_copy)
-        out: dict[int, PlanEntry] = {}
+        out: dict[ParentId, PlanEntry] = {}
 
         for cap in filtered:
             hit = best_xy.get((cap.dangle_oid, cap.forced_target_parent))
@@ -5470,7 +5494,7 @@ class FillLineGaps:
         kruskal_rank_by_dangle_oid = result.kruskal_rank_by_dangle_oid
 
         # Capture snap-source dangle endpoints before _apply_plan moves them.
-        snap_source_dangle_xy: dict[int, tuple[float, float]] = {
+        snap_source_dangle_xy: dict[ParentId, tuple[float, float]] = {
             parent_id: (info.dangle_x, info.dangle_y)
             for parent_id, entries in plan.items()
             for info in entries
@@ -5506,9 +5530,9 @@ class FillLineGaps:
                     ),
                 )
             else:
-                resnap_crossing_rejected_oids: set[int] = set()
-                resnap_crossing_displaced_oids: set[int] = set()
-                resnap_crossing_winner_oids: set[int] = set()
+                resnap_crossing_rejected_oids: set[DangleOid] = set()
+                resnap_crossing_displaced_oids: set[DangleOid] = set()
+                resnap_crossing_winner_oids: set[DangleOid] = set()
 
             self._apply_plan({pid: [entry] for pid, entry in resnap_plan.items()})
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1086,6 +1086,7 @@ class FillLineGaps:
 
         self.reject_crossing_connectors: bool = bool(adv.reject_crossing_connectors)
         self.crossing_check_spatial_reference = adv.crossing_check_spatial_reference
+        self.barrier_layers: list[str] | None = adv.barrier_layers or None
 
         if (
             self.source_direction_mode
@@ -2039,6 +2040,62 @@ class FillLineGaps:
         arcpy.management.Delete(_cands_fc)
 
         return conflict_keys, trimmed_cache
+
+    def _find_barrier_crossing_keys(
+        self,
+        *,
+        legal_rows_by_dangle: "_Grouped",
+        dangle_xy: dict[int, tuple[float, float]],
+        barrier_layers: list[str] | None,
+        trim_distance: float,
+        spatial_reference: Any,
+    ) -> set[tuple[int, str, int]]:
+        """Return keys of candidates whose trimmed connector crosses a barrier layer.
+
+        Returns an empty set immediately when barrier_layers is None or empty.
+        barrier_layers are never used as snap targets; they only block candidates
+        that cross them.
+        """
+        if not barrier_layers:
+            return set()
+
+        cands_with_keys: list[tuple[Any, Any]] = []
+        for dangle_oid, candidates in legal_rows_by_dangle.items():
+            dangle_oid = int(dangle_oid)
+            xy = dangle_xy.get(dangle_oid)
+            if xy is None:
+                continue
+            from_x, from_y = xy
+            for cand in candidates:
+                key = (dangle_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))
+                trimmed = self._build_trimmed_connector(
+                    from_x=from_x,
+                    from_y=from_y,
+                    to_x=float(cand["near_x"]),
+                    to_y=float(cand["near_y"]),
+                    trim_distance=trim_distance,
+                    spatial_reference=spatial_reference,
+                )
+                if trimmed is not None:
+                    cands_with_keys.append((key, trimmed))
+
+        if not cands_with_keys:
+            return set()
+
+        _fc = "memory/barrier_crossing_check"
+        oid_to_key = self._write_trimmed_cands_fc(
+            cands_with_keys=cands_with_keys,
+            fc_path=_fc,
+            spatial_reference=spatial_reference,
+        )
+        crossing_pairs = self._find_crossing_pairs(_fc, barrier_layers)
+        arcpy.management.Delete(_fc)
+
+        return {
+            key
+            for in_oid in crossing_pairs
+            if (key := oid_to_key.get(in_oid)) is not None
+        }
 
     # ----------------------------
     # Illegal targets detection
@@ -3183,13 +3240,55 @@ class FillLineGaps:
 
         # ----------------------------
         # Crossing conflict pre-filter (last legality check)
-        # Run after all other legality checks so only surviving legal candidates
-        # are written to the temp FC.  The trimmed connector cache is reused in
-        # _run_kruskal for the candidate-vs-candidate crossing check.
+        # Barrier check runs first so the subsequent check against existing
+        # features only processes survivors.  The trimmed connector cache built
+        # by _find_crossing_conflict_keys is reused in _run_kruskal.
         # ----------------------------
+        _crossing_trim = 2.0 * float(self.connectivity_tolerance_meters)
+        _crossing_sr = (
+            arcpy.SpatialReference(self.crossing_check_spatial_reference)
+            if self.crossing_check_spatial_reference is not None
+            else None
+        )
+
+        if self.barrier_layers and legal_rows_by_dangle and _crossing_sr is not None:
+            _barrier_keys = self._find_barrier_crossing_keys(
+                legal_rows_by_dangle=legal_rows_by_dangle,
+                dangle_xy=dangle_xy,
+                barrier_layers=self.barrier_layers,
+                trim_distance=_crossing_trim,
+                spatial_reference=_crossing_sr,
+            )
+            if _barrier_keys:
+                for _dangle_oid in list(legal_rows_by_dangle.keys()):
+                    _parent_id = parent_id_by_dangle[_dangle_oid]
+                    _remaining: list[dict] = []
+                    for _cand in legal_rows_by_dangle[_dangle_oid]:
+                        _cand_key = (
+                            _dangle_oid,
+                            str(_cand["near_fc_key"]),
+                            int(_cand["near_fid"]),
+                        )
+                        if _cand_key in _barrier_keys:
+                            if collect_diags:
+                                _step1a_illegal.append(
+                                    (
+                                        _dangle_oid,
+                                        _parent_id,
+                                        _cand,
+                                        "crosses_barrier_layer",
+                                    )
+                                )
+                        else:
+                            _remaining.append(_cand)
+                    if _remaining:
+                        legal_rows_by_dangle[_dangle_oid] = _remaining
+                    else:
+                        del legal_rows_by_dangle[_dangle_oid]
+                        parent_id_by_dangle.pop(_dangle_oid, None)
+
         trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
-        if self.reject_crossing_connectors and legal_rows_by_dangle:
-            _crossing_sr = arcpy.SpatialReference(self.crossing_check_spatial_reference)
+        if self.reject_crossing_connectors and legal_rows_by_dangle and _crossing_sr is not None:
             # lines_copy provides self-line geometries; external polyline layers
             # whose ds_key is in polyline_by_external were loaded as angle caches.
             _check_layers: list[str] = [self.lines_copy]
@@ -3201,7 +3300,7 @@ class FillLineGaps:
                     legal_rows_by_dangle=legal_rows_by_dangle,
                     dangle_xy=dangle_xy,
                     check_feature_layers=_check_layers,
-                    trim_distance=2.0 * float(self.connectivity_tolerance_meters),
+                    trim_distance=_crossing_trim,
                     spatial_reference=_crossing_sr,
                 )
             )

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -43,6 +43,7 @@ class FillLineGaps:
             adv.increased_tolerance_edge_case_distance_meters
         )
         self.edit_method = logic_config.EditMethod(adv.edit_method)
+        self.propagate_illigal_targets = adv.propagating_illigal_targets
 
         if self.connect_to_features is None and self.fill_gaps_on_self is False:
             raise ValueError(
@@ -340,7 +341,7 @@ class FillLineGaps:
         *,
         dangle_parent: dict[int, int],
         target_layers: list[str],
-    ) -> dict[int, dict[str, set[int]]]:
+    ) -> tuple[dict[int, dict[str, set[int]]], dict[int, set[int]]]:
         """
         illegal[parent_id][dataset_key] -> set(objectid)
 
@@ -354,12 +355,16 @@ class FillLineGaps:
             illegal=illegal,
             parent_ids=set(dangle_parent.values()),
         )
-        self._illegal_connected_features(
+        adjacency = self._illegal_connected_features(
             illegal=illegal,
             target_layers=target_layers,
         )
-
-        return illegal
+        if self.propagate_illigal_targets:
+            self._propagate_external_illegal_within_components(
+                illegal=illegal,
+                adjacency=adjacency,
+            )
+        return illegal, adjacency
 
     def _illegal_self_line(
         self,
@@ -376,13 +381,9 @@ class FillLineGaps:
         *,
         illegal: dict[int, dict[str, set[int]]],
         target_layers: list[str],
-    ) -> None:
-        """
-        Endpoint connectivity:
-          - create BOTH_ENDS points for lines_copy (each carries ORIGINAL_ID)
-          - near-table with radius 0 against the target layers
-          - anything at distance 0 is connected -> illegal
-        """
+    ) -> dict[int, set[int]]:
+        adjacency: dict[int, set[int]] = {}
+
         arcpy.management.FeatureVerticesToPoints(
             self.lines_copy, self.conn_endpoints, "BOTH_ENDS"
         )
@@ -395,11 +396,19 @@ class FillLineGaps:
             for eo, pid in cur:
                 endpoint_parent[int(eo)] = int(pid)
 
+        # IMPORTANT: include full lines_copy for building adjacency/components
+        near_features = list(target_layers)
+        if self.lines_copy not in near_features:
+            near_features.append(self.lines_copy)
+
+        connect_tol_m = 0.02
+        connect_tol = f"{connect_tol_m} Meters"
+
         arcpy.analysis.GenerateNearTable(
             in_features=self.conn_endpoints,
-            near_features=target_layers,
+            near_features=near_features,
             out_table=self.conn_table,
-            search_radius="0 Meters",
+            search_radius=connect_tol,
             location="NO_LOCATION",
             angle="NO_ANGLE",
             closest="ALL",
@@ -407,22 +416,114 @@ class FillLineGaps:
             method="PLANAR",
         )
 
+        lines_key = self._dataset_key(self.lines_copy)
+        line_keys = self._line_dataset_keys()
+
+        lines_copy_key = self._dataset_key(self.lines_copy)
+        target_self_key = self._dataset_key(self.target_self)
+
+        lines_copy_oid_to_orig = self._oid_to_original_id_lookup(self.lines_copy)
+        target_self_oid_to_orig = (
+            self._oid_to_original_id_lookup(self.target_self)
+            if self.fill_gaps_on_self
+            else {}
+        )
+
         fields = [self.F_IN_FID, self.F_NEAR_FID, self.F_NEAR_FC, self.F_NEAR_DIST]
         with arcpy.da.SearchCursor(self.conn_table, fields) as cur:
             for in_fid, near_fid, near_fc, near_dist in cur:
                 if near_fid is None or near_dist is None:
                     continue
-                if float(near_dist) != 0.0:
+
+                if float(near_dist) >= float(connect_tol_m):
                     continue
 
-                pid = endpoint_parent.get(int(in_fid))
-                if pid is None:
+                a_parent = endpoint_parent.get(int(in_fid))
+                if a_parent is None:
                     continue
+                a_parent = int(a_parent)
 
-                ds_key = self._dataset_key(near_fc)
-                illegal.setdefault(int(pid), {}).setdefault(ds_key, set()).add(
-                    int(near_fid)
+                raw_key = self._dataset_key(near_fc)
+                nf_id = int(near_fid)
+
+                # Convert line-like near_fid into ORIGINAL_ID space
+                if raw_key == lines_copy_key:
+                    nf_id = int(lines_copy_oid_to_orig.get(nf_id, nf_id))
+                elif raw_key == target_self_key:
+                    nf_id = int(target_self_oid_to_orig.get(nf_id, nf_id))
+
+                ds_key = self._normalize_target_key(
+                    near_fc_key=raw_key,
+                    lines_key=lines_key,
+                    line_keys=line_keys,
                 )
+
+                illegal.setdefault(a_parent, {}).setdefault(ds_key, set()).add(
+                    int(nf_id)
+                )
+
+                # Build adjacency only for line network connections
+                if ds_key == lines_key:
+                    b_parent = int(nf_id)
+                    if b_parent != a_parent:
+                        adjacency.setdefault(a_parent, set()).add(b_parent)
+                        adjacency.setdefault(b_parent, set()).add(a_parent)
+
+        return adjacency
+
+    def _propagate_external_illegal_within_components(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        adjacency: dict[int, set[int]],
+    ) -> None:
+        """
+        For each connected component of the line network, union external illegal targets
+        and apply to every member.
+
+        External illegal targets = everything except the canonical lines_key (self-line rule).
+        """
+        lines_key = self._dataset_key(self.lines_copy)
+
+        visited: set[int] = set()
+
+        # Ensure we include isolated nodes too
+        all_nodes = set(illegal.keys()) | set(adjacency.keys())
+        for pid in list(all_nodes):
+            pid = int(pid)
+            if pid in visited:
+                continue
+
+            # BFS to get component
+            stack = [pid]
+            component: set[int] = set()
+
+            while stack:
+                cur = int(stack.pop())
+                if cur in visited:
+                    continue
+                visited.add(cur)
+                component.add(cur)
+
+                for nb in adjacency.get(cur, set()):
+                    nb = int(nb)
+                    if nb not in visited:
+                        stack.append(nb)
+
+            # Union external illegal across component
+            union_external: dict[str, set[int]] = {}
+            for member in component:
+                ds_map = illegal.get(int(member), {})
+                for ds_key, ids in ds_map.items():
+                    if ds_key == lines_key:
+                        continue  # keep self-line constraint per member
+                    union_external.setdefault(ds_key, set()).update(ids)
+
+            # Apply union to each member
+            for member in component:
+                illegal.setdefault(int(member), {})
+                for ds_key, ids in union_external.items():
+                    illegal[int(member)].setdefault(ds_key, set()).update(ids)
 
     def _is_illegal(
         self,
@@ -590,21 +691,28 @@ class FillLineGaps:
         cand: dict,
         base_tol: float,
         dangle_tol: float,
+        component_id: dict[int, int] | None = None,
     ) -> bool:
         ds_key = cand["near_fc_key"]
         oid = int(cand["near_fid"])
         dist = float(cand["near_dist"])
 
+        a_comp = component_id.get(int(parent_id)) if component_id is not None else None
+
         if ds_key == dangles_fc_key:
             if dist > dangle_tol:
                 return False
 
-            # legality of snapping to a dangle is assessed via its parent line
-            other_parent = dangle_parent.get(oid)
+            other_parent = dangle_parent.get(int(oid))
             if other_parent is None:
                 return False
 
-            # treat as snapping to that parent line for illegal checks
+            # NEW: disallow snapping to a dangle whose parent is in the same connected component
+            if a_comp is not None and component_id is not None:
+                if component_id.get(int(other_parent)) == a_comp:
+                    return False
+
+            # existing illegal check (treat as snapping to that parent line)
             if self._is_illegal(
                 illegal=illegal,
                 parent_id=parent_id,
@@ -619,9 +727,13 @@ class FillLineGaps:
         if dist > base_tol:
             return False
 
-        # hard guard: never snap to own parent line (canonical lines key)
         if ds_key == lines_fc_key and int(oid) == int(parent_id):
             return False
+
+        # NEW: disallow snapping to a line in the same connected component
+        if ds_key == lines_fc_key and a_comp is not None and component_id is not None:
+            if component_id.get(int(oid)) == a_comp:
+                return False
 
         if self._is_illegal(
             illegal=illegal,
@@ -668,6 +780,7 @@ class FillLineGaps:
         parent_id: int,
         base_tol: float,
         dangle_tol: float,
+        component_id: dict[int, int] | None = None,
     ) -> Optional[dict]:
         for cand in candidates_sorted:
             if self._candidate_is_legal(
@@ -679,6 +792,7 @@ class FillLineGaps:
                 cand=cand,
                 base_tol=base_tol,
                 dangle_tol=dangle_tol,
+                component_id=component_id,
             ):
                 return cand
         return None
@@ -704,6 +818,30 @@ class FillLineGaps:
                 return cand
         return None
 
+    def _build_component_ids(
+        self, *, adjacency: dict[int, set[int]], nodes: set[int]
+    ) -> dict[int, int]:
+        comp_id: dict[int, int] = {}
+        visited: set[int] = set()
+        cid = 0
+
+        for start in nodes | set(adjacency.keys()):
+            start = int(start)
+            if start in visited:
+                continue
+            cid += 1
+            stack = [start]
+            while stack:
+                cur = int(stack.pop())
+                if cur in visited:
+                    continue
+                visited.add(cur)
+                comp_id[cur] = cid
+                for nb in adjacency.get(cur, set()):
+                    if nb not in visited:
+                        stack.append(int(nb))
+        return comp_id
+
     # ----------------------------
     # Build plan (two-phase: detect pairs first, then decide moves)
     # ----------------------------
@@ -714,11 +852,16 @@ class FillLineGaps:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
-        illegal = self.detect_illegal_targets(
+        illegal, adjacency = self.detect_illegal_targets(
             dangle_parent=dangle_parent,
             target_layers=target_layers,
         )
-
+        nodes = set(dangle_parent.values())
+        component_id = (
+            self._build_component_ids(adjacency=adjacency, nodes=nodes)
+            if self.propagate_illigal_targets
+            else None
+        )
         dangles_key = self._dataset_key(dangles_fc)
 
         lines_key = self._dataset_key(self.lines_copy)
@@ -798,6 +941,7 @@ class FillLineGaps:
                 parent_id=int(parent_id),
                 base_tol=base_tol,
                 dangle_tol=dangle_tol,
+                component_id=component_id,
             )
             if first_legal is None:
                 no_legal += 1
@@ -977,6 +1121,7 @@ class FillLineGaps:
                 cand=a_to_b_line,
                 base_tol=float(base_tol),
                 dangle_tol=float(dangle_tol),
+                component_id=component_id,
             ):
                 a_to_b_line = None
 
@@ -989,6 +1134,7 @@ class FillLineGaps:
                 cand=b_to_a_line,
                 base_tol=float(base_tol),
                 dangle_tol=float(dangle_tol),
+                component_id=component_id,
             ):
                 b_to_a_line = None
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -768,16 +768,16 @@ class _DangleProposal:
 
 
 @dataclass(frozen=True)
-class _NetworkProposal:
+class _ConnectionProposal:
     """Stage-A candidate; Z normalized within its pair_key group."""
     ctx:           "_CandidateContext"
     dangle_norm_z: Optional[float]   # carried from _DangleProposal.score.norm_z
-    score:         "_ProposalScore"  # score.norm_z = network_norm_z
+    score:         "_ProposalScore"  # score.norm_z = connection_norm_z
 
     @classmethod
     def from_dangle(
         cls, d: "_DangleProposal", score: "_ProposalScore"
-    ) -> "_NetworkProposal":
+    ) -> "_ConnectionProposal":
         return cls(ctx=d.ctx, dangle_norm_z=d.score.norm_z, score=score)
 
     def sort_key(self) -> tuple:
@@ -791,15 +791,15 @@ class _GlobalProposal:
     """Stage-B candidate; Z normalized across all Stage-A winners."""
     ctx:            "_CandidateContext"
     dangle_norm_z:  Optional[float]
-    network_norm_z: Optional[float]
+    connection_norm_z: Optional[float]
     score:          "_ProposalScore"  # score.norm_z = global_norm_z
 
     @classmethod
     def from_network(
-        cls, n: "_NetworkProposal", score: "_ProposalScore"
+        cls, n: "_ConnectionProposal", score: "_ProposalScore"
     ) -> "_GlobalProposal":
         return cls(ctx=n.ctx, dangle_norm_z=n.dangle_norm_z,
-                   network_norm_z=n.score.norm_z, score=score)
+                   connection_norm_z=n.score.norm_z, score=score)
 
     def sort_key(self) -> tuple:
         c = self.ctx
@@ -865,7 +865,7 @@ class CandidateDiagnostic:
                               blocked_by_angle | expanded_dangle_angle_disallowed |
                               blocked_by_z_drop
         legal_not_selected:   outscored_within_dangle
-        selected_for_dangle:  lost_pair_competition | lost_cycle_prevention
+        selected_for_dangle:  lost_connection_selection | lost_kruskal_selection
         applied_to_output:    applied_main | applied_resnapped
     """
 
@@ -889,7 +889,7 @@ class CandidateDiagnostic:
     start_z:         Optional[float] = None  # Z at the dangle point (candidate start); None when no rasters
     end_z:           Optional[float] = None  # Z at the near point (candidate end); None when no rasters
     dangle_norm_z:   Optional[float] = None  # Z normalized within dangle candidate set; None for illegals
-    network_norm_z:  Optional[float] = None  # Z normalized within pair_key group; None for illegals/deferred
+    connection_norm_z:  Optional[float] = None  # Z normalized within pair_key group; None for illegals/deferred
     global_norm_z:   Optional[float] = None  # Z normalized across all Stage-A winners; None unless Stage-B reached
 
 
@@ -2665,264 +2665,46 @@ class FillLineGaps:
         if not grouped:
             return {}, {}, []
 
-        # ----------------------------
-        # Diagnostic collection (populated only when candidate_connections_output is set)
-        # ----------------------------
         collect_diags = self.candidate_connections_output is not None
 
-        # (dangle_oid, parent_id, cand, reason) — failed step-1A legality
-        _step1a_illegal: list[tuple[int, int, dict, str]] = []
-        # (dangle_oid, parent_id, cand, assess, reason, start_z, end_z) — blocked in step-1B
-        _step1b_illegal: list[tuple[int, int, dict, AngleAssessment, str, Optional[float], Optional[float]]] = []
-        # (dangle_oid, parent_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner,
-        #  score_tuple, norm_z, start_z, end_z)
-        _step1b_scored: list[tuple] = []
-
-        # Pipeline stage fate sets — populated as _build_plan progresses;
-        # _assemble_diagnostics captures them by reference so early-return calls
-        # always see whatever has been filled in at that point.
-        stage_a_loser_oids: set[int] = set()       # local winners that lost Stage-A pair competition
-        stage_b_rejected_oids: set[int] = set()    # Stage-A winners dropped by Kruskal
-        accepted_dangle_oids: set[int] = set()     # proposals that made it into the main plan
-        gap_source_by_dangle: dict[int, str] = {}  # gap_source for accepted main-plan candidates
-
-        # Z normalization dicts — keyed by dangle_oid; captured by reference in _assemble_diagnostics.
-        # dangle_norm_z_by_dangle: winner's per-dangle norm_z (same as sc_norm_z for winner rows)
-        # network_norm_z_by_dangle: populated during Pass-2 for all active proposals
-        # global_norm_z_by_dangle: populated during Pass-3 for Stage-A winners
-        dangle_norm_z_by_dangle:  dict[int, Optional[float]] = {}
-        network_norm_z_by_dangle: dict[int, Optional[float]] = {}
-        global_norm_z_by_dangle:  dict[int, Optional[float]] = {}
-
-        def _assemble_diagnostics() -> list[CandidateDiagnostic]:
-            if not collect_diags:
-                return []
-            result: list[CandidateDiagnostic] = []
-
-            def _z_pair(
-                d_xy: tuple[float, float], near_x: float, near_y: float
-            ) -> tuple[Optional[float], Optional[float]]:
-                if not self._raster_handles:
-                    return None, None
-                sz = geometry_tools.local_z_at_xy(
-                    self._raster_handles, float(d_xy[0]), float(d_xy[1])
-                )
-                ez = geometry_tools.local_z_at_xy(
-                    self._raster_handles, float(near_x), float(near_y)
-                )
-                return sz, ez
-
-            # Step-1A illegals: angle never computed; z values looked up here
-            for d_oid, p_id, cand, reason in _step1a_illegal:
-                xy = dangle_xy.get(int(d_oid))
-                if xy is None:
-                    continue
-                _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
-                result.append(CandidateDiagnostic(
-                    parent_id=p_id,
-                    dangle_oid=d_oid,
-                    dangle_x=float(xy[0]),
-                    dangle_y=float(xy[1]),
-                    near_fc_key=str(cand["near_fc_key"]),
-                    near_fid=int(cand["near_fid"]),
-                    near_x=float(cand["near_x"]),
-                    near_y=float(cand["near_y"]),
-                    raw_distance=float(cand["near_dist"]),
-                    candidate_status="illegal",
-                    status_reason=reason,
-                    best_fit_score=None,
-                    best_fit_rank=None,
-                    bonus_applied=None,
-                    assess=None,
-                    target_parent_id=self._resolve_target_parent_id(
-                        cand, dangle_parent, dangles_key, lines_key
-                    ),
-                    final_gap_source=None,
-                    start_z=_sz,
-                    end_z=_ez,
-                    dangle_norm_z=None,
-                    network_norm_z=None,
-                    global_norm_z=None,
-                ))
-
-            # Step-1B angle-blocked illegals: z values carried in tuple
-            for d_oid, p_id, cand, assess, reason, _sz, _ez in _step1b_illegal:
-                xy = dangle_xy.get(int(d_oid))
-                if xy is None:
-                    continue
-                result.append(CandidateDiagnostic(
-                    parent_id=p_id,
-                    dangle_oid=d_oid,
-                    dangle_x=float(xy[0]),
-                    dangle_y=float(xy[1]),
-                    near_fc_key=str(cand["near_fc_key"]),
-                    near_fid=int(cand["near_fid"]),
-                    near_x=float(cand["near_x"]),
-                    near_y=float(cand["near_y"]),
-                    raw_distance=float(cand["near_dist"]),
-                    candidate_status="illegal",
-                    status_reason=reason,
-                    best_fit_score=None,
-                    best_fit_rank=None,
-                    bonus_applied=None,
-                    assess=assess,
-                    target_parent_id=self._resolve_target_parent_id(
-                        cand, dangle_parent, dangles_key, lines_key
-                    ),
-                    final_gap_source=None,
-                    start_z=_sz,
-                    end_z=_ez,
-                    dangle_norm_z=None,
-                    network_norm_z=None,
-                    global_norm_z=None,
-                ))
-
-            # Compute per-dangle rank for scored candidates (1 = local winner)
-            scored_by_dangle: dict[int, list] = {}
-            for entry in _step1b_scored:
-                scored_by_dangle.setdefault(int(entry[0]), []).append(entry)
-            rank_map: dict[tuple[int, str, int], int] = {}
-            for d_oid, entries in scored_by_dangle.items():
-                for rank, entry in enumerate(
-                    sorted(entries, key=lambda e: e[8]), start=1
-                ):
-                    cand = entry[2]
-                    rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = rank
-
-            # Step-1B scored candidates; z values carried in tuple
-            for (
-                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus,
-                is_local_winner, _score, sc_norm_z, sc_start_z, sc_end_z,
-            ) in _step1b_scored:
-                xy = dangle_xy.get(int(d_oid))
-                if xy is None:
-                    continue
-                rank = rank_map.get((d_oid, str(cand["near_fc_key"]), int(cand["near_fid"])))
-
-                if not is_local_winner:
-                    status = "legal_not_selected"
-                    reason = "outscored_within_dangle"
-                    final_gs: Optional[str] = None
-                    net_nz: Optional[float] = None
-                    glob_nz: Optional[float] = None
-                elif int(d_oid) in stage_a_loser_oids:
-                    status = "selected_for_dangle"
-                    reason = "lost_pair_competition"
-                    final_gs = None
-                    net_nz = network_norm_z_by_dangle.get(int(d_oid))
-                    glob_nz = None
-                elif int(d_oid) in stage_b_rejected_oids:
-                    status = "selected_for_dangle"
-                    reason = "lost_cycle_prevention"
-                    final_gs = None
-                    net_nz = network_norm_z_by_dangle.get(int(d_oid))
-                    glob_nz = global_norm_z_by_dangle.get(int(d_oid))
-                elif int(d_oid) in accepted_dangle_oids:
-                    status = "applied_to_output"
-                    reason = "applied_main"
-                    final_gs = gap_source_by_dangle.get(int(d_oid))
-                    net_nz = network_norm_z_by_dangle.get(int(d_oid))
-                    glob_nz = global_norm_z_by_dangle.get(int(d_oid))
-                else:
-                    # Local winner that didn't reach proposal construction
-                    # (e.g. target dangle had no resolvable parent)
-                    status = "selected_for_dangle"
-                    reason = None
-                    final_gs = None
-                    net_nz = None
-                    glob_nz = None
-
-                result.append(CandidateDiagnostic(
-                    parent_id=p_id,
-                    dangle_oid=d_oid,
-                    dangle_x=float(xy[0]),
-                    dangle_y=float(xy[1]),
-                    near_fc_key=str(cand["near_fc_key"]),
-                    near_fid=int(cand["near_fid"]),
-                    near_x=float(cand["near_x"]),
-                    near_y=float(cand["near_y"]),
-                    raw_distance=float(raw_dist),
-                    candidate_status=status,
-                    status_reason=reason,
-                    best_fit_score=float(best_fit),
-                    best_fit_rank=rank,
-                    bonus_applied=bool(bonus),
-                    assess=assess,
-                    target_parent_id=self._resolve_target_parent_id(
-                        cand, dangle_parent, dangles_key, lines_key
-                    ),
-                    final_gap_source=final_gs,
-                    start_z=sc_start_z,
-                    end_z=sc_end_z,
-                    dangle_norm_z=sc_norm_z,
-                    network_norm_z=net_nz,
-                    global_norm_z=glob_nz,
-                ))
-            return result
-
         # ----------------------------
-        # Step 1A: collect legal candidates per dangle
+        # Dangle filtering: collect legal candidates per dangle
         # ----------------------------
-        legal_rows_by_dangle: dict[int, list[dict]] = {}
-        parent_id_by_dangle: dict[int, int] = {}
-
-        for dangle_oid in sorted(grouped.keys()):
-            candidates = grouped[dangle_oid]
-            dangle_oid = int(dangle_oid)
-
-            parent_id = dangle_parent.get(dangle_oid)
-            if parent_id is None:
-                continue
-            parent_id = int(parent_id)
-
-            rows = sorted(candidates, key=self._candidate_sort_key)
-
-            legal_rows: list[dict] = []
-            for cand in rows:
-                # Self-parent candidates are excluded from the plan and from diagnostics.
-                if (
-                    str(cand["near_fc_key"]) == str(lines_key)
-                    and int(cand["near_fid"]) == int(parent_id)
-                ):
-                    continue
-
-                is_legal = self._candidate_is_legal(
-                    illegal=illegal,
-                    dangle_parent=dangle_parent,
-                    dangles_fc_key=dangles_key,
-                    lines_fc_key=lines_key,
-                    parent_id=parent_id,
-                    cand=cand,
-                    base_tol=base_tol,
-                    dangle_candidate_tol=dangle_tol,
-                    topology=topology,
-                )
-                if is_legal:
-                    legal_rows.append(cand)
-                elif collect_diags:
-                    reason = self._candidate_rejection_reason(
-                        illegal=illegal,
-                        dangle_parent=dangle_parent,
-                        dangles_fc_key=dangles_key,
-                        lines_fc_key=lines_key,
-                        parent_id=parent_id,
-                        cand=cand,
-                        base_tol=base_tol,
-                        dangle_candidate_tol=dangle_tol,
-                        topology=topology,
-                    )
-                    _step1a_illegal.append((dangle_oid, parent_id, cand, reason))
-
-            if not legal_rows:
-                continue
-
-            legal_rows_by_dangle[dangle_oid] = legal_rows
-            parent_id_by_dangle[dangle_oid] = parent_id
+        legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
+            self._filter_legal_candidates(
+                grouped=grouped,
+                dangle_parent=dangle_parent,
+                illegal=illegal,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+                base_tol=base_tol,
+                dangle_tol=dangle_tol,
+                topology=topology,
+                collect_diags=collect_diags,
+            )
+        )
 
         if not legal_rows_by_dangle:
-            return {}, {}, _assemble_diagnostics()
+            return {}, {}, self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                step1a_illegal=_step1a_illegal,
+                step1b_illegal=[],
+                step1b_scored=[],
+                connection_loser_oids=set(),
+                kruskal_rejected_oids=set(),
+                accepted_dangle_oids=set(),
+                gap_source_by_dangle={},
+                dangle_norm_z_by_dangle={},
+                connection_norm_z_by_dangle={},
+                global_norm_z_by_dangle={},
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+            )
+
         # ----------------------------
-        # Angle caches (new)
+        # Angle caches
         # ----------------------------
         polyline_by_parent = self._build_polyline_by_parent_id()
 
@@ -3019,9 +2801,274 @@ class FillLineGaps:
             if best is not None:
                 best_line_parent_by_dangle[int(dangle_oid)] = int(best)
         # ----------------------------
-        # Step 1B: choose exactly ONE proposal per dangle using angle-aware scoring
+        # Dangle selection: choose one proposal per dangle using angle-aware scoring
         # ----------------------------
+        _dangle_proposals, dangle_norm_z_by_dangle, _step1b_illegal, _step1b_scored = (
+            self._select_dangle_proposals(
+                legal_rows_by_dangle=legal_rows_by_dangle,
+                parent_id_by_dangle=parent_id_by_dangle,
+                dangle_xy=dangle_xy,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+                base_tol=base_tol,
+                polyline_by_parent=polyline_by_parent,
+                polyline_by_external=polyline_by_external,
+                is_external_line_like=is_external_line_like,
+                best_line_parent_by_dangle=best_line_parent_by_dangle,
+                dangle_parent=dangle_parent,
+                topology=topology,
+                collect_diags=collect_diags,
+            )
+        )
+
+        if not _dangle_proposals:
+            return {}, [], self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                step1a_illegal=_step1a_illegal,
+                step1b_illegal=_step1b_illegal,
+                step1b_scored=_step1b_scored,
+                connection_loser_oids=set(),
+                kruskal_rejected_oids=set(),
+                accepted_dangle_oids=set(),
+                gap_source_by_dangle={},
+                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                connection_norm_z_by_dangle={},
+                global_norm_z_by_dangle={},
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+            )
+
+        # ----------------------------
+        # Mutual detection (for labeling)
+        # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
+        # - network mutual: any proposal exists in both directions between the two network nodes
+        # ----------------------------
+        active: list[_DangleProposal] = list(_dangle_proposals.values())
+        if not active:
+            return {}, [], self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                step1a_illegal=_step1a_illegal,
+                step1b_illegal=_step1b_illegal,
+                step1b_scored=_step1b_scored,
+                connection_loser_oids=set(),
+                kruskal_rejected_oids=set(),
+                accepted_dangle_oids=set(),
+                gap_source_by_dangle={},
+                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                connection_norm_z_by_dangle={},
+                global_norm_z_by_dangle={},
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+            )
+        active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
+
+        dangle_mutual_oids: set[int] = set()
+        for p in active:
+            if p.ctx.target_dangle_oid is None:
+                continue
+            q = active_by_dangle.get(int(p.ctx.target_dangle_oid))
+            if q is None or q.ctx.target_dangle_oid is None:
+                continue
+            if int(q.ctx.target_dangle_oid) == int(p.ctx.dangle_oid):
+                dangle_mutual_oids.add(int(p.ctx.dangle_oid))
+                dangle_mutual_oids.add(int(q.ctx.dangle_oid))
+
+        directed_network_edges: set[tuple[EntityKey, EntityKey]] = {
+            (p.ctx.src_node, p.ctx.tgt_node) for p in active
+        }
+
+        # ----------------------------
+        # Connection normalization: re-normalize Z within each undirected A↔B connection group
+        # ----------------------------
+        connection_proposals_by_dangle, connection_norm_z_by_dangle = (
+            self._run_connection_normalization(_dangle_proposals)
+        )
+
+        # ----------------------------
+        # Connection selection: one winner per undirected connection
+        # ----------------------------
+        _connection_proposals, connection_loser_oids = self._run_connection_selection(
+            connection_proposals_by_dangle=connection_proposals_by_dangle,
+            directed_edges=directed_network_edges,
+            dangle_mutual_oids=dangle_mutual_oids,
+            collect_diags=collect_diags,
+        )
+
+        # ----------------------------
+        # Global normalization: re-normalize Z across all connection winners
+        # ----------------------------
+        _global_winners, global_norm_z_by_dangle = self._run_global_normalization(
+            _connection_proposals
+        )
+
+        # ----------------------------
+        # Global selection: Kruskal cycle prevention across accepted connections
+        # ----------------------------
+        _global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle = (
+            self._run_kruskal(
+                global_winners=_global_winners,
+                topology=topology,
+                collect_diags=collect_diags,
+            )
+        )
+
+        if not _global_proposals:
+            return {}, [], self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                step1a_illegal=_step1a_illegal,
+                step1b_illegal=_step1b_illegal,
+                step1b_scored=_step1b_scored,
+                connection_loser_oids=connection_loser_oids,
+                kruskal_rejected_oids=kruskal_rejected_oids,
+                accepted_dangle_oids=accepted_dangle_oids,
+                gap_source_by_dangle=gap_source_by_dangle,
+                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+                global_norm_z_by_dangle=global_norm_z_by_dangle,
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+            )
+
+        # ----------------------------
+        # Resnap candidate identification
+        # ----------------------------
+        resnap_captures = self._identify_resnap_captures(_global_proposals)
+
+        # ----------------------------
+        # Build plan_by_parent: parent_id -> list[plan_entry]
+        # ----------------------------
+        plan_by_parent = self._assemble_plan_entries(_global_proposals)
+
+        return plan_by_parent, resnap_captures, self._assemble_diagnostics(
+            collect_diags=collect_diags,
+            step1a_illegal=_step1a_illegal,
+            step1b_illegal=_step1b_illegal,
+            step1b_scored=_step1b_scored,
+            connection_loser_oids=connection_loser_oids,
+            kruskal_rejected_oids=kruskal_rejected_oids,
+            accepted_dangle_oids=accepted_dangle_oids,
+            gap_source_by_dangle=gap_source_by_dangle,
+            dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+            connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+            global_norm_z_by_dangle=global_norm_z_by_dangle,
+            dangle_xy=dangle_xy,
+            dangle_parent=dangle_parent,
+            dangles_key=dangles_key,
+            lines_key=lines_key,
+        )
+
+    def _filter_legal_candidates(
+        self,
+        *,
+        grouped: dict,
+        dangle_parent: dict[int, int],
+        illegal,
+        dangles_key: str,
+        lines_key: str,
+        base_tol: float,
+        dangle_tol: float,
+        topology: "TopologyModel",
+        collect_diags: bool,
+    ) -> tuple[dict[int, list[dict]], dict[int, int], list[tuple]]:
+        """Dangle filtering: collect legal candidates per dangle.
+
+        Returns (legal_rows_by_dangle, parent_id_by_dangle, step1a_illegal).
+        """
+        legal_rows_by_dangle: dict[int, list[dict]] = {}
+        parent_id_by_dangle: dict[int, int] = {}
+        _step1a_illegal: list[tuple[int, int, dict, str]] = []
+
+        for dangle_oid in sorted(grouped.keys()):
+            candidates = grouped[dangle_oid]
+            dangle_oid = int(dangle_oid)
+
+            parent_id = dangle_parent.get(dangle_oid)
+            if parent_id is None:
+                continue
+            parent_id = int(parent_id)
+
+            rows = sorted(candidates, key=self._candidate_sort_key)
+
+            legal_rows: list[dict] = []
+            for cand in rows:
+                # Self-parent candidates are excluded from the plan and from diagnostics.
+                if (
+                    str(cand["near_fc_key"]) == str(lines_key)
+                    and int(cand["near_fid"]) == int(parent_id)
+                ):
+                    continue
+
+                is_legal = self._candidate_is_legal(
+                    illegal=illegal,
+                    dangle_parent=dangle_parent,
+                    dangles_fc_key=dangles_key,
+                    lines_fc_key=lines_key,
+                    parent_id=parent_id,
+                    cand=cand,
+                    base_tol=base_tol,
+                    dangle_candidate_tol=dangle_tol,
+                    topology=topology,
+                )
+                if is_legal:
+                    legal_rows.append(cand)
+                elif collect_diags:
+                    reason = self._candidate_rejection_reason(
+                        illegal=illegal,
+                        dangle_parent=dangle_parent,
+                        dangles_fc_key=dangles_key,
+                        lines_fc_key=lines_key,
+                        parent_id=parent_id,
+                        cand=cand,
+                        base_tol=base_tol,
+                        dangle_candidate_tol=dangle_tol,
+                        topology=topology,
+                    )
+                    _step1a_illegal.append((dangle_oid, parent_id, cand, reason))
+
+            if not legal_rows:
+                continue
+
+            legal_rows_by_dangle[dangle_oid] = legal_rows
+            parent_id_by_dangle[dangle_oid] = parent_id
+
+        return legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal
+
+    def _select_dangle_proposals(
+        self,
+        *,
+        legal_rows_by_dangle: dict[int, list[dict]],
+        parent_id_by_dangle: dict[int, int],
+        dangle_xy: dict[int, tuple[float, float]],
+        dangles_key: str,
+        lines_key: str,
+        base_tol: float,
+        polyline_by_parent: dict,
+        polyline_by_external: dict,
+        is_external_line_like: dict,
+        best_line_parent_by_dangle: dict,
+        dangle_parent: dict[int, int],
+        topology: "TopologyModel",
+        collect_diags: bool,
+    ) -> tuple[
+        dict[int, "_DangleProposal"],
+        dict[int, "Optional[float]"],
+        list[tuple],
+        list[tuple],
+    ]:
+        """Dangle selection: choose one proposal per dangle using angle-aware scoring.
+
+        Returns (_dangle_proposals, dangle_norm_z_by_dangle, step1b_illegal, step1b_scored).
+        """
         _dangle_proposals: dict[int, _DangleProposal] = {}
+        dangle_norm_z_by_dangle: dict[int, Optional[float]] = {}
+        _step1b_illegal: list[tuple] = []
+        _step1b_scored: list[tuple] = []
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             dangle_oid = int(dangle_oid)
@@ -3324,44 +3371,24 @@ class FillLineGaps:
             _dangle_proposals[dangle_oid] = _DangleProposal(ctx=ctx, score=winner_dangle_score)
             dangle_norm_z_by_dangle[dangle_oid] = winner_norm_z
 
-        if not _dangle_proposals:
-            return {}, [], _assemble_diagnostics()
+        return _dangle_proposals, dangle_norm_z_by_dangle, _step1b_illegal, _step1b_scored
 
-        # ----------------------------
-        # Mutual detection (for labeling)
-        # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
-        # - network mutual: any proposal exists in both directions between the two network nodes
-        # ----------------------------
-        active: list[_DangleProposal] = list(_dangle_proposals.values())
-        if not active:
-            return {}, [], _assemble_diagnostics()
-        active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
+    def _run_connection_normalization(
+        self,
+        dangle_proposals: "dict[int, _DangleProposal]",
+    ) -> "tuple[dict[int, _ConnectionProposal], dict[int, Optional[float]]]":
+        """Connection normalization: re-normalize Z within each undirected A↔B connection group.
 
-        dangle_mutual_oids: set[int] = set()
+        Returns (connection_proposals_by_dangle, connection_norm_z_by_dangle).
+        """
+        active = list(dangle_proposals.values())
+        _by_connection_for_normalization: dict[tuple, list[_DangleProposal]] = {}
         for p in active:
-            if p.ctx.target_dangle_oid is None:
-                continue
-            q = active_by_dangle.get(int(p.ctx.target_dangle_oid))
-            if q is None or q.ctx.target_dangle_oid is None:
-                continue
-            if int(q.ctx.target_dangle_oid) == int(p.ctx.dangle_oid):
-                dangle_mutual_oids.add(int(p.ctx.dangle_oid))
-                dangle_mutual_oids.add(int(q.ctx.dangle_oid))
+            _by_connection_for_normalization.setdefault(p.ctx.pair_key, []).append(p)
 
-        directed_network_edges: set[tuple[EntityKey, EntityKey]] = {
-            (p.ctx.src_node, p.ctx.tgt_node) for p in active
-        }
-
-        # ----------------------------
-        # Pass 2: Network-scope Z normalization (before Stage A)
-        # Group active proposals by pair_key; normalize Z within each group.
-        # ----------------------------
-        _by_pair_for_network: dict[tuple, list[_DangleProposal]] = {}
-        for p in active:
-            _by_pair_for_network.setdefault(p.ctx.pair_key, []).append(p)
-
-        network_proposals_by_dangle: dict[int, _NetworkProposal] = {}
-        for _pair_group in _by_pair_for_network.values():
+        connection_proposals_by_dangle: dict[int, _ConnectionProposal] = {}
+        connection_norm_z_by_dangle: dict[int, Optional[float]] = {}
+        for _pair_group in _by_connection_for_normalization.values():
             _group_end_z = [p.ctx.end_z for p in _pair_group]
             for p in _pair_group:
                 net_norm_z = self._normalize_z_within(_group_end_z, p.ctx.end_z)
@@ -3376,28 +3403,39 @@ class FillLineGaps:
                     norm_angle=p.score.norm_angle,
                     norm_z=net_norm_z,
                 )
-                network_proposals_by_dangle[int(p.ctx.dangle_oid)] = (
-                    _NetworkProposal.from_dangle(p, score=net_score)
+                connection_proposals_by_dangle[int(p.ctx.dangle_oid)] = (
+                    _ConnectionProposal.from_dangle(p, score=net_score)
                 )
-                network_norm_z_by_dangle[int(p.ctx.dangle_oid)] = net_norm_z
+                connection_norm_z_by_dangle[int(p.ctx.dangle_oid)] = net_norm_z
 
-        # ----------------------------
-        # Stage A: one winner per unordered network pair (using network-scoped scores)
-        # ----------------------------
-        by_pair: dict[tuple, list[_NetworkProposal]] = {}
-        for p in network_proposals_by_dangle.values():
-            by_pair.setdefault(p.ctx.pair_key, []).append(p)
+        return connection_proposals_by_dangle, connection_norm_z_by_dangle
 
-        _network_proposals: list[tuple[_NetworkProposal, str]] = []
-        for pair_key in sorted(by_pair.keys()):
-            group = by_pair[pair_key]
+    def _run_connection_selection(
+        self,
+        *,
+        connection_proposals_by_dangle: "dict[int, _ConnectionProposal]",
+        directed_edges: "set[tuple[EntityKey, EntityKey]]",
+        dangle_mutual_oids: "set[int]",
+        collect_diags: bool,
+    ) -> "tuple[list[tuple[_ConnectionProposal, str]], set[int]]":
+        """Connection selection: one winner per undirected connection.
+
+        Returns (_connection_proposals, connection_loser_oids).
+        """
+        by_connection: dict[tuple, list[_ConnectionProposal]] = {}
+        for p in connection_proposals_by_dangle.values():
+            by_connection.setdefault(p.ctx.pair_key, []).append(p)
+
+        _connection_proposals: list[tuple[_ConnectionProposal, str]] = []
+        for pair_key in sorted(by_connection.keys()):
+            group = by_connection[pair_key]
             winner = min(group, key=lambda pr: pr.sort_key())
 
             a_node, b_node = pair_key
-            mutual_network = (a_node, b_node) in directed_network_edges and (
+            mutual_network = (a_node, b_node) in directed_edges and (
                 b_node,
                 a_node,
-            ) in directed_network_edges
+            ) in directed_edges
 
             if (
                 winner.ctx.target_dangle_oid is not None
@@ -3409,23 +3447,31 @@ class FillLineGaps:
             else:
                 gap_source = self.GAP_SOURCE_DEFAULT
 
-            _network_proposals.append((winner, str(gap_source)))
+            _connection_proposals.append((winner, str(gap_source)))
 
+        connection_loser_oids: set[int] = set()
         if collect_diags:
-            _stage_a_winner_oids = {int(prop.ctx.dangle_oid) for prop, _ in _network_proposals}
-            stage_a_loser_oids.update(
+            _stage_a_winner_oids = {int(prop.ctx.dangle_oid) for prop, _ in _connection_proposals}
+            connection_loser_oids.update(
                 int(p.ctx.dangle_oid)
-                for p in network_proposals_by_dangle.values()
+                for p in connection_proposals_by_dangle.values()
                 if int(p.ctx.dangle_oid) not in _stage_a_winner_oids
             )
 
-        # ----------------------------
-        # Pass 3: Global-scope Z normalization (before Stage B)
-        # Normalize Z across all Stage-A winners.
-        # ----------------------------
-        _all_end_z_global = [p.ctx.end_z for p, _ in _network_proposals]
+        return _connection_proposals, connection_loser_oids
+
+    def _run_global_normalization(
+        self,
+        connection_proposals: "list[tuple[_ConnectionProposal, str]]",
+    ) -> "tuple[list[tuple[_GlobalProposal, str]], dict[int, Optional[float]]]":
+        """Global normalization: re-normalize Z across all connection winners.
+
+        Returns (_global_winners, global_norm_z_by_dangle).
+        """
+        _all_end_z_global = [p.ctx.end_z for p, _ in connection_proposals]
         _global_winners: list[tuple[_GlobalProposal, str]] = []
-        for n_prop, gap_source in _network_proposals:
+        global_norm_z_by_dangle: dict[int, Optional[float]] = {}
+        for n_prop, gap_source in connection_proposals:
             glob_norm_z = self._normalize_z_within(_all_end_z_global, n_prop.ctx.end_z)
             glob_score = _ProposalScore(
                 composite=self._compute_best_fit_score(
@@ -3442,9 +3488,19 @@ class FillLineGaps:
             _global_winners.append((g_prop, gap_source))
             global_norm_z_by_dangle[int(n_prop.ctx.dangle_oid)] = glob_norm_z
 
-        # ----------------------------
-        # Stage B: Kruskal-style cycle prevention (component scopes only)
-        # ----------------------------
+        return _global_winners, global_norm_z_by_dangle
+
+    def _run_kruskal(
+        self,
+        *,
+        global_winners: "list[tuple[_GlobalProposal, str]]",
+        topology: "TopologyModel",
+        collect_diags: bool,
+    ) -> "tuple[list[tuple[_GlobalProposal, str]], set[int], set[int], dict[int, str]]":
+        """Global selection: Kruskal cycle prevention across accepted connections.
+
+        Returns (_global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle).
+        """
         scope = topology.scope
         _global_proposals: list[tuple[_GlobalProposal, str]] = []
 
@@ -3465,46 +3521,52 @@ class FillLineGaps:
             for (ds_key, oid), cid in (topology.connectivity_id_by_optional or {}).items():
                 cand_ds_key = topo_to_cand_ds_key.get(ds_key, ds_key)
                 uf.union(("component", int(cid)), ("optional_candidate", str(cand_ds_key), int(oid)))
-            for prop, gap_source in sorted(_global_winners, key=lambda t: t[0].sort_key()):
+            for prop, gap_source in sorted(global_winners, key=lambda t: t[0].sort_key()):
                 if uf.find(prop.ctx.src_node) == uf.find(prop.ctx.tgt_node):
                     continue
                 uf.union(prop.ctx.src_node, prop.ctx.tgt_node)
                 _global_proposals.append((prop, gap_source))
         else:
-            # NONE / DIRECT_CONNECTION: only Stage A (already globally normalized)
-            _global_proposals = list(_global_winners)
+            # NONE / DIRECT_CONNECTION: only connection selection (already globally normalized)
+            _global_proposals = list(global_winners)
 
+        accepted_dangle_oids: set[int] = set()
+        kruskal_rejected_oids: set[int] = set()
+        gap_source_by_dangle: dict[int, str] = {}
         if collect_diags and _global_proposals:
             _accepted_oids = {int(prop.ctx.dangle_oid) for prop, _ in _global_proposals}
             accepted_dangle_oids.update(_accepted_oids)
-            stage_b_rejected_oids.update(
+            kruskal_rejected_oids.update(
                 int(prop.ctx.dangle_oid)
-                for prop, _ in _global_winners
+                for prop, _ in global_winners
                 if int(prop.ctx.dangle_oid) not in _accepted_oids
             )
             gap_source_by_dangle.update(
                 {int(prop.ctx.dangle_oid): str(gs) for prop, gs in _global_proposals}
             )
 
-        if not _global_proposals:
-            return {}, [], _assemble_diagnostics()
+        return _global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle
 
-        # ----------------------------
-        # Resnap candidate identification
-        # A connection A→B needs resnap if:
-        #   1. B is the target_parent_id of A's accepted connection
-        #   2. Another accepted connection B→T exists with GAP_SOURCE_PAIR_DANGLE
-        #      (i.e. B's dangle endpoint will move when B snaps to T)
-        #   3. A's near-point lies on B's last segment — checked in _resnap_connections
-        #      using post-apply geometry (this block is a cheap pre-filter only).
-        # ----------------------------
+    def _identify_resnap_captures(
+        self,
+        global_proposals: "list[tuple[_GlobalProposal, str]]",
+    ) -> "list[_ResnappedCapture]":
+        """Identify connections whose near-point may need re-resolving after snap.
+
+        A connection A→B needs resnap if:
+          1. B is the target_parent_id of A's accepted connection
+          2. Another accepted connection B→T exists with GAP_SOURCE_PAIR_DANGLE
+             (i.e. B's dangle endpoint will move when B snaps to T)
+          3. A's near-point lies on B's last segment — checked in _resnap_connections
+             using post-apply geometry (this block is a cheap pre-filter only).
+        """
         snap_source_parents: set[int] = {
             int(prop.ctx.src_parent_id)
-            for prop, gap_source in _global_proposals
+            for prop, gap_source in global_proposals
             if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE
         }
         resnap_captures: list[_ResnappedCapture] = []
-        for prop, gap_source in _global_proposals:
+        for prop, gap_source in global_proposals:
             tp = prop.ctx.target_parent_id
             if tp is None or int(tp) not in snap_source_parents:
                 continue
@@ -3515,13 +3577,16 @@ class FillLineGaps:
                 proposal=prop,
                 gap_source=str(gap_source),
             ))
+        return resnap_captures
 
-        # ----------------------------
-        # Build plan_by_parent: parent_id -> list[plan_entry]
-        # ----------------------------
+    def _assemble_plan_entries(
+        self,
+        global_proposals: "list[tuple[_GlobalProposal, str]]",
+    ) -> "dict[int, list[dict]]":
+        """Assemble plan_by_parent from accepted global proposals."""
         tmp: dict[int, list[tuple[tuple, dict]]] = {}
 
-        for prop, gap_source in sorted(_global_proposals, key=lambda t: t[0].sort_key()):
+        for prop, gap_source in sorted(global_proposals, key=lambda t: t[0].sort_key()):
             entry = self._make_plan_entry(
                 parent_id=int(prop.ctx.src_parent_id),
                 dangle_oid=int(prop.ctx.dangle_oid),
@@ -3549,7 +3614,192 @@ class FillLineGaps:
             )
             plan_by_parent[int(pid)] = [entry for _, entry in ordered]
 
-        return plan_by_parent, resnap_captures, _assemble_diagnostics()
+        return plan_by_parent
+
+    def _assemble_diagnostics(
+        self,
+        *,
+        collect_diags: bool,
+        step1a_illegal: list,
+        step1b_illegal: list,
+        step1b_scored: list,
+        connection_loser_oids: "set[int]",
+        kruskal_rejected_oids: "set[int]",
+        accepted_dangle_oids: "set[int]",
+        gap_source_by_dangle: "dict[int, str]",
+        dangle_norm_z_by_dangle: "dict[int, Optional[float]]",
+        connection_norm_z_by_dangle: "dict[int, Optional[float]]",
+        global_norm_z_by_dangle: "dict[int, Optional[float]]",
+        dangle_xy: "dict[int, tuple[float, float]]",
+        dangle_parent: "dict[int, int]",
+        dangles_key: str,
+        lines_key: str,
+    ) -> "list[CandidateDiagnostic]":
+        """Assemble CandidateDiagnostic records from all pipeline state collected during _build_plan."""
+        if not collect_diags:
+            return []
+        result: list[CandidateDiagnostic] = []
+
+        def _z_pair(
+            d_xy: tuple[float, float], near_x: float, near_y: float
+        ) -> tuple[Optional[float], Optional[float]]:
+            if not self._raster_handles:
+                return None, None
+            sz = geometry_tools.local_z_at_xy(
+                self._raster_handles, float(d_xy[0]), float(d_xy[1])
+            )
+            ez = geometry_tools.local_z_at_xy(
+                self._raster_handles, float(near_x), float(near_y)
+            )
+            return sz, ez
+
+        # Step-1A illegals: angle never computed; z values looked up here
+        for d_oid, p_id, cand, reason in step1a_illegal:
+            xy = dangle_xy.get(int(d_oid))
+            if xy is None:
+                continue
+            _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
+            result.append(CandidateDiagnostic(
+                parent_id=p_id,
+                dangle_oid=d_oid,
+                dangle_x=float(xy[0]),
+                dangle_y=float(xy[1]),
+                near_fc_key=str(cand["near_fc_key"]),
+                near_fid=int(cand["near_fid"]),
+                near_x=float(cand["near_x"]),
+                near_y=float(cand["near_y"]),
+                raw_distance=float(cand["near_dist"]),
+                candidate_status="illegal",
+                status_reason=reason,
+                best_fit_score=None,
+                best_fit_rank=None,
+                bonus_applied=None,
+                assess=None,
+                target_parent_id=self._resolve_target_parent_id(
+                    cand, dangle_parent, dangles_key, lines_key
+                ),
+                final_gap_source=None,
+                start_z=_sz,
+                end_z=_ez,
+                dangle_norm_z=None,
+                connection_norm_z=None,
+                global_norm_z=None,
+            ))
+
+        # Step-1B angle-blocked illegals: z values carried in tuple
+        for d_oid, p_id, cand, assess, reason, _sz, _ez in step1b_illegal:
+            xy = dangle_xy.get(int(d_oid))
+            if xy is None:
+                continue
+            result.append(CandidateDiagnostic(
+                parent_id=p_id,
+                dangle_oid=d_oid,
+                dangle_x=float(xy[0]),
+                dangle_y=float(xy[1]),
+                near_fc_key=str(cand["near_fc_key"]),
+                near_fid=int(cand["near_fid"]),
+                near_x=float(cand["near_x"]),
+                near_y=float(cand["near_y"]),
+                raw_distance=float(cand["near_dist"]),
+                candidate_status="illegal",
+                status_reason=reason,
+                best_fit_score=None,
+                best_fit_rank=None,
+                bonus_applied=None,
+                assess=assess,
+                target_parent_id=self._resolve_target_parent_id(
+                    cand, dangle_parent, dangles_key, lines_key
+                ),
+                final_gap_source=None,
+                start_z=_sz,
+                end_z=_ez,
+                dangle_norm_z=None,
+                connection_norm_z=None,
+                global_norm_z=None,
+            ))
+
+        # Compute per-dangle rank for scored candidates (1 = local winner)
+        scored_by_dangle: dict[int, list] = {}
+        for entry in step1b_scored:
+            scored_by_dangle.setdefault(int(entry[0]), []).append(entry)
+        rank_map: dict[tuple[int, str, int], int] = {}
+        for d_oid, entries in scored_by_dangle.items():
+            for rank, entry in enumerate(
+                sorted(entries, key=lambda e: e[8]), start=1
+            ):
+                cand = entry[2]
+                rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = rank
+
+        # Step-1B scored candidates; z values carried in tuple
+        for (
+            d_oid, p_id, cand, assess, raw_dist, best_fit, bonus,
+            is_local_winner, _score, sc_norm_z, sc_start_z, sc_end_z,
+        ) in step1b_scored:
+            xy = dangle_xy.get(int(d_oid))
+            if xy is None:
+                continue
+            rank = rank_map.get((d_oid, str(cand["near_fc_key"]), int(cand["near_fid"])))
+
+            if not is_local_winner:
+                status = "legal_not_selected"
+                reason = "outscored_within_dangle"
+                final_gs: Optional[str] = None
+                conn_nz: Optional[float] = None
+                glob_nz: Optional[float] = None
+            elif int(d_oid) in connection_loser_oids:
+                status = "selected_for_dangle"
+                reason = "lost_connection_selection"
+                final_gs = None
+                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
+                glob_nz = None
+            elif int(d_oid) in kruskal_rejected_oids:
+                status = "selected_for_dangle"
+                reason = "lost_kruskal_selection"
+                final_gs = None
+                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
+                glob_nz = global_norm_z_by_dangle.get(int(d_oid))
+            elif int(d_oid) in accepted_dangle_oids:
+                status = "applied_to_output"
+                reason = "applied_main"
+                final_gs = gap_source_by_dangle.get(int(d_oid))
+                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
+                glob_nz = global_norm_z_by_dangle.get(int(d_oid))
+            else:
+                # Local winner that didn't reach proposal construction
+                # (e.g. target dangle had no resolvable parent)
+                status = "selected_for_dangle"
+                reason = None
+                final_gs = None
+                conn_nz = None
+                glob_nz = None
+
+            result.append(CandidateDiagnostic(
+                parent_id=p_id,
+                dangle_oid=d_oid,
+                dangle_x=float(xy[0]),
+                dangle_y=float(xy[1]),
+                near_fc_key=str(cand["near_fc_key"]),
+                near_fid=int(cand["near_fid"]),
+                near_x=float(cand["near_x"]),
+                near_y=float(cand["near_y"]),
+                raw_distance=float(raw_dist),
+                candidate_status=status,
+                status_reason=reason,
+                best_fit_score=float(best_fit),
+                best_fit_rank=rank,
+                bonus_applied=bool(bonus),
+                assess=assess,
+                target_parent_id=self._resolve_target_parent_id(
+                    cand, dangle_parent, dangles_key, lines_key
+                ),
+                final_gap_source=final_gs,
+                start_z=sc_start_z,
+                end_z=sc_end_z,
+                dangle_norm_z=sc_norm_z,
+                connection_norm_z=conn_nz,
+                global_norm_z=glob_nz,
+            ))
+        return result
 
     def _make_plan_entry(
         self,
@@ -3891,7 +4141,7 @@ class FillLineGaps:
         arcpy.management.AddField(fc_path, "start_z", "DOUBLE")
         arcpy.management.AddField(fc_path, "end_z", "DOUBLE")
         arcpy.management.AddField(fc_path, "dangle_norm_z", "DOUBLE")
-        arcpy.management.AddField(fc_path, "network_norm_z", "DOUBLE")
+        arcpy.management.AddField(fc_path, "connection_norm_z", "DOUBLE")
         arcpy.management.AddField(fc_path, "global_norm_z", "DOUBLE")
 
     def _write_candidate_connections_output(
@@ -3926,7 +4176,7 @@ class FillLineGaps:
             "start_z",
             "end_z",
             "dangle_norm_z",
-            "network_norm_z",
+            "connection_norm_z",
             "global_norm_z",
         ]
         with arcpy.da.InsertCursor(fc_path, fields) as cur:
@@ -3959,7 +4209,7 @@ class FillLineGaps:
                     d.start_z,
                     d.end_z,
                     d.dangle_norm_z,
-                    d.network_norm_z,
+                    d.connection_norm_z,
                     d.global_norm_z,
                 ))
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2008,8 +2008,10 @@ class FillLineGaps:
         )
 
         conflict_keys: set[tuple[int, str, int]] = set()
-        with arcpy.da.SearchCursor(_near_table, ["IN_FID"]) as cur:
-            for (in_fid,) in cur:
+        with arcpy.da.SearchCursor(_near_table, ["IN_FID", "NEAR_DIST"]) as cur:
+            for in_fid, near_dist in cur:
+                if near_dist != 0.0:
+                    continue
                 key = oid_to_key.get(int(in_fid))
                 if key is not None:
                     conflict_keys.add(key)
@@ -4193,9 +4195,11 @@ class FillLineGaps:
                     closest_count=0,
                     method="PLANAR",
                 )
-                with arcpy.da.SearchCursor(_kruskal_near, ["IN_FID", "NEAR_FID"]) as _cur:
-                    for _in_fid, _near_fid in _cur:
+                with arcpy.da.SearchCursor(_kruskal_near, ["IN_FID", "NEAR_FID", "NEAR_DIST"]) as _cur:
+                    for _in_fid, _near_fid, _near_dist in _cur:
                         if int(_in_fid) == int(_near_fid):
+                            continue
+                        if _near_dist != 0.0:
                             continue
                         _key_in = _kruskal_oid_to_key.get(int(_in_fid))
                         _key_near = _kruskal_oid_to_key.get(int(_near_fid))
@@ -4432,8 +4436,10 @@ class FillLineGaps:
 
         # {parent_id: set of conflicting accepted dangle_oids}
         conflicts_by_parent: dict[int, set[int]] = {}
-        with arcpy.da.SearchCursor(_near_table, ["IN_FID", "NEAR_FID"]) as cur:
-            for in_fid, near_fid in cur:
+        with arcpy.da.SearchCursor(_near_table, ["IN_FID", "NEAR_FID", "NEAR_DIST"]) as cur:
+            for in_fid, near_fid, near_dist in cur:
+                if near_dist != 0.0:
+                    continue
                 parent_id = oid_to_parent_id.get(int(in_fid))
                 acc_doid = oid_to_accepted_doid.get(int(near_fid))
                 if parent_id is not None and acc_doid is not None:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1031,7 +1031,12 @@ class FillLineGaps:
         self.source_direction_mode = logic_config.SourceDirectionMode(
             adv.source_direction_mode
         )
-        self.min_z_drop_meters: float = float(adv.min_z_drop_meters)
+        self.min_anchor_z_drop_meters: float = float(adv.min_anchor_z_drop_meters)
+        self.min_confident_flip_meters: Optional[float] = (
+            float(adv.min_confident_flip_meters)
+            if adv.min_confident_flip_meters is not None
+            else None
+        )
 
         # ----------------------------
         # Angle config
@@ -1636,8 +1641,9 @@ class FillLineGaps:
             input_lines=feature_class,
             raster_paths=self.raster_paths,
             orientation_mode=self._z_orient_mode_for_scope(),
-            min_z_drop_meters=self.min_z_drop_meters,
+            min_anchor_z_drop_meters=self.min_anchor_z_drop_meters,
             connectivity_tolerance_meters=self.connectivity_tolerance_meters,
+            min_confident_flip_meters=self.min_confident_flip_meters,
         )
         geometry_tools.LineZOrientTool(config=orient_config).run()
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -105,6 +105,7 @@ class TopologyBuilder:
         write_work_files_to_memory: bool,
         connectivity_tolerance_meters: float,
         line_connectivity_mode: "LineConnectivityMode",
+        file_name_prefix: str = "",
     ) -> None:
         self.lines_fc = lines_fc
         self.original_id_field = original_id_field
@@ -114,6 +115,17 @@ class TopologyBuilder:
         self.write_work_files_to_memory = bool(write_work_files_to_memory)
         self.tol_m = float(connectivity_tolerance_meters)
         self.line_mode = line_connectivity_mode
+        self.file_name_prefix = str(file_name_prefix)
+
+    @staticmethod
+    def _short_key(key: str, max_len: int = 24) -> str:
+        """Truncate a dataset key to at most max_len chars for use in file paths.
+        When truncation is needed, keeps the first 16 chars and appends 8 hex
+        chars from an MD5 digest of the full key so the result stays unique."""
+        if len(key) <= max_len:
+            return key
+        import hashlib
+        return key[:16] + hashlib.md5(key.encode()).hexdigest()[:8]
 
     def build(
         self,
@@ -300,7 +312,7 @@ class TopologyBuilder:
     def _build_parent_adjacency_endpoints(
         self, restrict_to_parent_ids: Optional[set[int]]
     ) -> dict[int, set[int]]:
-        endpoints_fc = self.wfm.build_file_path(file_name="topo_line_endpoints")
+        endpoints_fc = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_line_endpoints")
         arcpy.management.FeatureVerticesToPoints(
             self.lines_fc, endpoints_fc, "BOTH_ENDS"
         )
@@ -316,7 +328,7 @@ class TopologyBuilder:
                 endpoints_lyr, "NEW_SELECTION", where
             )
 
-        near_table = self.wfm.build_file_path(file_name="topo_endpoints_near_lines")
+        near_table = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_endpoints_near_lines")
         arcpy.analysis.GenerateNearTable(
             in_features=endpoints_lyr,
             near_features=[self.lines_fc],
@@ -379,7 +391,7 @@ class TopologyBuilder:
             )
             arcpy.management.SelectLayerByAttribute(lines_lyr, "NEW_SELECTION", where)
 
-        near_table = self.wfm.build_file_path(file_name="topo_lines_near_lines")
+        near_table = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_lines_near_lines")
         arcpy.analysis.GenerateNearTable(
             in_features=lines_lyr,
             near_features=[self.lines_fc],
@@ -526,7 +538,7 @@ class TopologyBuilder:
             # Now link per dataset-layer (so dataset_key is explicit and stable)
             for ds_key, opt_lyr in optional_layers:
                 table = self.wfm.build_file_path(
-                    file_name=f"topo_lines_to_opt_{ds_key}"
+                    file_name=f"{self.file_name_prefix}topo_lines_to_opt_{self._short_key(ds_key)}"
                 )
                 arcpy.analysis.GenerateNearTable(
                     in_features=lines_lyr,
@@ -568,7 +580,7 @@ class TopologyBuilder:
         for path in optional_paths:
             ds_key = self.dataset_key_fn(path)
             table = self.wfm.build_file_path(
-                file_name=f"topo_lines_to_opt_attach_{ds_key}"
+                file_name=f"{self.file_name_prefix}topo_lines_to_opt_attach_{self._short_key(ds_key)}"
             )
 
             arcpy.analysis.GenerateNearTable(
@@ -617,7 +629,7 @@ class TopologyBuilder:
         """
         Adds undirected optional↔optional edges to union-find for TRANSITIVE.
         """
-        table = self.wfm.build_file_path(file_name=f"topo_optopt_{ds_in}_to_{ds_near}")
+        table = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_optopt_{self._short_key(ds_in)}_to_{self._short_key(ds_near)}")
         arcpy.analysis.GenerateNearTable(
             in_features=in_layer,
             near_features=[near_layer],
@@ -728,6 +740,24 @@ class Proposal:
     pair_key: tuple[EntityKey, EntityKey]  # unordered network pair
     target_parent_id: Optional[int]  # only for line/dangle targets (ORIGINAL_ID space)
     target_dangle_oid: Optional[int]  # only if chosen is a dangle target
+
+
+@dataclass(frozen=True)
+class DeferredCapture:
+    """
+    Original proposal metadata captured when a proposal is marked deferred.
+
+    Carries both the routing information (which dangle, which forced target) and
+    the original selection metadata (Proposal + AngleAssessment) from the main
+    plan phase.  The geometry is resolved later from post-pass-1 line positions,
+    but the metadata here answers *why* the connection was chosen.
+    """
+
+    parent_id: int
+    dangle_oid: int
+    forced_target_parent: int
+    proposal: "Proposal"
+    assess: "AngleAssessment"
 
 
 @dataclass(frozen=True)
@@ -1147,6 +1177,30 @@ class FillLineGaps:
         )
 
         return raw_distance, effective_distance, bool(bonus_applied), score
+
+    def _compute_best_fit_score(
+        self, *, norm_dist: float, assess: "AngleAssessment"
+    ) -> float:
+        """
+        Normalized weighted composite best-fit score. Lower is better.
+
+        Unavailable dimensions are excluded from the composite and the score
+        is normalized by the sum of available weights only.  This ensures a
+        missing angle is neutral rather than treated as a perfect fit.
+        """
+        w_d = float(self.best_fit_weights.distance)
+        w_a = float(self.best_fit_weights.angle)
+
+        total_w = w_d
+        score = w_d * float(norm_dist)
+
+        if assess.angle_metric_deg is not None:
+            norm_a = float(assess.angle_metric_deg) / float(assess.angle_max_deg)
+            score += w_a * norm_a
+            total_w += w_a
+        # angle unavailable: exclude w_a from total so the score is not biased
+
+        return float(score) / float(total_w) if total_w > 0.0 else 0.0
 
     # ----------------------------
     # Preprocessing
@@ -1976,12 +2030,8 @@ class FillLineGaps:
             _diff = self._orientation_diff
             angle_max_deg = 90.0
 
-        connector_target_diff = _diff(
-            float(connector_angle), float(target_angle)
-        )
-        src_target_diff = _diff(
-            float(src_angle_deg), float(target_angle)
-        )
+        connector_target_diff = _diff(float(connector_angle), float(target_angle))
+        src_target_diff = _diff(float(src_angle_deg), float(target_angle))
         # connector_transition_diff mixes src→connector and connector→target.
         # For dangle pairs, use directional src→connector to stay consistent.
         _src_conn_for_transition = (
@@ -2425,11 +2475,9 @@ class FillLineGaps:
                 # Line targets do not use edge-case bonus.
                 raw_dist = float(cand["near_dist"])
                 _tol = float(self.gap_tolerance_meters) or 1.0
-                _norm_d = raw_dist / _tol
-                _norm_a = (float(assess.angle_metric_deg) / float(assess.angle_max_deg)
-                           if assess.angle_metric_deg is not None else 0.0)
-                eff = (float(self.best_fit_weights.distance) * _norm_d
-                       + float(self.best_fit_weights.angle) * _norm_a)
+                eff = self._compute_best_fit_score(
+                    norm_dist=raw_dist / _tol, assess=assess
+                )
 
                 # Deterministic tie-break:
                 score = (float(eff), float(raw_dist), self._candidate_sort_key(cand))
@@ -2532,12 +2580,8 @@ class FillLineGaps:
 
                 # 4) Normalized weighted composite score
                 _tol = float(self.gap_tolerance_meters) or 1.0
-                _norm_d = float(effective_distance) / _tol
-                _norm_a = (float(assess.angle_metric_deg) / float(assess.angle_max_deg)
-                           if assess.angle_metric_deg is not None else 0.0)
-                effective_for_scoring = (
-                    float(self.best_fit_weights.distance) * _norm_d
-                    + float(self.best_fit_weights.angle) * _norm_a
+                effective_for_scoring = self._compute_best_fit_score(
+                    norm_dist=float(effective_distance) / _tol, assess=assess
                 )
 
                 # Keep score tuple shape stable; only replace the first element
@@ -2649,7 +2693,7 @@ class FillLineGaps:
                 int(p.target_parent_id)
             )
 
-        deferred_by_parent: dict[int, dict] = {}
+        deferred_by_parent: dict[int, DeferredCapture] = {}
         deferred_score_by_parent: dict[int, tuple] = {}
         deferred_dangles: set[int] = set()
 
@@ -2671,11 +2715,13 @@ class FillLineGaps:
             # Keep only one deferred per parent (deterministic: best score)
             cur_best = deferred_score_by_parent.get(int(p.src_parent_id))
             if cur_best is None or p.score < cur_best:
-                deferred_by_parent[int(p.src_parent_id)] = {
-                    "parent_id": int(p.src_parent_id),
-                    "dangle_oid": int(p.dangle_oid),
-                    "forced_target_parent": int(b_parent),
-                }
+                deferred_by_parent[int(p.src_parent_id)] = DeferredCapture(
+                    parent_id=int(p.src_parent_id),
+                    dangle_oid=int(p.dangle_oid),
+                    forced_target_parent=int(b_parent),
+                    proposal=p,
+                    assess=assess_by_dangle[int(p.dangle_oid)],
+                )
                 deferred_score_by_parent[int(p.src_parent_id)] = p.score
                 deferred_dangles.add(int(p.dangle_oid))
 
@@ -2826,7 +2872,9 @@ class FillLineGaps:
                 entry["meta_src_connector_diff"] = assess.src_connector_diff
                 entry["meta_connector_target_diff"] = assess.connector_target_diff
                 entry["meta_src_target_diff"] = assess.src_target_diff
-                entry["meta_connector_transition_diff"] = assess.connector_transition_diff
+                entry["meta_connector_transition_diff"] = (
+                    assess.connector_transition_diff
+                )
                 entry["meta_line_match_diff"] = assess.line_match_diff
                 entry["meta_angle_metric_deg"] = assess.angle_metric_deg
                 entry["meta_best_fit_score"] = best_fit_score
@@ -2859,31 +2907,121 @@ class FillLineGaps:
     # Deferred handling
     # ----------------------------
 
+    def _rebuild_topology_for_deferred(
+        self, *, captures: "dict[int, DeferredCapture]"
+    ) -> "TopologyModel":
+        """
+        Rebuild topology from the post-pass-1 lines_copy so that deferred
+        connectivity checks reflect the updated network state.
+        """
+        relevant: set[int] = set()
+        for cap in captures.values():
+            relevant.add(int(cap.parent_id))
+            relevant.add(int(cap.forced_target_parent))
+
+        return TopologyBuilder(
+            lines_fc=self.lines_copy,
+            original_id_field=self.ORIGINAL_ID,
+            connect_to_features=self.connect_to_features,
+            dataset_key_fn=self._dataset_key,
+            wfm=self.wfm,
+            write_work_files_to_memory=self.write_work_files_to_memory,
+            connectivity_tolerance_meters=self.connectivity_tolerance_meters,
+            line_connectivity_mode=self.line_connectivity_mode,
+            file_name_prefix="deferred_",
+        ).build(
+            scope=self.connectivity_scope,
+            relevant_parent_ids=relevant,
+        )
+
+    def _accept_deferred_candidates(
+        self,
+        *,
+        candidates: "list[tuple[DeferredCapture, float, float]]",
+        updated_topology: "TopologyModel",
+    ) -> "list[tuple[DeferredCapture, float, float]]":
+        """
+        Validate and accept deferred candidates against the post-pass-1 topology.
+
+        Per-candidate: reject if src and forced-target are now in the same network.
+        For component scopes: greedy Kruskal acceptance ordered by original
+        proposal.score so the result is deterministic and cycle-free.
+
+        Each entry is (capture, near_x, near_y).
+        """
+        valid = [
+            (cap, nx, ny)
+            for cap, nx, ny in candidates
+            if not self._same_network(
+                a_parent=cap.parent_id,
+                b_parent=cap.forced_target_parent,
+                topology=updated_topology,
+            )
+        ]
+
+        if not valid:
+            return []
+
+        scope = updated_topology.scope
+        if scope not in (
+            logic_config.ConnectivityScope.INPUT_LINES,
+            logic_config.ConnectivityScope.ONE_DEGREE,
+            logic_config.ConnectivityScope.TRANSITIVE,
+        ):
+            # NONE / DIRECT_CONNECTION: per-candidate check is sufficient
+            return valid
+
+        # Component scopes: greedy acceptance to prevent deferred candidates
+        # from creating cycles among themselves, ordered by original score.
+        sorted_valid = sorted(valid, key=lambda t: t[0].proposal.score)
+        uf = _UnionFind()
+        accepted: list[tuple[DeferredCapture, float, float]] = []
+        for cap, nx, ny in sorted_valid:
+            src_node = self._node_for_parent(
+                parent_id=cap.parent_id, topology=updated_topology
+            )
+            tgt_node = self._node_for_parent(
+                parent_id=cap.forced_target_parent, topology=updated_topology
+            )
+            if uf.find(src_node) == uf.find(tgt_node):
+                continue
+            uf.union(src_node, tgt_node)
+            accepted.append((cap, nx, ny))
+
+        return accepted
+
     def _build_deferred_plan(
         self,
         *,
-        deferred: dict[int, dict],
+        deferred: "dict[int, DeferredCapture]",
         dangles_fc: str,
     ) -> dict[int, dict]:
-        # Deferred dangles layer
-        dangles_oid = arcpy.Describe(dangles_fc).OIDFieldName
-        dangle_oids = sorted({int(v["dangle_oid"]) for v in deferred.values()})
+        """
+        Resolve deferred connections in three stages:
+        1. Geometry lookup — find the best near-point on each forced target line,
+           using updated post-pass-1 geometry.
+        2. Connectivity validation — rebuild topology from updated lines_copy and
+           reject any candidate that would now create a forbidden connection.
+        3. Plan entry construction — reuse original proposal/assess metadata so
+           the output correctly reflects why the connection was chosen.
+        """
+        dangle_oids = sorted({int(cap.dangle_oid) for cap in deferred.values()})
         if not dangle_oids:
             return {}
 
+        # --- 1a. Feature layers for near-table lookup ---
+        dangles_oid = arcpy.Describe(dangles_fc).OIDFieldName
         where_d = f"{arcpy.AddFieldDelimiters(dangles_fc, dangles_oid)} IN ({','.join(map(str, dangle_oids))})"
         deferred_lyr = "deferred_dangles_lyr"
         arcpy.management.MakeFeatureLayer(dangles_fc, deferred_lyr, where_d)
 
-        # Locked forced-target lines layer (UPDATED geometry because pass 1 already ran)
         forced_parents = sorted(
-            {int(v["forced_target_parent"]) for v in deferred.values()}
+            {int(cap.forced_target_parent) for cap in deferred.values()}
         )
         where_l = f"{arcpy.AddFieldDelimiters(self.lines_copy, self.ORIGINAL_ID)} IN ({','.join(map(str, forced_parents))})"
         forced_lines_lyr = "forced_lines_lyr"
         arcpy.management.MakeFeatureLayer(self.lines_copy, forced_lines_lyr, where_l)
 
-        # Map near OID -> parent id (do NOT assume OID == ORIGINAL_ID)
         lines_oid = arcpy.Describe(forced_lines_lyr).OIDFieldName
         near_oid_to_parent: dict[int, int] = {}
         with arcpy.da.SearchCursor(
@@ -2892,16 +3030,14 @@ class FillLineGaps:
             for oid, pid in cur:
                 near_oid_to_parent[int(oid)] = int(pid)
 
-        # Large tolerance (keep your current heuristic)
+        # --- 1b. GenerateNearTable against updated forced-target geometry ---
         large_m = max(50, int(self.gap_tolerance_meters) * 10)
-        large_tol = f"{int(large_m)} Meters"
-
         forced_table = self.wfm.build_file_path(file_name="deferred_forced_table")
         arcpy.analysis.GenerateNearTable(
             in_features=deferred_lyr,
             near_features=[forced_lines_lyr],
             out_table=forced_table,
-            search_radius=large_tol,
+            search_radius=f"{int(large_m)} Meters",
             location="LOCATION",
             angle="NO_ANGLE",
             closest="ALL",
@@ -2909,8 +3045,7 @@ class FillLineGaps:
             method="PLANAR",
         )
 
-        # Best near point per (dangle_oid, forced_parent)
-        best_xy: dict[tuple[int, int], tuple[float, float, float]] = {}  # -> (x,y,dist)
+        best_xy: dict[tuple[int, int], tuple[float, float]] = {}
         fields = [
             self.F_IN_FID,
             self.F_NEAR_FID,
@@ -2922,57 +3057,64 @@ class FillLineGaps:
             for in_fid, near_fid, near_dist, near_x, near_y in cur:
                 if near_fid is None or near_dist is None:
                     continue
-                d_oid = int(in_fid)
                 near_parent = near_oid_to_parent.get(int(near_fid))
                 if near_parent is None:
                     continue
-
-                dist = float(near_dist)
-                key = (d_oid, int(near_parent))
-                prev = best_xy.get(key)
-                if prev is None or dist < prev[2]:
-                    best_xy[key] = (float(near_x), float(near_y), dist)
+                key = (int(in_fid), int(near_parent))
+                prev_dist = best_xy.get(key, (0.0, 0.0, float("inf")))[2]  # type: ignore[misc]
+                if float(near_dist) < prev_dist:
+                    best_xy[key] = (float(near_x), float(near_y), float(near_dist))  # type: ignore[assignment]
 
         if not best_xy:
             return {}
 
-        # Dangle XY (only build once)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc)
 
+        # --- 1c. Pair each capture with its resolved near-point ---
+        candidates: list[tuple[DeferredCapture, float, float]] = []
+        for cap in deferred.values():
+            hit = best_xy.get((cap.dangle_oid, cap.forced_target_parent))
+            if hit is None:
+                continue
+            if dangle_xy.get(cap.dangle_oid) is None:
+                continue
+            candidates.append((cap, float(hit[0]), float(hit[1])))
+
+        if not candidates:
+            return {}
+
+        # --- 2. Validate against post-pass-1 connectivity ---
+        updated_topology = self._rebuild_topology_for_deferred(captures=deferred)
+        accepted = self._accept_deferred_candidates(
+            candidates=candidates,
+            updated_topology=updated_topology,
+        )
+
+        if not accepted:
+            return {}
+
+        # --- 3. Build plan entries with preserved original metadata ---
         lines_key = self._dataset_key(self.lines_copy)
         out: dict[int, dict] = {}
 
-        for a_parent, info in deferred.items():
-            a_parent = int(a_parent)
-            d_oid = int(info["dangle_oid"])
-            forced_parent = int(info["forced_target_parent"])
-
-            hit = best_xy.get((d_oid, forced_parent))
-            if hit is None:
-                continue
-
-            dxy = dangle_xy.get(d_oid)
-            if dxy is None:
-                continue
-            dangle_x, dangle_y = dxy
-
-            near_x, near_y, _ = hit
-
-            out[a_parent] = {
-                "processed": False,
-                "skip": False,
-                "gap_source": self.GAP_SOURCE_DEFERRED,
-                "edit_op": str(
-                    self._resolve_edit_op(gap_source=self.GAP_SOURCE_DEFERRED).value
-                ),
-                "dangle_oid": d_oid,
-                "dangle_x": float(dangle_x),
-                "dangle_y": float(dangle_y),
-                "near_x": float(near_x),
-                "near_y": float(near_y),
-                "chosen_near_fc_key": lines_key,
-                "chosen_near_fid": forced_parent,  # parent-id space, consistent with your plan
-            }
+        for cap, near_x, near_y in accepted:
+            dangle_x, dangle_y = dangle_xy[cap.dangle_oid]
+            out[cap.parent_id] = self._make_plan_entry(
+                parent_id=cap.parent_id,
+                dangle_oid=cap.dangle_oid,
+                dangle_x=float(dangle_x),
+                dangle_y=float(dangle_y),
+                chosen={
+                    "near_x": float(near_x),
+                    "near_y": float(near_y),
+                    "near_fc_key": lines_key,
+                    "near_fid": cap.forced_target_parent,
+                },
+                gap_source=self.GAP_SOURCE_DEFERRED,
+                bonus_applied=cap.proposal.bonus_applied,
+                assess=cap.assess,
+                best_fit_score=cap.proposal.best_fit_score,
+            )
 
         return out
 
@@ -3018,7 +3160,9 @@ class FillLineGaps:
                 arcpy.management.AddField(self.line_changes_output, fname, "DOUBLE")
 
         if "bonus_applied" not in existing:
-            arcpy.management.AddField(self.line_changes_output, "bonus_applied", "SHORT")
+            arcpy.management.AddField(
+                self.line_changes_output, "bonus_applied", "SHORT"
+            )
 
     def _build_change_row(
         self,
@@ -3041,16 +3185,18 @@ class FillLineGaps:
         geom = arcpy.Polyline(arr, spatial_reference)
         row = [geom, int(original_id), float(dist), str(gap_source)]
         if meta is not None:
-            row.extend([
-                meta.get("meta_src_connector_diff"),
-                meta.get("meta_connector_target_diff"),
-                meta.get("meta_src_target_diff"),
-                meta.get("meta_connector_transition_diff"),
-                meta.get("meta_line_match_diff"),
-                meta.get("meta_angle_metric_deg"),
-                meta.get("meta_best_fit_score"),
-                meta.get("meta_bonus_applied"),
-            ])
+            row.extend(
+                [
+                    meta.get("meta_src_connector_diff"),
+                    meta.get("meta_connector_target_diff"),
+                    meta.get("meta_src_target_diff"),
+                    meta.get("meta_connector_transition_diff"),
+                    meta.get("meta_line_match_diff"),
+                    meta.get("meta_angle_metric_deg"),
+                    meta.get("meta_best_fit_score"),
+                    meta.get("meta_bonus_applied"),
+                ]
+            )
         return tuple(row)
 
     def _apply_plan(self, plan) -> None:
@@ -3111,21 +3257,34 @@ class FillLineGaps:
 
                     info["processed"] = True
 
-                    if self.line_changes_output is not None and self.write_output_metadata:
-                        meta = {k: info.get(k) for k in (
-                            "meta_src_connector_diff",
-                            "meta_connector_target_diff",
-                            "meta_src_target_diff",
-                            "meta_connector_transition_diff",
-                            "meta_line_match_diff",
-                            "meta_angle_metric_deg",
-                            "meta_best_fit_score",
-                            "meta_bonus_applied",
-                        )} if any(k in info for k in (
-                            "meta_src_connector_diff",
-                            "meta_angle_metric_deg",
-                            "meta_bonus_applied",
-                        )) else None
+                    if (
+                        self.line_changes_output is not None
+                        and self.write_output_metadata
+                    ):
+                        meta = (
+                            {
+                                k: info.get(k)
+                                for k in (
+                                    "meta_src_connector_diff",
+                                    "meta_connector_target_diff",
+                                    "meta_src_target_diff",
+                                    "meta_connector_transition_diff",
+                                    "meta_line_match_diff",
+                                    "meta_angle_metric_deg",
+                                    "meta_best_fit_score",
+                                    "meta_bonus_applied",
+                                )
+                            }
+                            if any(
+                                k in info
+                                for k in (
+                                    "meta_src_connector_diff",
+                                    "meta_angle_metric_deg",
+                                    "meta_bonus_applied",
+                                )
+                            )
+                            else None
+                        )
                         row = self._build_change_row(
                             original_id=pid,
                             dangle_x=float(info["dangle_x"]),
@@ -3143,7 +3302,11 @@ class FillLineGaps:
 
                 cur.updateRow((original_id, current_shape))
 
-        if self.line_changes_output is not None and self.write_output_metadata and change_rows:
+        if (
+            self.line_changes_output is not None
+            and self.write_output_metadata
+            and change_rows
+        ):
             meta_fields = [
                 "src_connector_diff",
                 "connector_target_diff",
@@ -3161,11 +3324,12 @@ class FillLineGaps:
                     self.ORIGINAL_ID,
                     self.FIELD_GAP_DIST_M,
                     self.FIELD_GAP_SOURCE,
-                ] + meta_fields,
+                ]
+                + meta_fields,
             ) as icur:
                 for row in change_rows:
                     if len(row) == 4:
-                        # Deferred / polygon rows — no metadata; pad with None
+                        # Polygon (non-line) rows have no angle metadata; pad with None.
                         row = row + (None,) * len(meta_fields)
                     icur.insertRow(row)
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -703,6 +703,25 @@ class TopologyBuilder:
         return f"{fld} IN ({','.join(str(v) for v in safe)})"
 
 
+@dataclass(frozen=True)
+class Proposal:
+    """
+    One best-fit legal candidate per dangle (no fallback).
+    """
+
+    dangle_oid: int
+    src_parent_id: int
+    src_node: EntityKey
+    tgt_node: EntityKey
+    chosen: dict  # the chosen candidate row dict
+    score: tuple[
+        float, int, int, str, int
+    ]  # (dist, src_parent, dangle_oid, near_fc_key, near_fid)
+    pair_key: tuple[EntityKey, EntityKey]  # unordered network pair
+    target_parent_id: Optional[int]  # only for line/dangle targets (ORIGINAL_ID space)
+    target_dangle_oid: Optional[int]  # only if chosen is a dangle target
+
+
 class FillLineGaps:
     ORIGINAL_ID = "line_gap_original_id"
 
@@ -919,6 +938,48 @@ class FillLineGaps:
             points.append(arcpy.Point(near_x, near_y))
 
         return arcpy.Polyline(arcpy.Array(points), shape.spatialReference)
+
+    def _candidate_sort_key(self, cand: dict) -> tuple:
+        # Deterministic ordering for candidate rows within a dangle
+        return (
+            float(cand.get("near_dist", float("inf"))),
+            str(cand.get("near_fc_key", "")),
+            int(cand.get("near_fid", -1)),
+            float(cand.get("near_x", 0.0)),
+            float(cand.get("near_y", 0.0)),
+        )
+
+    def _unordered_pair_key(
+        self, a: EntityKey, b: EntityKey
+    ) -> tuple[EntityKey, EntityKey]:
+        # Deterministic unordered key using tuple ordering
+        return (a, b) if a <= b else (b, a)
+
+    def _node_for_parent(self, *, parent_id: int, topology: TopologyModel) -> EntityKey:
+        """
+        Network identity for a parent line.
+        - Component scopes: prefer ("component", connectivity_id)
+        - Otherwise: ("parent", parent_id)
+        """
+        scope = topology.scope
+        if scope in (
+            logic_config.ConnectivityScope.INPUT_LINES,
+            logic_config.ConnectivityScope.ONE_DEGREE,
+            logic_config.ConnectivityScope.TRANSITIVE,
+        ):
+            cid = (topology.connectivity_id_by_parent or {}).get(int(parent_id))
+            if cid is not None:
+                return ("component", int(cid))
+        return ("parent", int(parent_id))
+
+    def _node_for_optional_candidate(
+        self, *, dataset_key: str, near_fid: int
+    ) -> EntityKey:
+        """
+        Optional identity in candidate space.
+        Isolated behind a function so it can be upgraded later if SOURCE_OID becomes available.
+        """
+        return ("optional_candidate", str(dataset_key), int(near_fid))
 
     # ----------------------------
     # Preprocessing
@@ -1762,12 +1823,12 @@ class FillLineGaps:
 
     def _build_plan(
         self, *, dangles_fc: str, target_layers: list[str]
-    ) -> dict[int, dict]:
+    ) -> tuple[dict[int, list[dict]], dict[int, dict]]:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
-        # Value-neutral topology (computed independently of dangle candidate layers)
         relevant_parent_ids = set(dangle_parent.values())
+
         topology = TopologyBuilder(
             lines_fc=self.lines_copy,
             original_id_field=self.ORIGINAL_ID,
@@ -1789,9 +1850,8 @@ class FillLineGaps:
         )
 
         dangles_key = self._dataset_key(dangles_fc)
-
         lines_key = self._dataset_key(self.lines_copy)
-        lines_fc_keys = self._line_dataset_keys()
+
         near_features = list(target_layers) + [dangles_fc]
 
         base_tol = float(self.gap_tolerance_meters)
@@ -1807,13 +1867,14 @@ class FillLineGaps:
             else {}
         )
 
-        # One near-table for everything (expanded radius so we can see dangle pairs)
+        # Expanded radius so we can see dangle→dangle candidates, but legality will enforce tol rules.
         self._generate_near_table(
             in_dangles=dangles_fc,
             near_features=near_features,
             search_radius=self._expanded_dangle_tolerance_linear_unit(),
             out_table=self.near_table,
         )
+
         grouped = self._read_near_table_grouped(
             near_table=self.near_table,
             dangles_fc_key=dangles_key,
@@ -1824,308 +1885,261 @@ class FillLineGaps:
         )
 
         if not grouped:
-            return {}
+            return {}, {}
 
         # ----------------------------
-        # Phase 1: per dangle -> first legal + pair token
+        # Step 1: build exactly ONE proposal per dangle (best-fit legal)
         # ----------------------------
-        total_dangles = 0
-        no_parent = 0
-        no_legal = 0
-        per_dangle: dict[int, dict] = {}
+        proposals_by_dangle: dict[int, Proposal] = {}
+
         for dangle_oid, candidates in grouped.items():
-            total_dangles += 1
-            parent_id = dangle_parent.get(int(dangle_oid))
+            dangle_oid = int(dangle_oid)
+            parent_id = dangle_parent.get(dangle_oid)
             if parent_id is None:
-                no_parent += 1
+                continue
+            parent_id = int(parent_id)
+
+            rows = sorted(candidates, key=self._candidate_sort_key)
+
+            chosen = None
+            for cand in rows:
+                if self._candidate_is_legal(
+                    illegal=illegal,
+                    dangle_parent=dangle_parent,
+                    dangles_fc_key=dangles_key,
+                    lines_fc_key=lines_key,
+                    parent_id=parent_id,
+                    cand=cand,
+                    base_tol=base_tol,
+                    dangle_candidate_tol=dangle_tol,  # expanded tolerance applies ONLY for dangle targets
+                    topology=topology,
+                ):
+                    chosen = cand
+                    break
+
+            if chosen is None:
                 continue
 
-            rows = sorted(candidates, key=lambda r: r["near_dist"])
+            src_node = self._node_for_parent(parent_id=parent_id, topology=topology)
 
-            first_legal = self._select_first_legal_candidate(
-                candidates_sorted=rows,
-                illegal=illegal,
-                dangle_parent=dangle_parent,
-                dangles_fc_key=dangles_key,
-                lines_fc_key=lines_key,
-                parent_id=int(parent_id),
-                base_tol=base_tol,
-                topology=topology,
-            )
+            target_parent_id: Optional[int] = None
+            target_dangle_oid: Optional[int] = None
 
-            if first_legal is None:
-                no_legal += 1
-                continue
-            token = self._pair_token_from_candidate(
-                dangle_parent=dangle_parent,
-                dangles_fc_key=dangles_key,
-                lines_fc_keys=lines_fc_keys,
-                cand=first_legal,
-            )
+            ds_key = str(chosen["near_fc_key"])
+            near_fid = int(chosen["near_fid"])
 
-            per_dangle[int(dangle_oid)] = {
-                "parent_id": int(parent_id),
-                "rows": rows,
-                "first_legal": first_legal,
-                "pair_token_parent": token,  # other parent id if pair-like
-            }
-            if len(per_dangle) < 20:
-                arcpy.AddMessage(
-                    f"DEBUG example: dangle_oid={dangle_oid} parent={parent_id} "
-                    f"first_legal key={first_legal['near_fc_key']} raw={first_legal.get('near_fc_key_raw')} "
-                    f"near_fid={first_legal['near_fid']} dist={first_legal['near_dist']}"
+            if ds_key == dangles_key:
+                target_dangle_oid = near_fid
+                other_parent = dangle_parent.get(int(target_dangle_oid))
+                if other_parent is None:
+                    # Defensive; should be blocked by _candidate_is_legal already
+                    continue
+                target_parent_id = int(other_parent)
+                tgt_node = self._node_for_parent(
+                    parent_id=target_parent_id, topology=topology
                 )
 
-        arcpy.AddMessage(
-            f"DEBUG grouped={len(grouped)} total={total_dangles} "
-            f"no_parent={no_parent} no_legal={no_legal}"
-        )
-        if not per_dangle:
-            return {}
+            elif ds_key == lines_key:
+                target_parent_id = near_fid  # already in ORIGINAL_ID space
+                tgt_node = self._node_for_parent(
+                    parent_id=target_parent_id, topology=topology
+                )
 
-        parent_to_dangles: dict[int, list[int]] = {}
-        for d_oid, info in per_dangle.items():
-            parent_to_dangles.setdefault(int(info["parent_id"]), []).append(int(d_oid))
+            else:
+                # Optional/other target: keep as standalone candidate node for now
+                tgt_node = self._node_for_optional_candidate(
+                    dataset_key=ds_key, near_fid=near_fid
+                )
+
+            # Deterministic proposal score and pair key
+            score = (
+                float(chosen["near_dist"]),
+                int(parent_id),
+                int(dangle_oid),
+                str(chosen["near_fc_key"]),
+                int(chosen["near_fid"]),
+            )
+            pair_key = self._unordered_pair_key(src_node, tgt_node)
+
+            proposals_by_dangle[dangle_oid] = Proposal(
+                dangle_oid=dangle_oid,
+                src_parent_id=parent_id,
+                src_node=src_node,
+                tgt_node=tgt_node,
+                chosen=chosen,
+                score=score,
+                pair_key=pair_key,
+                target_parent_id=target_parent_id,
+                target_dangle_oid=target_dangle_oid,
+            )
+
+        if not proposals_by_dangle:
+            return {}, {}
 
         # ----------------------------
-        # Phase 2: decide moves with pair logic + defer logic
+        # Deferred detection (preserved behavior)
+        # - If A proposes to parent B (via line/dangle target),
+        #   and B has dangles in this run but does NOT propose back to parent A,
+        #   then A is deferred (computed later against updated geometry).
+        # - Keep deferred container shape as dict[parent_id -> dict].
         # ----------------------------
-        decided_by_parent: dict[int, dict] = {}
+        parents_with_dangles = sorted(set(dangle_parent.values()))
+        parents_with_dangles_set = {int(v) for v in parents_with_dangles}
+
+        outgoing_parent_targets: dict[int, set[int]] = {}
+        for p in proposals_by_dangle.values():
+            if p.target_parent_id is None:
+                continue
+            outgoing_parent_targets.setdefault(int(p.src_parent_id), set()).add(
+                int(p.target_parent_id)
+            )
+
         deferred_by_parent: dict[int, dict] = {}
-        visited_pairs: set[tuple[int, int]] = set()
+        deferred_score_by_parent: dict[int, tuple] = {}
+        deferred_dangles: set[int] = set()
 
-        all_parents = sorted(parent_to_dangles.keys())
+        for p in proposals_by_dangle.values():
+            b_parent = p.target_parent_id
+            if b_parent is None:
+                continue
+            b_parent = int(b_parent)
 
-        for a_parent in all_parents:
-            a_parent = int(a_parent)
-            if a_parent in decided_by_parent or a_parent in deferred_by_parent:
+            # Only defer when the target parent has dangles in this run
+            if b_parent not in parents_with_dangles_set:
                 continue
 
-            a_dangle = self._best_dangle_for_parent(
-                parent_id=a_parent,
-                parent_to_dangles=parent_to_dangles,
-                per_dangle=per_dangle,
-            )
-            if a_dangle is None:
+            # No reciprocal proposal from B -> A (parent-id space)
+            b_out = outgoing_parent_targets.get(b_parent, set())
+            if int(p.src_parent_id) in b_out:
                 continue
 
-            info = per_dangle.get(int(a_dangle))
-            if not info:
-                continue
-
-            token_parent = info.get("pair_token_parent")
-
-            if token_parent is None:
-                chosen = info["first_legal"]
-                dx, dy = dangle_xy[int(a_dangle)]
-                decided_by_parent[a_parent] = self._make_plan_entry(
-                    parent_id=a_parent,
-                    dangle_oid=int(a_dangle),
-                    dangle_x=dx,
-                    dangle_y=dy,
-                    chosen=chosen,
-                    gap_source=self.GAP_SOURCE_DEFAULT,
-                )
-                continue
-
-            b_parent = int(token_parent)
-            # If the other parent doesn't have any dangles in this run, treat as normal
-            # (this is equivalent to your old "b_dangle is None => normal" behavior)
-            if int(b_parent) not in parent_to_dangles:
-                chosen = info["first_legal"]
-                dx, dy = dangle_xy[int(a_dangle)]
-                decided_by_parent[a_parent] = self._make_plan_entry(
-                    parent_id=a_parent,
-                    dangle_oid=int(a_dangle),
-                    dangle_x=dx,
-                    dangle_y=dy,
-                    chosen=chosen,
-                    gap_source=self.GAP_SOURCE_DEFAULT,
-                )
-                continue
-
-            # A already points to B (via A's representative dangle).
-            # Now find which of B's dangles (if any) points back to A.
-            b_dangle = self._best_dangle_for_parent_towards_target_parent(
-                parent_id=int(b_parent),
-                target_parent_id=int(a_parent),
-                parent_to_dangles=parent_to_dangles,
-                per_dangle=per_dangle,
-            )
-
-            # If B has dangles, but none of them "want A", A must be deferred
-            if b_dangle is None:
-                deferred_by_parent[a_parent] = {
-                    "parent_id": a_parent,
-                    "dangle_oid": int(a_dangle),
+            # Keep only one deferred per parent (deterministic: best score)
+            cur_best = deferred_score_by_parent.get(int(p.src_parent_id))
+            if cur_best is None or p.score < cur_best:
+                deferred_by_parent[int(p.src_parent_id)] = {
+                    "parent_id": int(p.src_parent_id),
+                    "dangle_oid": int(p.dangle_oid),
                     "forced_target_parent": int(b_parent),
                 }
+                deferred_score_by_parent[int(p.src_parent_id)] = p.score
+                deferred_dangles.add(int(p.dangle_oid))
+
+        # Active proposals exclude deferred dangles (no fallback)
+        active: list[Proposal] = [
+            p
+            for d_oid, p in proposals_by_dangle.items()
+            if int(d_oid) not in deferred_dangles
+        ]
+        if not active:
+            return {}, deferred_by_parent
+
+        # ----------------------------
+        # Mutual detection (for labeling)
+        # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
+        # - network mutual: any proposal exists in both directions between the two network nodes
+        # ----------------------------
+        active_by_dangle = {int(p.dangle_oid): p for p in active}
+
+        dangle_mutual_oids: set[int] = set()
+        for p in active:
+            if p.target_dangle_oid is None:
                 continue
-
-            b_info = per_dangle[int(b_dangle)]
-
-            # Mutual pair
-            pair_key = tuple(sorted((a_parent, b_parent)))
-            if pair_key in visited_pairs:
+            q = active_by_dangle.get(int(p.target_dangle_oid))
+            if q is None or q.target_dangle_oid is None:
                 continue
-            visited_pairs.add(pair_key)
+            if int(q.target_dangle_oid) == int(p.dangle_oid):
+                dangle_mutual_oids.add(int(p.dangle_oid))
+                dangle_mutual_oids.add(int(q.dangle_oid))
 
-            # Pair constraint: they must not share an illegal target object
-            if self._parents_share_illegal_target(
-                illegal=illegal,
-                a_parent=a_parent,
-                b_parent=b_parent,
-            ):
-                # Fall back to normal for each (still mark as pair for symmetric skip)
-                for parent, dangle in [
-                    (a_parent, int(a_dangle)),
-                    (b_parent, int(b_dangle)),
-                ]:
-                    ii = per_dangle[int(dangle)]
-                    chosen = ii["first_legal"]
-                    dx, dy = dangle_xy[int(dangle)]
-                    decided_by_parent[parent] = self._make_plan_entry(
-                        parent_id=parent,
-                        dangle_oid=int(dangle),
-                        dangle_x=dx,
-                        dangle_y=dy,
-                        chosen=chosen,
-                        gap_source=self.GAP_SOURCE_DEFAULT,
-                    )
-                decided_by_parent[a_parent]["pair_parent"] = b_parent
-                decided_by_parent[b_parent]["pair_parent"] = a_parent
-                continue
-
-            # ----------------------------
-            # Pair preference:
-            # - We can snap to each other's DANGLE within dangle_tol
-            # - BUT the parent lines must be within base_tol (and legal)
-            # ----------------------------
-
-            # (1) Prefer snapping specifically to the chosen pairing endpoints
-            a_to_b_dangle = self._find_specific_dangle_candidate(
-                candidates_sorted=info["rows"],
-                dangles_fc_key=dangles_key,
-                other_dangle_oid=int(b_dangle),  # chosen B endpoint that points to A
-                dangle_tol=float(dangle_tol),
-            )
-
-            b_to_a_dangle = self._find_specific_dangle_candidate(
-                candidates_sorted=b_info["rows"],
-                dangles_fc_key=dangles_key,
-                other_dangle_oid=int(a_dangle),  # chosen A endpoint
-                dangle_tol=float(dangle_tol),
-            )
-
-            # Optional fallback: allow snapping to the closest endpoint on the parent if the
-            # exact endpoint row isn't present in the near table output
-            if a_to_b_dangle is None:
-                a_to_b_dangle = self._find_best_dangle_candidate_to_parent(
-                    candidates_sorted=info["rows"],
-                    dangles_fc_key=dangles_key,
-                    dangle_parent=dangle_parent,
-                    target_parent_id=int(b_parent),
-                    dangle_tol=float(dangle_tol),
-                )
-
-            if b_to_a_dangle is None:
-                b_to_a_dangle = self._find_best_dangle_candidate_to_parent(
-                    candidates_sorted=b_info["rows"],
-                    dangles_fc_key=dangles_key,
-                    dangle_parent=dangle_parent,
-                    target_parent_id=int(a_parent),
-                    dangle_tol=float(dangle_tol),
-                )
-
-            # (2) Explicit parent-line proximity rows (must be within base tolerance)
-            a_to_b_line = self._find_specific_line_candidate(
-                candidates_sorted=info["rows"],
-                lines_fc_keys=lines_fc_keys,
-                other_parent_id=int(b_parent),
-                base_tol=float(base_tol),
-            )
-            b_to_a_line = self._find_specific_line_candidate(
-                candidates_sorted=b_info["rows"],
-                lines_fc_keys=lines_fc_keys,
-                other_parent_id=int(a_parent),
-                base_tol=float(base_tol),
-            )
-
-            # (3) Enforce legality for those line candidates too (connected/illegal rules)
-            if a_to_b_line is not None and not self._candidate_is_legal(
-                illegal=illegal,
-                dangle_parent=dangle_parent,
-                dangles_fc_key=dangles_key,
-                lines_fc_key=lines_key,
-                parent_id=int(a_parent),
-                cand=a_to_b_line,
-                base_tol=float(base_tol),
-                dangle_candidate_tol=base_tol,
-                topology=topology,
-            ):
-                a_to_b_line = None
-
-            if b_to_a_line is not None and not self._candidate_is_legal(
-                illegal=illegal,
-                dangle_parent=dangle_parent,
-                dangles_fc_key=dangles_key,
-                lines_fc_key=lines_key,
-                parent_id=int(b_parent),
-                cand=b_to_a_line,
-                base_tol=float(base_tol),
-                dangle_candidate_tol=base_tol,
-                topology=topology,
-            ):
-                b_to_a_line = None
-
-            # Decide chosen targets for each parent
-            if (
-                a_to_b_dangle is not None
-                and b_to_a_dangle is not None
-                and a_to_b_line is not None
-                and b_to_a_line is not None
-            ):
-                # Both can snap to each other’s dangle within custom tolerance,
-                # AND their parent lines are within base tolerance (and legal)
-                a_chosen = a_to_b_dangle
-                b_chosen = b_to_a_dangle
-                a_source = self.GAP_SOURCE_PAIR_DANGLE
-                b_source = self.GAP_SOURCE_PAIR_DANGLE
-            else:
-                # Pair exists but dangle snap not allowed by constraints
-                a_chosen = info["first_legal"]
-                b_chosen = b_info["first_legal"]
-                a_source = self.GAP_SOURCE_PAIR_LINE
-                b_source = self.GAP_SOURCE_PAIR_LINE
-
-            # Write entries (still need symmetric skip: only one moves)
-            for parent, dangle, chosen, source in [
-                (a_parent, int(a_dangle), a_chosen, a_source),
-                (b_parent, int(b_dangle), b_chosen, b_source),
-            ]:
-                dx, dy = dangle_xy[int(dangle)]
-                decided_by_parent[int(parent)] = self._make_plan_entry(
-                    parent_id=int(parent),
-                    dangle_oid=int(dangle),
-                    dangle_x=dx,
-                    dangle_y=dy,
-                    chosen=chosen,
-                    gap_source=str(source),
-                )
-
-            decided_by_parent[a_parent]["pair_parent"] = b_parent
-            decided_by_parent[b_parent]["pair_parent"] = a_parent
-
-        # Apply symmetric skip on mutual pairs (only one moves)
-        self._apply_pair_symmetric_skip(decided_by_parent)
-
-        plan = {
-            pid: entry
-            for pid, entry in decided_by_parent.items()
-            if not entry.get("skip", False)
+        directed_network_edges: set[tuple[EntityKey, EntityKey]] = {
+            (p.src_node, p.tgt_node) for p in active
         }
 
-        return plan, deferred_by_parent
+        # ----------------------------
+        # Stage A: one winner per unordered network pair
+        # ----------------------------
+        by_pair: dict[tuple[EntityKey, EntityKey], list[Proposal]] = {}
+        for p in active:
+            by_pair.setdefault(p.pair_key, []).append(p)
+
+        stage_a_winners: list[tuple[Proposal, str]] = []
+        for pair_key in sorted(by_pair.keys()):
+            group = by_pair[pair_key]
+            winner = min(group, key=lambda pr: pr.score)
+
+            a_node, b_node = pair_key
+            mutual_network = (a_node, b_node) in directed_network_edges and (
+                b_node,
+                a_node,
+            ) in directed_network_edges
+
+            if (
+                winner.target_dangle_oid is not None
+                and int(winner.dangle_oid) in dangle_mutual_oids
+            ):
+                gap_source = self.GAP_SOURCE_PAIR_DANGLE
+            elif mutual_network:
+                gap_source = self.GAP_SOURCE_PAIR_LINE
+            else:
+                gap_source = self.GAP_SOURCE_DEFAULT
+
+            stage_a_winners.append((winner, str(gap_source)))
+
+        # ----------------------------
+        # Stage B: Kruskal-style cycle prevention (component scopes only)
+        # ----------------------------
+        scope = topology.scope
+        accepted: list[tuple[Proposal, str]] = []
+
+        if scope in (
+            logic_config.ConnectivityScope.INPUT_LINES,
+            logic_config.ConnectivityScope.ONE_DEGREE,
+            logic_config.ConnectivityScope.TRANSITIVE,
+        ):
+            uf = _UnionFind()
+            for prop, gap_source in sorted(stage_a_winners, key=lambda t: t[0].score):
+                if uf.find(prop.src_node) == uf.find(prop.tgt_node):
+                    continue
+                uf.union(prop.src_node, prop.tgt_node)
+                accepted.append((prop, gap_source))
+        else:
+            # NONE / DIRECT_CONNECTION: only Stage A
+            accepted = list(stage_a_winners)
+
+        if not accepted:
+            return {}, deferred_by_parent
+
+        # ----------------------------
+        # Build plan_by_parent: parent_id -> list[plan_entry]
+        # ----------------------------
+        tmp: dict[int, list[tuple[tuple, dict]]] = {}
+
+        for prop, gap_source in sorted(accepted, key=lambda t: t[0].score):
+            xy = dangle_xy.get(int(prop.dangle_oid))
+            if xy is None:
+                continue
+            d_x, d_y = xy
+
+            entry = self._make_plan_entry(
+                parent_id=int(prop.src_parent_id),
+                dangle_oid=int(prop.dangle_oid),
+                dangle_x=float(d_x),
+                dangle_y=float(d_y),
+                chosen=prop.chosen,
+                gap_source=str(gap_source),
+            )
+
+            tmp.setdefault(int(prop.src_parent_id), []).append((prop.score, entry))
+
+        plan_by_parent: dict[int, list[dict]] = {}
+        for pid, items in tmp.items():
+            # Deterministic per-parent order
+            ordered = sorted(
+                items, key=lambda t: (t[0], int(t[1].get("dangle_oid", 0)))
+            )
+            plan_by_parent[int(pid)] = [entry for _, entry in ordered]
+
+        return plan_by_parent, deferred_by_parent
 
     def _make_plan_entry(
         self,
@@ -2344,58 +2358,80 @@ class FillLineGaps:
         geom = arcpy.Polyline(arr, spatial_reference)
         return (geom, int(original_id), float(dist), str(gap_source))
 
-    def _apply_plan(self, plan: dict[int, dict]) -> None:
+    def _apply_plan(self, plan) -> None:
         if not plan:
             return
 
         spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
         change_rows: list[tuple] = []
 
+        def _as_entries(value) -> list[dict]:
+            # Backwards compatible: allow dict (single) or list[dict] (multi)
+            if value is None:
+                return []
+            if isinstance(value, list):
+                return [v for v in value if isinstance(v, dict)]
+            if isinstance(value, dict):
+                return [value]
+            return []
+
         with arcpy.da.UpdateCursor(
             self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"]
         ) as cur:
             for original_id, shape in cur:
                 pid = int(original_id)
-                info = plan.get(pid)
-                if not info:
-                    continue
-                if info.get("skip", False) or info.get("processed", False):
+                entries = _as_entries(plan.get(pid))
+                if not entries:
                     continue
 
-                edit_op = str(info.get("edit_op", EditOp.EXTEND.value))
+                pending = [
+                    e
+                    for e in entries
+                    if not e.get("skip", False) and not e.get("processed", False)
+                ]
+                if not pending:
+                    continue
 
-                if edit_op == EditOp.SNAP.value:
-                    new_shape = self._snap_endpoint(
-                        shape=shape,
-                        dangle_x=float(info["dangle_x"]),
-                        dangle_y=float(info["dangle_y"]),
-                        near_x=float(info["near_x"]),
-                        near_y=float(info["near_y"]),
-                    )
-                else:
-                    new_shape = self._extend_endpoint(
-                        shape=shape,
-                        dangle_x=float(info["dangle_x"]),
-                        dangle_y=float(info["dangle_y"]),
-                        near_x=float(info["near_x"]),
-                        near_y=float(info["near_y"]),
-                    )
+                current_shape = shape
 
-                cur.updateRow((original_id, new_shape))
-                info["processed"] = True  # optional
+                for info in pending:
+                    edit_op = str(info.get("edit_op", EditOp.EXTEND.value))
 
-                if self.line_changes_output is not None:
-                    row = self._build_change_row(
-                        original_id=pid,
-                        dangle_x=float(info["dangle_x"]),
-                        dangle_y=float(info["dangle_y"]),
-                        near_x=float(info["near_x"]),
-                        near_y=float(info["near_y"]),
-                        spatial_reference=spatial_reference,
-                        gap_source=str(info.get("gap_source", self.GAP_SOURCE_DEFAULT)),
-                    )
-                    if row is not None:
-                        change_rows.append(row)
+                    if edit_op == EditOp.SNAP.value:
+                        current_shape = self._snap_endpoint(
+                            shape=current_shape,
+                            dangle_x=float(info["dangle_x"]),
+                            dangle_y=float(info["dangle_y"]),
+                            near_x=float(info["near_x"]),
+                            near_y=float(info["near_y"]),
+                        )
+                    else:
+                        current_shape = self._extend_endpoint(
+                            shape=current_shape,
+                            dangle_x=float(info["dangle_x"]),
+                            dangle_y=float(info["dangle_y"]),
+                            near_x=float(info["near_x"]),
+                            near_y=float(info["near_y"]),
+                        )
+
+                    info["processed"] = True
+
+                    if self.line_changes_output is not None:
+                        row = self._build_change_row(
+                            original_id=pid,
+                            dangle_x=float(info["dangle_x"]),
+                            dangle_y=float(info["dangle_y"]),
+                            near_x=float(info["near_x"]),
+                            near_y=float(info["near_y"]),
+                            spatial_reference=spatial_reference,
+                            gap_source=str(
+                                info.get("gap_source", self.GAP_SOURCE_DEFAULT)
+                            ),
+                        )
+                        if row is not None:
+                            change_rows.append(row)
+
+                cur.updateRow((original_id, current_shape))
 
         if self.line_changes_output is not None and change_rows:
             with arcpy.da.InsertCursor(

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 import math
+import os
 
 from typing import Optional, Callable, Iterable, Any
 
@@ -779,6 +780,36 @@ class AngleAssessment:
     line_match_diff: Optional[float] = None
 
 
+@dataclass(frozen=True)
+class CandidateDiagnostic:
+    """
+    Diagnostic record for one candidate connection evaluated during the main planning phase.
+
+    One record exists per (dangle, target) pair, excluding the self parent line target.
+    Covers all three outcomes: chosen, legal-but-not-chosen, and illegal.
+
+    Step-1A illegals (failed topological/distance legality) have assess=None because
+    angle was never computed for them.  Step-1B illegals (angle-blocked or
+    expanded-dangle-gated) carry the computed assess.
+    """
+
+    parent_id: int
+    dangle_oid: int
+    dangle_x: float
+    dangle_y: float
+    near_fc_key: str
+    near_fid: int
+    near_x: float
+    near_y: float
+    raw_distance: float
+    candidate_status: str            # "chosen" | "legal_not_chosen" | "illegal"
+    candidate_reason: Optional[str]  # None unless status == "illegal"
+    best_fit_score: Optional[float]
+    bonus_applied: Optional[bool]
+    assess: Optional[AngleAssessment]
+    target_parent_id: Optional[int]
+
+
 class FillLineGaps:
     ORIGINAL_ID = "line_gap_original_id"
 
@@ -809,6 +840,7 @@ class FillLineGaps:
         self.fill_gaps_on_self = bool(adv.fill_gaps_on_self)
         self.line_changes_output = adv.line_changes_output
         self.write_output_metadata = bool(adv.write_output_metadata)
+        self.candidate_connections_output = adv.candidate_connections_output
         self.increased_tolerance_edge_case_distance_meters = int(
             adv.increased_tolerance_edge_case_distance_meters
         )
@@ -1883,6 +1915,71 @@ class FillLineGaps:
 
         return True
 
+    def _candidate_rejection_reason(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        dangle_parent: dict[int, int],
+        dangles_fc_key: str,
+        lines_fc_key: str,
+        parent_id: int,
+        cand: dict,
+        base_tol: float,
+        dangle_candidate_tol: float,
+        topology: "TopologyModel | None",
+    ) -> str:
+        """Return the legality-failure reason for a candidate, mirroring _candidate_is_legal."""
+        ds_key = cand["near_fc_key"]
+        oid = int(cand["near_fid"])
+        dist = float(cand["near_dist"])
+
+        if ds_key == dangles_fc_key:
+            if dist > float(dangle_candidate_tol):
+                return "beyond_distance_tolerance"
+            other_parent = dangle_parent.get(int(oid))
+            if other_parent is None:
+                return "illegal_target"
+            if topology is not None and self._same_network(
+                a_parent=int(parent_id), b_parent=int(other_parent), topology=topology
+            ):
+                return "same_network"
+            if self._is_illegal(
+                illegal=illegal,
+                parent_id=parent_id,
+                target_fc_key=lines_fc_key,
+                target_oid=int(other_parent),
+            ):
+                return "illegal_target"
+            return "illegal_target"
+
+        if dist > float(base_tol):
+            return "beyond_distance_tolerance"
+        if topology is not None and ds_key == lines_fc_key and self._same_network(
+            a_parent=int(parent_id), b_parent=int(oid), topology=topology
+        ):
+            return "same_network"
+        if self._is_illegal(
+            illegal=illegal, parent_id=parent_id, target_fc_key=ds_key, target_oid=oid
+        ):
+            return "illegal_target"
+        return "illegal_target"
+
+    def _resolve_target_parent_id(
+        self,
+        cand: dict,
+        dangle_parent: dict[int, int],
+        dangles_fc_key: str,
+        lines_fc_key: str,
+    ) -> Optional[int]:
+        """Return the target parent original ID for a candidate, or None for external targets."""
+        ds_key = str(cand["near_fc_key"])
+        near_fid = int(cand["near_fid"])
+        if ds_key == dangles_fc_key:
+            return dangle_parent.get(near_fid)
+        if ds_key == lines_fc_key:
+            return near_fid  # already in ORIGINAL_ID space
+        return None
+
     def _assess_angle(
         self,
         *,
@@ -2286,7 +2383,7 @@ class FillLineGaps:
 
     def _build_plan(
         self, *, dangles_fc: str, target_layers: list[str]
-    ) -> tuple[dict[int, list[dict]], dict[int, dict]]:
+    ) -> tuple[dict[int, list[dict]], dict[int, dict], list[CandidateDiagnostic]]:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
@@ -2348,7 +2445,96 @@ class FillLineGaps:
         )
 
         if not grouped:
-            return {}, {}
+            return {}, {}, []
+
+        # ----------------------------
+        # Diagnostic collection (populated only when candidate_connections_output is set)
+        # ----------------------------
+        collect_diags = self.candidate_connections_output is not None
+
+        # (dangle_oid, parent_id, cand, reason) — failed step-1A legality
+        _step1a_illegal: list[tuple[int, int, dict, str]] = []
+        # (dangle_oid, parent_id, cand, assess, reason) — passed step-1A but blocked in step-1B
+        _step1b_illegal: list[tuple[int, int, dict, AngleAssessment, str]] = []
+        # (dangle_oid, parent_id, cand, assess, raw_dist, best_fit, bonus, is_chosen)
+        _step1b_scored: list[tuple[int, int, dict, AngleAssessment, float, float, bool, bool]] = []
+
+        def _assemble_diagnostics() -> list[CandidateDiagnostic]:
+            if not collect_diags:
+                return []
+            result: list[CandidateDiagnostic] = []
+            for d_oid, p_id, cand, reason in _step1a_illegal:
+                xy = dangle_xy.get(int(d_oid))
+                if xy is None:
+                    continue
+                result.append(CandidateDiagnostic(
+                    parent_id=p_id,
+                    dangle_oid=d_oid,
+                    dangle_x=float(xy[0]),
+                    dangle_y=float(xy[1]),
+                    near_fc_key=str(cand["near_fc_key"]),
+                    near_fid=int(cand["near_fid"]),
+                    near_x=float(cand["near_x"]),
+                    near_y=float(cand["near_y"]),
+                    raw_distance=float(cand["near_dist"]),
+                    candidate_status="illegal",
+                    candidate_reason=reason,
+                    best_fit_score=None,
+                    bonus_applied=None,
+                    assess=None,
+                    target_parent_id=self._resolve_target_parent_id(
+                        cand, dangle_parent, dangles_key, lines_key
+                    ),
+                ))
+            for d_oid, p_id, cand, assess, reason in _step1b_illegal:
+                xy = dangle_xy.get(int(d_oid))
+                if xy is None:
+                    continue
+                result.append(CandidateDiagnostic(
+                    parent_id=p_id,
+                    dangle_oid=d_oid,
+                    dangle_x=float(xy[0]),
+                    dangle_y=float(xy[1]),
+                    near_fc_key=str(cand["near_fc_key"]),
+                    near_fid=int(cand["near_fid"]),
+                    near_x=float(cand["near_x"]),
+                    near_y=float(cand["near_y"]),
+                    raw_distance=float(cand["near_dist"]),
+                    candidate_status="illegal",
+                    candidate_reason=reason,
+                    best_fit_score=None,
+                    bonus_applied=None,
+                    assess=assess,
+                    target_parent_id=self._resolve_target_parent_id(
+                        cand, dangle_parent, dangles_key, lines_key
+                    ),
+                ))
+            for (
+                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus, is_chosen
+            ) in _step1b_scored:
+                xy = dangle_xy.get(int(d_oid))
+                if xy is None:
+                    continue
+                result.append(CandidateDiagnostic(
+                    parent_id=p_id,
+                    dangle_oid=d_oid,
+                    dangle_x=float(xy[0]),
+                    dangle_y=float(xy[1]),
+                    near_fc_key=str(cand["near_fc_key"]),
+                    near_fid=int(cand["near_fid"]),
+                    near_x=float(cand["near_x"]),
+                    near_y=float(cand["near_y"]),
+                    raw_distance=float(raw_dist),
+                    candidate_status="chosen" if is_chosen else "legal_not_chosen",
+                    candidate_reason=None,
+                    best_fit_score=float(best_fit),
+                    bonus_applied=bool(bonus),
+                    assess=assess,
+                    target_parent_id=self._resolve_target_parent_id(
+                        cand, dangle_parent, dangles_key, lines_key
+                    ),
+                ))
+            return result
 
         # ----------------------------
         # Step 1A: collect legal candidates per dangle
@@ -2369,7 +2555,14 @@ class FillLineGaps:
 
             legal_rows: list[dict] = []
             for cand in rows:
-                if self._candidate_is_legal(
+                # Self-parent candidates are excluded from the plan and from diagnostics.
+                if (
+                    str(cand["near_fc_key"]) == str(lines_key)
+                    and int(cand["near_fid"]) == int(parent_id)
+                ):
+                    continue
+
+                is_legal = self._candidate_is_legal(
                     illegal=illegal,
                     dangle_parent=dangle_parent,
                     dangles_fc_key=dangles_key,
@@ -2379,8 +2572,22 @@ class FillLineGaps:
                     base_tol=base_tol,
                     dangle_candidate_tol=dangle_tol,
                     topology=topology,
-                ):
+                )
+                if is_legal:
                     legal_rows.append(cand)
+                elif collect_diags:
+                    reason = self._candidate_rejection_reason(
+                        illegal=illegal,
+                        dangle_parent=dangle_parent,
+                        dangles_fc_key=dangles_key,
+                        lines_fc_key=lines_key,
+                        parent_id=parent_id,
+                        cand=cand,
+                        base_tol=base_tol,
+                        dangle_candidate_tol=dangle_tol,
+                        topology=topology,
+                    )
+                    _step1a_illegal.append((dangle_oid, parent_id, cand, reason))
 
             if not legal_rows:
                 continue
@@ -2389,7 +2596,7 @@ class FillLineGaps:
             parent_id_by_dangle[dangle_oid] = parent_id
 
         if not legal_rows_by_dangle:
-            return {}, {}
+            return {}, {}, _assemble_diagnostics()
         # ----------------------------
         # Angle caches (new)
         # ----------------------------
@@ -2544,6 +2751,10 @@ class FillLineGaps:
 
                 # 1) Candidate blocking (angle_block_threshold_degrees)
                 if assess.blocks:
+                    if collect_diags:
+                        _step1b_illegal.append(
+                            (dangle_oid, parent_id, cand, assess, "blocked_by_angle")
+                        )
                     continue
 
                 # 2) Expanded dangle tolerance gating (angle_extra_dangle_threshold_degrees)
@@ -2556,6 +2767,16 @@ class FillLineGaps:
                     and not bool(assess.allow_extra_dangle)
                 ):
                     # Candidate is only legal due to expanded tolerance; angle disallows it
+                    if collect_diags:
+                        _step1b_illegal.append(
+                            (
+                                dangle_oid,
+                                parent_id,
+                                cand,
+                                assess,
+                                "expanded_dangle_angle_disallowed",
+                            )
+                        )
                     continue
 
                 # 3) Edge-case bonus eligibility is angle-controlled (and conservative when angle missing)
@@ -2609,6 +2830,7 @@ class FillLineGaps:
             if not scored_candidates:
                 continue
 
+            winner_item = min(scored_candidates, key=lambda item: item[0])
             (
                 score,
                 chosen,
@@ -2616,10 +2838,21 @@ class FillLineGaps:
                 effective_distance_for_scoring,
                 bonus_applied,
                 chosen_assess,
-            ) = min(
-                scored_candidates,
-                key=lambda item: item[0],
-            )
+            ) = winner_item
+
+            if collect_diags:
+                for sc_tuple in scored_candidates:
+                    sc_score, sc_cand, sc_raw, sc_best_fit, sc_bonus, sc_assess = sc_tuple
+                    _step1b_scored.append((
+                        dangle_oid,
+                        parent_id,
+                        sc_cand,
+                        sc_assess,
+                        float(sc_raw),
+                        float(sc_best_fit),
+                        bool(sc_bonus),
+                        sc_tuple is winner_item,
+                    ))
 
             # ----------------------------
             # Proposal construction (unchanged semantics)
@@ -2675,7 +2908,7 @@ class FillLineGaps:
             assess_by_dangle[dangle_oid] = chosen_assess
 
         if not proposals_by_dangle:
-            return {}, {}
+            return {}, {}, _assemble_diagnostics()
 
         # ----------------------------
         # Mutual detection (for labeling)
@@ -2732,7 +2965,7 @@ class FillLineGaps:
             if int(d_oid) not in deferred_dangles
         ]
         if not active:
-            return {}, deferred_by_parent
+            return {}, deferred_by_parent, _assemble_diagnostics()
         active_by_dangle = {int(p.dangle_oid): p for p in active}
 
         dangle_mutual_oids: set[int] = set()
@@ -2802,7 +3035,7 @@ class FillLineGaps:
             accepted = list(stage_a_winners)
 
         if not accepted:
-            return {}, deferred_by_parent
+            return {}, deferred_by_parent, _assemble_diagnostics()
 
         # ----------------------------
         # Build plan_by_parent: parent_id -> list[plan_entry]
@@ -2837,7 +3070,7 @@ class FillLineGaps:
             )
             plan_by_parent[int(pid)] = [entry for _, entry in ordered]
 
-        return plan_by_parent, deferred_by_parent
+        return plan_by_parent, deferred_by_parent, _assemble_diagnostics()
 
     def _make_plan_entry(
         self,
@@ -3199,6 +3432,93 @@ class FillLineGaps:
             )
         return tuple(row)
 
+    def _setup_candidate_connections_output(self, fc_path: str) -> None:
+        """Create and schema the candidate-connections diagnostic feature class."""
+        sr = arcpy.Describe(self.lines_copy).spatialReference
+        out_path, out_name = os.path.split(fc_path)
+        if arcpy.Exists(fc_path):
+            arcpy.management.Delete(fc_path)
+        arcpy.management.CreateFeatureclass(
+            out_path=out_path,
+            out_name=out_name,
+            geometry_type="POLYLINE",
+            spatial_reference=sr,
+        )
+        arcpy.management.AddField(fc_path, "src_line_id", "LONG")
+        arcpy.management.AddField(fc_path, "src_dangle_oid", "LONG")
+        arcpy.management.AddField(fc_path, "target_ds_key", "TEXT", field_length=100)
+        arcpy.management.AddField(fc_path, "target_fid", "LONG")
+        arcpy.management.AddField(fc_path, "target_parent_id", "LONG")
+        arcpy.management.AddField(fc_path, "raw_distance", "DOUBLE")
+        arcpy.management.AddField(fc_path, "best_fit_score", "DOUBLE")
+        arcpy.management.AddField(fc_path, "bonus_applied", "SHORT")
+        for fname in (
+            "angle_metric_deg",
+            "src_connector_diff",
+            "connector_target_diff",
+            "src_target_diff",
+            "connector_transition_diff",
+            "line_match_diff",
+        ):
+            arcpy.management.AddField(fc_path, fname, "DOUBLE")
+        arcpy.management.AddField(fc_path, "candidate_status", "TEXT", field_length=20)
+        arcpy.management.AddField(fc_path, "candidate_reason", "TEXT", field_length=50)
+
+    def _write_candidate_connections_output(
+        self,
+        fc_path: str,
+        diagnostics: list[CandidateDiagnostic],
+        spatial_reference,
+    ) -> None:
+        """Write one row per CandidateDiagnostic to the candidate-connections feature class."""
+        if not diagnostics:
+            return
+        fields = [
+            "SHAPE@",
+            "src_line_id",
+            "src_dangle_oid",
+            "target_ds_key",
+            "target_fid",
+            "target_parent_id",
+            "raw_distance",
+            "best_fit_score",
+            "bonus_applied",
+            "angle_metric_deg",
+            "src_connector_diff",
+            "connector_target_diff",
+            "src_target_diff",
+            "connector_transition_diff",
+            "line_match_diff",
+            "candidate_status",
+            "candidate_reason",
+        ]
+        with arcpy.da.InsertCursor(fc_path, fields) as cur:
+            for d in diagnostics:
+                arr = arcpy.Array(
+                    [arcpy.Point(d.dangle_x, d.dangle_y), arcpy.Point(d.near_x, d.near_y)]
+                )
+                geom = arcpy.Polyline(arr, spatial_reference)
+                a = d.assess
+                cur.insertRow((
+                    geom,
+                    d.parent_id,
+                    d.dangle_oid,
+                    d.near_fc_key,
+                    d.near_fid,
+                    d.target_parent_id,
+                    d.raw_distance,
+                    d.best_fit_score,
+                    int(d.bonus_applied) if d.bonus_applied is not None else None,
+                    a.angle_metric_deg if a is not None else None,
+                    a.src_connector_diff if a is not None else None,
+                    a.connector_target_diff if a is not None else None,
+                    a.src_target_diff if a is not None else None,
+                    a.connector_transition_diff if a is not None else None,
+                    a.line_match_diff if a is not None else None,
+                    d.candidate_status,
+                    d.candidate_reason,
+                ))
+
     def _apply_plan(self, plan) -> None:
         if not plan:
             return
@@ -3364,7 +3684,10 @@ class FillLineGaps:
                 arcpy.management.Delete(self.line_changes_output)
             self._setup_line_changes_output()
 
-        plan, deferred = self._build_plan(
+        if self.candidate_connections_output is not None:
+            self._setup_candidate_connections_output(self.candidate_connections_output)
+
+        plan, deferred, diagnostics = self._build_plan(
             dangles_fc=dangles_for_plan, target_layers=targets
         )
 
@@ -3375,6 +3698,14 @@ class FillLineGaps:
                 deferred=deferred, dangles_fc=dangles_for_plan
             )
             self._apply_plan(deferred_plan)
+
+        if self.candidate_connections_output is not None and diagnostics:
+            spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
+            self._write_candidate_connections_output(
+                fc_path=self.candidate_connections_output,
+                diagnostics=diagnostics,
+                spatial_reference=spatial_reference,
+            )
 
         self._write_output()
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -4,7 +4,7 @@ from enum import Enum
 import math
 import os
 
-from typing import Optional, Callable, Iterable, Any
+from typing import Optional, Callable, Iterable, Any, TypeAlias
 
 import arcpy
 
@@ -892,6 +892,20 @@ class CandidateDiagnostic:
     connection_norm_z:  Optional[float] = None  # Z normalized within pair_key group; None for illegals/deferred
     global_norm_z:   Optional[float] = None  # Z normalized across all Stage-A winners; None unless Stage-B reached
 
+
+# ---------------------------------------------------------------------------
+# Pipeline type aliases
+# ---------------------------------------------------------------------------
+_IllegalTargets:       TypeAlias = dict[int, dict[str, set[int]]]
+_CandRow:              TypeAlias = dict[str, Any]
+_Grouped:              TypeAlias = dict[int, list[_CandRow]]
+_NormZByDangle:        TypeAlias = dict[int, Optional[float]]
+_ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, str]
+_GlobalWithSource:     TypeAlias = tuple[_GlobalProposal, str]
+# Diagnostic collection tuples (produced in _select_dangle_proposals, consumed in _assemble_diagnostics)
+_Step1AIllegalEntry:   TypeAlias = tuple[int, int, _CandRow, str]
+_Step1BIllegalEntry:   TypeAlias = tuple[int, int, _CandRow, AngleAssessment, str, Optional[float], Optional[float]]
+_Step1BScoredEntry:    TypeAlias = tuple[int, int, _CandRow, AngleAssessment, float, float, bool, bool, tuple[float, int, float], Optional[float], Optional[float], Optional[float]]
 
 class FillLineGaps:
     ORIGINAL_ID = "line_gap_original_id"
@@ -2740,7 +2754,7 @@ class FillLineGaps:
         # Best line parent per dangle (angle-aware)
         # Used by edge-case bonus detection.
         # ----------------------------
-        best_line_parent_by_dangle = {}
+        best_line_parent_by_dangle: dict[int, int] = {}
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             parent_id = int(parent_id_by_dangle[dangle_oid])
@@ -2966,23 +2980,23 @@ class FillLineGaps:
     def _filter_legal_candidates(
         self,
         *,
-        grouped: dict,
+        grouped: _Grouped,
         dangle_parent: dict[int, int],
-        illegal,
+        illegal: _IllegalTargets,
         dangles_key: str,
         lines_key: str,
         base_tol: float,
         dangle_tol: float,
-        topology: "TopologyModel",
+        topology: TopologyModel,
         collect_diags: bool,
-    ) -> tuple[dict[int, list[dict]], dict[int, int], list[tuple]]:
+    ) -> tuple[_Grouped, dict[int, int], list[_Step1AIllegalEntry]]:
         """Dangle filtering: collect legal candidates per dangle.
 
         Returns (legal_rows_by_dangle, parent_id_by_dangle, step1a_illegal).
         """
         legal_rows_by_dangle: dict[int, list[dict]] = {}
         parent_id_by_dangle: dict[int, int] = {}
-        _step1a_illegal: list[tuple[int, int, dict, str]] = []
+        _step1a_illegal: list[_Step1AIllegalEntry] = []
 
         for dangle_oid in sorted(grouped.keys()):
             candidates = grouped[dangle_oid]
@@ -3042,24 +3056,24 @@ class FillLineGaps:
     def _select_dangle_proposals(
         self,
         *,
-        legal_rows_by_dangle: dict[int, list[dict]],
+        legal_rows_by_dangle: _Grouped,
         parent_id_by_dangle: dict[int, int],
         dangle_xy: dict[int, tuple[float, float]],
         dangles_key: str,
         lines_key: str,
         base_tol: float,
-        polyline_by_parent: dict,
-        polyline_by_external: dict,
-        is_external_line_like: dict,
-        best_line_parent_by_dangle: dict,
+        polyline_by_parent: dict[int, Any],
+        polyline_by_external: dict[str, dict[int, Any]],
+        is_external_line_like: dict[str, bool],
+        best_line_parent_by_dangle: dict[int, int],
         dangle_parent: dict[int, int],
-        topology: "TopologyModel",
+        topology: TopologyModel,
         collect_diags: bool,
     ) -> tuple[
-        dict[int, "_DangleProposal"],
-        dict[int, "Optional[float]"],
-        list[tuple],
-        list[tuple],
+        dict[int, _DangleProposal],
+        _NormZByDangle,
+        list[_Step1BIllegalEntry],
+        list[_Step1BScoredEntry],
     ]:
         """Dangle selection: choose one proposal per dangle using angle-aware scoring.
 
@@ -3067,8 +3081,8 @@ class FillLineGaps:
         """
         _dangle_proposals: dict[int, _DangleProposal] = {}
         dangle_norm_z_by_dangle: dict[int, Optional[float]] = {}
-        _step1b_illegal: list[tuple] = []
-        _step1b_scored: list[tuple] = []
+        _step1b_illegal: list[_Step1BIllegalEntry] = []
+        _step1b_scored: list[_Step1BScoredEntry] = []
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             dangle_oid = int(dangle_oid)
@@ -3137,7 +3151,7 @@ class FillLineGaps:
                         _dangle_target_parents.add(int(_p))
 
             # (_ProposalScore, cand, raw_dist, best_fit, bonus, assess, norm_z, end_z)
-            scored_candidates: list[tuple] = []
+            scored_candidates: list[tuple[Any, ...]] = []
 
             for _cand_idx, cand in enumerate(legal_rows):
                 assess = self._assess_angle(
@@ -3375,8 +3389,8 @@ class FillLineGaps:
 
     def _run_connection_normalization(
         self,
-        dangle_proposals: "dict[int, _DangleProposal]",
-    ) -> "tuple[dict[int, _ConnectionProposal], dict[int, Optional[float]]]":
+        dangle_proposals: dict[int, _DangleProposal],
+    ) -> tuple[dict[int, _ConnectionProposal], _NormZByDangle]:
         """Connection normalization: re-normalize Z within each undirected A↔B connection group.
 
         Returns (connection_proposals_by_dangle, connection_norm_z_by_dangle).
@@ -3413,11 +3427,11 @@ class FillLineGaps:
     def _run_connection_selection(
         self,
         *,
-        connection_proposals_by_dangle: "dict[int, _ConnectionProposal]",
-        directed_edges: "set[tuple[EntityKey, EntityKey]]",
-        dangle_mutual_oids: "set[int]",
+        connection_proposals_by_dangle: dict[int, _ConnectionProposal],
+        directed_edges: set[tuple[EntityKey, EntityKey]],
+        dangle_mutual_oids: set[int],
         collect_diags: bool,
-    ) -> "tuple[list[tuple[_ConnectionProposal, str]], set[int]]":
+    ) -> tuple[list[_ConnectionWithSource], set[int]]:
         """Connection selection: one winner per undirected connection.
 
         Returns (_connection_proposals, connection_loser_oids).
@@ -3426,7 +3440,7 @@ class FillLineGaps:
         for p in connection_proposals_by_dangle.values():
             by_connection.setdefault(p.ctx.pair_key, []).append(p)
 
-        _connection_proposals: list[tuple[_ConnectionProposal, str]] = []
+        _connection_proposals: list[_ConnectionWithSource] = []
         for pair_key in sorted(by_connection.keys()):
             group = by_connection[pair_key]
             winner = min(group, key=lambda pr: pr.sort_key())
@@ -3462,14 +3476,14 @@ class FillLineGaps:
 
     def _run_global_normalization(
         self,
-        connection_proposals: "list[tuple[_ConnectionProposal, str]]",
-    ) -> "tuple[list[tuple[_GlobalProposal, str]], dict[int, Optional[float]]]":
+        connection_proposals: list[_ConnectionWithSource],
+    ) -> tuple[list[_GlobalWithSource], _NormZByDangle]:
         """Global normalization: re-normalize Z across all connection winners.
 
         Returns (_global_winners, global_norm_z_by_dangle).
         """
         _all_end_z_global = [p.ctx.end_z for p, _ in connection_proposals]
-        _global_winners: list[tuple[_GlobalProposal, str]] = []
+        _global_winners: list[_GlobalWithSource] = []
         global_norm_z_by_dangle: dict[int, Optional[float]] = {}
         for n_prop, gap_source in connection_proposals:
             glob_norm_z = self._normalize_z_within(_all_end_z_global, n_prop.ctx.end_z)
@@ -3493,16 +3507,16 @@ class FillLineGaps:
     def _run_kruskal(
         self,
         *,
-        global_winners: "list[tuple[_GlobalProposal, str]]",
-        topology: "TopologyModel",
+        global_winners: list[_GlobalWithSource],
+        topology: TopologyModel,
         collect_diags: bool,
-    ) -> "tuple[list[tuple[_GlobalProposal, str]], set[int], set[int], dict[int, str]]":
+    ) -> tuple[list[_GlobalWithSource], set[int], set[int], dict[int, str]]:
         """Global selection: Kruskal cycle prevention across accepted connections.
 
         Returns (_global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle).
         """
         scope = topology.scope
-        _global_proposals: list[tuple[_GlobalProposal, str]] = []
+        _global_proposals: list[_GlobalWithSource] = []
 
         if scope in (
             logic_config.ConnectivityScope.INPUT_LINES,
@@ -3549,8 +3563,8 @@ class FillLineGaps:
 
     def _identify_resnap_captures(
         self,
-        global_proposals: "list[tuple[_GlobalProposal, str]]",
-    ) -> "list[_ResnappedCapture]":
+        global_proposals: list[_GlobalWithSource],
+    ) -> list[_ResnappedCapture]:
         """Identify connections whose near-point may need re-resolving after snap.
 
         A connection A→B needs resnap if:
@@ -3581,10 +3595,10 @@ class FillLineGaps:
 
     def _assemble_plan_entries(
         self,
-        global_proposals: "list[tuple[_GlobalProposal, str]]",
-    ) -> "dict[int, list[dict]]":
+        global_proposals: list[_GlobalWithSource],
+    ) -> dict[int, list[dict[str, Any]]]:
         """Assemble plan_by_parent from accepted global proposals."""
-        tmp: dict[int, list[tuple[tuple, dict]]] = {}
+        tmp: dict[int, list[tuple[tuple[Any, ...], dict[str, Any]]]] = {}
 
         for prop, gap_source in sorted(global_proposals, key=lambda t: t[0].sort_key()):
             entry = self._make_plan_entry(
@@ -3620,21 +3634,21 @@ class FillLineGaps:
         self,
         *,
         collect_diags: bool,
-        step1a_illegal: list,
-        step1b_illegal: list,
-        step1b_scored: list,
-        connection_loser_oids: "set[int]",
-        kruskal_rejected_oids: "set[int]",
-        accepted_dangle_oids: "set[int]",
-        gap_source_by_dangle: "dict[int, str]",
-        dangle_norm_z_by_dangle: "dict[int, Optional[float]]",
-        connection_norm_z_by_dangle: "dict[int, Optional[float]]",
-        global_norm_z_by_dangle: "dict[int, Optional[float]]",
-        dangle_xy: "dict[int, tuple[float, float]]",
-        dangle_parent: "dict[int, int]",
+        step1a_illegal: list[_Step1AIllegalEntry],
+        step1b_illegal: list[_Step1BIllegalEntry],
+        step1b_scored: list[_Step1BScoredEntry],
+        connection_loser_oids: set[int],
+        kruskal_rejected_oids: set[int],
+        accepted_dangle_oids: set[int],
+        gap_source_by_dangle: dict[int, str],
+        dangle_norm_z_by_dangle: _NormZByDangle,
+        connection_norm_z_by_dangle: _NormZByDangle,
+        global_norm_z_by_dangle: _NormZByDangle,
+        dangle_xy: dict[int, tuple[float, float]],
+        dangle_parent: dict[int, int],
         dangles_key: str,
         lines_key: str,
-    ) -> "list[CandidateDiagnostic]":
+    ) -> list[CandidateDiagnostic]:
         """Assemble CandidateDiagnostic records from all pipeline state collected during _build_plan."""
         if not collect_diags:
             return []
@@ -3719,7 +3733,7 @@ class FillLineGaps:
             ))
 
         # Compute per-dangle rank for scored candidates (1 = local winner)
-        scored_by_dangle: dict[int, list] = {}
+        scored_by_dangle: dict[int, list[_Step1BScoredEntry]] = {}
         for entry in step1b_scored:
             scored_by_dangle.setdefault(int(entry[0]), []).append(entry)
         rank_map: dict[tuple[int, str, int], int] = {}

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -737,6 +737,9 @@ class AngleAssessment:
     blocks: bool
     allow_extra_dangle: bool  # expanded dangle tol + edge-case bonus
     angle_metric_deg: Optional[float]
+    # Normalisation range for angle_metric_deg used in best-fit scoring.
+    # 90.0 for undirected targets; 180.0 for directional dangle-pair targets.
+    angle_max_deg: float = 90.0
 
     # Diagnostics (optional)
     src_connector_diff: Optional[float] = None
@@ -1207,6 +1210,11 @@ class FillLineGaps:
         b = self._orientation(float(b_deg))
         raw = abs(a - b)
         return min(raw, 180.0 - raw)  # 0..90
+
+    def _directional_diff(self, a_deg: float, b_deg: float) -> float:
+        """Signed-aware circular difference between two direction angles. Result in [0, 180]."""
+        diff = abs(float(a_deg) - float(b_deg)) % 360.0
+        return min(diff, 360.0 - diff)  # 0..180
 
     def _connector_angle_deg(
         self, *, from_x: float, from_y: float, to_x: float, to_y: float
@@ -1958,14 +1966,31 @@ class FillLineGaps:
                 src_connector_diff=float(src_connector_diff),
             )
 
-        connector_target_diff = self._orientation_diff(
+        # Dangle-pair targets: use directional comparison so anti-parallel lines
+        # are not collapsed to zero diff. All other line-like targets keep the
+        # undirected orientation-based comparison.
+        if ds_key == dangles_fc_key:
+            _diff = self._directional_diff
+            angle_max_deg = 180.0
+        else:
+            _diff = self._orientation_diff
+            angle_max_deg = 90.0
+
+        connector_target_diff = _diff(
             float(connector_angle), float(target_angle)
         )
-        src_target_diff = self._orientation_diff(
+        src_target_diff = _diff(
             float(src_angle_deg), float(target_angle)
         )
+        # connector_transition_diff mixes src→connector and connector→target.
+        # For dangle pairs, use directional src→connector to stay consistent.
+        _src_conn_for_transition = (
+            self._directional_diff(float(src_angle_deg), float(connector_angle))
+            if ds_key == dangles_fc_key
+            else float(src_connector_diff)
+        )
         connector_transition_diff = 0.5 * (
-            float(src_connector_diff) + float(connector_target_diff)
+            _src_conn_for_transition + float(connector_target_diff)
         )
 
         w = float(self.line_alignment_weight)
@@ -1992,6 +2017,7 @@ class FillLineGaps:
             blocks=bool(blocks),
             allow_extra_dangle=bool(allow_extra),
             angle_metric_deg=float(metric),
+            angle_max_deg=float(angle_max_deg),
             src_connector_diff=float(src_connector_diff),
             connector_target_diff=float(connector_target_diff),
             src_target_diff=float(src_target_diff),
@@ -2400,7 +2426,7 @@ class FillLineGaps:
                 raw_dist = float(cand["near_dist"])
                 _tol = float(self.gap_tolerance_meters) or 1.0
                 _norm_d = raw_dist / _tol
-                _norm_a = (float(assess.angle_metric_deg) / 90.0
+                _norm_a = (float(assess.angle_metric_deg) / float(assess.angle_max_deg)
                            if assess.angle_metric_deg is not None else 0.0)
                 eff = (float(self.best_fit_weights.distance) * _norm_d
                        + float(self.best_fit_weights.angle) * _norm_a)
@@ -2507,7 +2533,7 @@ class FillLineGaps:
                 # 4) Normalized weighted composite score
                 _tol = float(self.gap_tolerance_meters) or 1.0
                 _norm_d = float(effective_distance) / _tol
-                _norm_a = (float(assess.angle_metric_deg) / 90.0
+                _norm_a = (float(assess.angle_metric_deg) / float(assess.angle_max_deg)
                            if assess.angle_metric_deg is not None else 0.0)
                 effective_for_scoring = (
                     float(self.best_fit_weights.distance) * _norm_d

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2468,9 +2468,9 @@ class FillLineGaps:
                 else:
                     metric = 180.0
             elif _is_directional:
-                # Non-endpoint line-like target: blend angular alignment with connector
-                # direction so mid-line snaps are not purely angle-driven.
-                metric = 0.5 * float(src_target_diff) + 0.5 * float(src_connector_diff)
+                # Non-endpoint line-like target: worst of angular alignment vs connector
+                # direction — a bad score on either component makes the candidate bad.
+                metric = max(float(src_target_diff), float(src_connector_diff))
             else:
                 # UNDIRECTED dangle-pair / dangle-parent-line after both normalizations.
                 metric = float(src_target_diff)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -2426,6 +2426,14 @@ class FillLineGaps:
                 _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
                 if not self._xy_is_at_line_start(tgt_poly, _tgt_snap_x, _tgt_snap_y):
                     target_angle = (float(target_angle) + 180.0) % 360.0
+            # In directional mode, override src_connector_diff to use directional diff
+            # so that anti-parallel src/connector (e.g. west vs east) reports 180° (BAD)
+            # rather than collapsing to 0° under orientation_diff.
+            # UNDIRECTED mode keeps the orientation-based value computed at line ~2286.
+            if _is_directional:
+                src_connector_diff = self._directional_diff(
+                    float(src_angle_deg), float(connector_angle)
+                )
         else:
             _diff = self._orientation_diff
             angle_max_deg = 90.0
@@ -2462,10 +2470,7 @@ class FillLineGaps:
             elif _is_directional:
                 # Non-endpoint line-like target: blend angular alignment with connector
                 # direction so mid-line snaps are not purely angle-driven.
-                _src_conn_directional = self._directional_diff(
-                    float(src_angle_deg), float(connector_angle)
-                )
-                metric = 0.5 * float(src_target_diff) + 0.5 * _src_conn_directional
+                metric = 0.5 * float(src_target_diff) + 0.5 * float(src_connector_diff)
             else:
                 # UNDIRECTED dangle-pair / dangle-parent-line after both normalizations.
                 metric = float(src_target_diff)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -5,7 +5,7 @@ from typing import Optional
 import arcpy
 
 from env_setup import environment_setup
-from custom_tools.general_tools import custom_arcpy
+from custom_tools.general_tools import custom_arcpy, file_utilities
 from file_manager import WorkFileManager
 from composition_configs import logic_config
 
@@ -35,6 +35,7 @@ class FillLineGaps:
     def __init__(self, line_gap_config: logic_config.FillLineGapsConfig):
         self.input_lines = line_gap_config.input_lines
         self.output_lines = line_gap_config.output_lines
+        self.line_changes_output = line_gap_config.line_changes_output
 
         self.gap_tolerance_meters = line_gap_config.gap_tolerance_meters
         self.connect_to_features = line_gap_config.connect_to_features
@@ -291,6 +292,67 @@ class FillLineGaps:
         """
         _ = plan
 
+    def _setup_line_changes_output(self) -> None:
+        """
+        What:
+            Ensures line_changes_output exists (if configured) and has required fields.
+
+        Why:
+            Avoids insert operations while an UpdateCursor transaction is active.
+        """
+        if self.line_changes_output is None:
+            return
+
+        file_utilities.create_feature_class(
+            template_feature=self.lines_copy,
+            new_feature=self.line_changes_output,
+        )
+
+        existing_fields = {
+            field.name for field in arcpy.ListFields(dataset=self.line_changes_output)
+        }
+
+        if self.ORIGINAL_ID not in existing_fields:
+            arcpy.management.AddField(
+                in_table=self.line_changes_output,
+                field_name=self.ORIGINAL_ID,
+                field_type="LONG",
+            )
+
+        if "gap_dist_m" not in existing_fields:
+            arcpy.management.AddField(
+                in_table=self.line_changes_output,
+                field_name="gap_dist_m",
+                field_type="DOUBLE",
+            )
+
+    def _build_change_row(
+        self,
+        original_id: int,
+        dangle_x: float,
+        dangle_y: float,
+        near_x: float,
+        near_y: float,
+        spatial_reference,
+    ):
+        """
+        What:
+            Builds a single insert row tuple for the change output, or returns None if no change.
+        """
+        dist = ((dangle_x - near_x) ** 2 + (dangle_y - near_y) ** 2) ** 0.5
+        if dist == 0.0:
+            return None
+
+        arr = arcpy.Array(
+            [arcpy.Point(X=dangle_x, Y=dangle_y), arcpy.Point(X=near_x, Y=near_y)]
+        )
+        geom = arcpy.Polyline(
+            inputs=arr,
+            spatial_reference=spatial_reference,
+        )
+
+        return (geom, int(original_id), float(dist))
+
     def _move_endpoint(
         self, shape, dangle_x: float, dangle_y: float, near_x: float, near_y: float
     ):
@@ -345,13 +407,19 @@ class FillLineGaps:
             )
             return
 
+        if self.line_changes_output is not None:
+            self._setup_line_changes_output()
+
+        spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
+        change_rows: list[tuple] = []
+
         fields = [self.ORIGINAL_ID, "SHAPE@"]
 
         with arcpy.da.UpdateCursor(
             in_table=self.lines_copy,
             field_names=fields,
-        ) as cursor:
-            for original_id, shape in cursor:
+        ) as update_cursor:
+            for original_id, shape in update_cursor:
                 original_id_int = int(original_id)
                 if original_id_int not in plan:
                     continue
@@ -360,14 +428,39 @@ class FillLineGaps:
                 if info["processed"] is True:
                     continue
 
+                dangle_x = float(info["dangle_x"])
+                dangle_y = float(info["dangle_y"])
+                near_x = float(info["near_x"])
+                near_y = float(info["near_y"])
+
                 new_shape = self._move_endpoint(
                     shape=shape,
-                    dangle_x=info["dangle_x"],
-                    dangle_y=info["dangle_y"],
-                    near_x=info["near_x"],
-                    near_y=info["near_y"],
+                    dangle_x=dangle_x,
+                    dangle_y=dangle_y,
+                    near_x=near_x,
+                    near_y=near_y,
                 )
-                cursor.updateRow((original_id, new_shape))
+                update_cursor.updateRow((original_id, new_shape))
+
+                if self.line_changes_output is not None:
+                    row = self._build_change_row(
+                        original_id=original_id_int,
+                        dangle_x=dangle_x,
+                        dangle_y=dangle_y,
+                        near_x=near_x,
+                        near_y=near_y,
+                        spatial_reference=spatial_reference,
+                    )
+                    if row is not None:
+                        change_rows.append(row)
+
+        if self.line_changes_output is not None and change_rows:
+            with arcpy.da.InsertCursor(
+                in_table=self.line_changes_output,
+                field_names=["SHAPE@", self.ORIGINAL_ID, "gap_dist_m"],
+            ) as insert_cursor:
+                for row in change_rows:
+                    insert_cursor.insertRow(row)
 
         arcpy.management.CopyFeatures(
             in_features=self.lines_copy,

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -953,6 +953,8 @@ _Grouped: TypeAlias = dict[int, list[_CandRow]]
 _NormZByDangle: TypeAlias = dict[int, Optional[float]]
 _ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, str]
 _GlobalWithSource: TypeAlias = tuple[_GlobalProposal, str]
+# (dangle_oid, dangle_x, dangle_y, near_x, near_y)
+_AcceptedConnectorRaw: TypeAlias = tuple[int, float, float, float, float]
 # Diagnostic collection tuples (produced in _select_dangle_proposals, consumed in _assemble_diagnostics)
 _Step1AIllegalEntry: TypeAlias = tuple[int, int, _CandRow, str]
 _Step1BIllegalEntry: TypeAlias = tuple[
@@ -1888,118 +1890,74 @@ class FillLineGaps:
             spatial_reference,
         )
 
-    @staticmethod
-    def _connector_intersects_any(
-        trimmed_connector: Any,
-        geom_with_extents: list[tuple[Any, Any]],
-    ) -> bool:
-        """
-        Returns True if trimmed_connector intersects any geometry in the list.
-
-        Caller must pre-trim the connector so that legitimate endpoint touches
-        are excluded before calling this method.
-
-        Each element of geom_with_extents is (geometry, geometry.extent).
-        The extent is used as a cheap bounding-box pre-filter so that the
-        expensive .disjoint() call is only made when envelopes actually overlap.
-        """
-        conn_ext = trimmed_connector.extent
-        cx_min = conn_ext.XMin
-        cx_max = conn_ext.XMax
-        cy_min = conn_ext.YMin
-        cy_max = conn_ext.YMax
-        for geom, ext in geom_with_extents:
-            if cx_max < ext.XMin or cx_min > ext.XMax:
-                continue
-            if cy_max < ext.YMin or cy_min > ext.YMax:
-                continue
-            if not trimmed_connector.disjoint(geom):
-                return True
-        return False
-
-    def _collect_spatially_selected_geometries(
+    def _write_trimmed_cands_fc(
         self,
         *,
-        trimmed_geoms: list[Any],
-        check_feature_layers: list[str],
+        cands_with_keys: list[tuple[Any, Any]],
+        fc_path: str,
         spatial_reference: Any,
-    ) -> list[tuple[Any, Any]]:
-        """
-        Writes trimmed_geoms to a temporary in-memory FC, then for each layer in
-        check_feature_layers runs SelectLayerByLocation (INTERSECT) to collect only
-        those features that intersect at least one trimmed connector.
+    ) -> dict[int, Any]:
+        """Write trimmed connector geometries to a temp in-memory FC.
 
-        Returns a list of (geometry, extent) pairs ready for _connector_intersects_any.
-        The temporary FC and feature layers are deleted before returning.
+        Creates fc_path, inserts one polyline per (key, geom) pair, and returns
+        a mapping from OID → key so near-table IN_FID results can be resolved
+        back to the original candidate identifier.
+
+        CAND_IDX stores the insertion index; a post-insert SearchCursor builds
+        the OID→key mapping without relying on OID-assignment order.
         """
-        _temp_fc = "memory/crossing_check_trimmed_cands"
-        if arcpy.Exists(_temp_fc):
-            arcpy.management.Delete(_temp_fc)
+        if arcpy.Exists(fc_path):
+            arcpy.management.Delete(fc_path)
+        workspace, fc_name = fc_path.rsplit("/", 1)
         arcpy.management.CreateFeatureclass(
-            "memory", "crossing_check_trimmed_cands", "POLYLINE",
-            spatial_reference=spatial_reference,
+            workspace, fc_name, "POLYLINE", spatial_reference=spatial_reference
         )
-        with arcpy.da.InsertCursor(_temp_fc, ["SHAPE@"]) as ins:
-            for geom in trimmed_geoms:
-                ins.insertRow((geom,))
+        arcpy.management.AddField(fc_path, "CAND_IDX", "LONG")
 
-        result: list[tuple[Any, Any]] = []
-        try:
-            for check_lyr in check_feature_layers:
-                _temp_lyr = "crossing_check_sel_lyr"
-                arcpy.management.MakeFeatureLayer(check_lyr, _temp_lyr)
-                try:
-                    arcpy.management.SelectLayerByLocation(
-                        _temp_lyr,
-                        "INTERSECT",
-                        _temp_fc,
-                        selection_type="NEW_SELECTION",
-                    )
-                    with arcpy.da.SearchCursor(_temp_lyr, ["SHAPE@"]) as cur:
-                        for (geom,) in cur:
-                            if geom is not None:
-                                result.append((geom, geom.extent))
-                finally:
-                    arcpy.management.Delete(_temp_lyr)
-        finally:
-            arcpy.management.Delete(_temp_fc)
+        keys_by_idx: dict[int, Any] = {}
+        with arcpy.da.InsertCursor(fc_path, ["SHAPE@", "CAND_IDX"]) as ins:
+            for idx, (key, geom) in enumerate(cands_with_keys):
+                ins.insertRow((geom, idx))
+                keys_by_idx[idx] = key
 
-        return result
+        oid_field = arcpy.Describe(fc_path).OIDFieldName
+        oid_to_key: dict[int, Any] = {}
+        with arcpy.da.SearchCursor(fc_path, [oid_field, "CAND_IDX"]) as cur:
+            for oid, idx in cur:
+                oid_to_key[int(oid)] = keys_by_idx[int(idx)]
+
+        return oid_to_key
 
     def _find_crossing_conflict_keys(
         self,
         *,
-        grouped: "_Grouped",
+        legal_rows_by_dangle: "_Grouped",
         dangle_xy: dict[int, tuple[float, float]],
         check_feature_layers: list[str],
         trim_distance: float,
         spatial_reference: Any,
     ) -> tuple[set[tuple[int, str, int]], dict[tuple[int, str, int], Any]]:
         """
-        Pre-filter: identify candidates whose connector crosses an existing feature.
+        Pre-filter: identify candidates whose trimmed connector crosses an existing feature.
 
-        Step 1 – builds trimmed connector geometries for all candidates and
-                 populates trimmed_cache.
-        Step 2 – delegates to _collect_spatially_selected_geometries to reduce
-                 each check layer to only those features that intersect at least
-                 one trimmed candidate (single arcpy spatial-index batch call per
-                 layer instead of O(candidates × features) Python geometry calls).
-        Step 3 – per-candidate intersection check against the reduced set.
+        Writes trimmed candidate connectors to a temp in-memory FC and uses
+        GenerateNearTable against check_feature_layers as the source of truth for
+        crossing conflicts.  Only legal candidates (already filtered by all other
+        legality checks) are considered, so the temp FC is as small as possible.
 
         Returns:
           crossing_conflict_keys
-            (dangle_oid, near_fc_key, near_fid) tuples whose trimmed connector
-            intersects at least one check geometry.
+            (dangle_oid, near_fc_key, near_fid) tuples whose trimmed connector is
+            within connectivity_tolerance_meters of any check feature.
           trimmed_cache
-            Trimmed connector polyline for every candidate key (None when the
-            connector is too short to trim).  Cached here so Kruskal's crossing
-            check can reuse the geometries without re-trimming.
+            Trimmed connector polyline for every legal candidate key (None when the
+            connector is too short to trim after 2x trimming).  Reused by the
+            Kruskal candidate-vs-candidate crossing check.
         """
-        # --- Step 1: build trimmed cache ---
         trimmed_cache: dict[tuple[int, str, int], Any] = {}
-        trimmed_geoms: list[Any] = []
+        cands_with_keys: list[tuple[tuple[int, str, int], Any]] = []
 
-        for dangle_oid, candidates in grouped.items():
+        for dangle_oid, candidates in legal_rows_by_dangle.items():
             dangle_oid = int(dangle_oid)
             xy = dangle_xy.get(dangle_oid)
             if xy is None:
@@ -2021,28 +1979,43 @@ class FillLineGaps:
                 )
                 trimmed_cache[key] = trimmed
                 if trimmed is not None:
-                    trimmed_geoms.append(trimmed)
+                    cands_with_keys.append((key, trimmed))
 
-        if not trimmed_geoms or not check_feature_layers:
+        if not cands_with_keys or not check_feature_layers:
             return set(), trimmed_cache
 
-        # --- Step 2: spatially-select check features ---
-        check_geoms_with_extents = self._collect_spatially_selected_geometries(
-            trimmed_geoms=trimmed_geoms,
-            check_feature_layers=check_feature_layers,
+        _cands_fc = "memory/crossing_check_trimmed_cands"
+        _near_table = "memory/crossing_check_near"
+
+        oid_to_key = self._write_trimmed_cands_fc(
+            cands_with_keys=cands_with_keys,
+            fc_path=_cands_fc,
             spatial_reference=spatial_reference,
         )
 
-        if not check_geoms_with_extents:
-            return set(), trimmed_cache
+        if arcpy.Exists(_near_table):
+            arcpy.management.Delete(_near_table)
+        arcpy.analysis.GenerateNearTable(
+            in_features=_cands_fc,
+            near_features=check_feature_layers,
+            out_table=_near_table,
+            search_radius=self._connectivity_tolerance_linear_unit(),
+            location="NO_LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=0,
+            method="PLANAR",
+        )
 
-        # --- Step 3: per-candidate intersection check against the reduced set ---
         conflict_keys: set[tuple[int, str, int]] = set()
-        for key, trimmed in trimmed_cache.items():
-            if trimmed is None:
-                continue
-            if self._connector_intersects_any(trimmed, check_geoms_with_extents):
-                conflict_keys.add(key)
+        with arcpy.da.SearchCursor(_near_table, ["IN_FID"]) as cur:
+            for (in_fid,) in cur:
+                key = oid_to_key.get(int(in_fid))
+                if key is not None:
+                    conflict_keys.add(key)
+
+        arcpy.management.Delete(_near_table)
+        arcpy.management.Delete(_cands_fc)
 
         return conflict_keys, trimmed_cache
 
@@ -3048,8 +3021,8 @@ class FillLineGaps:
         dict[int, list[dict]],
         list["_ResnappedCapture"],
         list["CandidateDiagnostic"],
-        list[Any],   # accepted_connector_geoms  (for resnap crossing re-check)
-        dict[int, int],  # kruskal_rank_by_dangle_oid (for resnap crossing re-check)
+        list[_AcceptedConnectorRaw],  # accepted_connector_raw (for resnap crossing re-check)
+        dict[int, int],               # kruskal_rank_by_dangle_oid (for resnap crossing re-check)
     ]:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
@@ -3160,37 +3133,6 @@ class FillLineGaps:
         if self.fill_gaps_on_self:
             line_like_ds_keys.add(lines_key)
 
-        # ----------------------------
-        # Crossing conflict pre-filter (Step 1a)
-        # Build trimmed connector geometries for all candidates and flag any
-        # that cross an existing feature (self-lines + connect_to_features).
-        # The trimmed connector cache is reused in _run_kruskal.
-        # ----------------------------
-        crossing_conflict_keys: set[tuple[int, str, int]] = set()
-        trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
-
-        if self.reject_crossing_connectors:
-            _crossing_sr = arcpy.SpatialReference(
-                self.crossing_check_spatial_reference
-            )
-            # lines_copy provides self-line geometries (source of polyline_by_parent).
-            # External layers whose ds_key is in polyline_by_external are polyline
-            # features that were loaded as angle caches; pass their layer paths so
-            # _find_crossing_conflict_keys can run SelectLayerByLocation on them.
-            _check_layers: list[str] = [self.lines_copy]
-            for _lyr in target_layers:
-                if self._dataset_key(_lyr) in polyline_by_external:
-                    _check_layers.append(_lyr)
-            crossing_conflict_keys, trimmed_connector_cache = (
-                self._find_crossing_conflict_keys(
-                    grouped=grouped,
-                    dangle_xy=dangle_xy,
-                    check_feature_layers=_check_layers,
-                    trim_distance=float(self.connectivity_tolerance_meters),
-                    spatial_reference=_crossing_sr,
-                )
-            )
-
         # In directed mode, source dangles at a line's start node are invalid sources.
         # polyline_by_parent is already built above; dangle_xy was built at the top.
         directed_start_dangles = self._directed_start_dangle_oids(
@@ -3215,9 +3157,62 @@ class FillLineGaps:
                 topology=topology,
                 collect_diags=collect_diags,
                 directed_source_illegal_oids=directed_start_dangles,
-                crossing_conflict_keys=crossing_conflict_keys,
             )
         )
+
+        # ----------------------------
+        # Crossing conflict pre-filter (last legality check)
+        # Run after all other legality checks so only surviving legal candidates
+        # are written to the temp FC.  The trimmed connector cache is reused in
+        # _run_kruskal for the candidate-vs-candidate crossing check.
+        # ----------------------------
+        trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
+        if self.reject_crossing_connectors and legal_rows_by_dangle:
+            _crossing_sr = arcpy.SpatialReference(
+                self.crossing_check_spatial_reference
+            )
+            # lines_copy provides self-line geometries; external polyline layers
+            # whose ds_key is in polyline_by_external were loaded as angle caches.
+            _check_layers: list[str] = [self.lines_copy]
+            for _lyr in target_layers:
+                if self._dataset_key(_lyr) in polyline_by_external:
+                    _check_layers.append(_lyr)
+            crossing_conflict_keys, trimmed_connector_cache = (
+                self._find_crossing_conflict_keys(
+                    legal_rows_by_dangle=legal_rows_by_dangle,
+                    dangle_xy=dangle_xy,
+                    check_feature_layers=_check_layers,
+                    trim_distance=2.0 * float(self.connectivity_tolerance_meters),
+                    spatial_reference=_crossing_sr,
+                )
+            )
+            if crossing_conflict_keys:
+                for _dangle_oid in list(legal_rows_by_dangle.keys()):
+                    _parent_id = parent_id_by_dangle[_dangle_oid]
+                    _remaining: list[dict] = []
+                    for _cand in legal_rows_by_dangle[_dangle_oid]:
+                        _cand_key = (
+                            _dangle_oid,
+                            str(_cand["near_fc_key"]),
+                            int(_cand["near_fid"]),
+                        )
+                        if _cand_key in crossing_conflict_keys:
+                            if collect_diags:
+                                _step1a_illegal.append(
+                                    (
+                                        _dangle_oid,
+                                        _parent_id,
+                                        _cand,
+                                        "crosses_existing_feature",
+                                    )
+                                )
+                        else:
+                            _remaining.append(_cand)
+                    if _remaining:
+                        legal_rows_by_dangle[_dangle_oid] = _remaining
+                    else:
+                        del legal_rows_by_dangle[_dangle_oid]
+                        parent_id_by_dangle.pop(_dangle_oid, None)
 
         if not legal_rows_by_dangle:
             return (
@@ -3438,7 +3433,7 @@ class FillLineGaps:
             kruskal_rejected_oids,
             kruskal_crossing_rejected_oids,
             gap_source_by_dangle,
-            accepted_connector_geoms,
+            accepted_connector_raw,
             kruskal_rank_by_dangle_oid,
         ) = self._run_kruskal(
             global_winners=_global_winners,
@@ -3509,7 +3504,7 @@ class FillLineGaps:
                 dangles_key=dangles_key,
                 lines_key=lines_key,
             ),
-            accepted_connector_geoms,
+            accepted_connector_raw,
             kruskal_rank_by_dangle_oid,
         )
 
@@ -3527,7 +3522,6 @@ class FillLineGaps:
         topology: TopologyModel,
         collect_diags: bool,
         directed_source_illegal_oids: set[int],
-        crossing_conflict_keys: set[tuple[int, str, int]],
     ) -> tuple[_Grouped, dict[int, int], list[_Step1AIllegalEntry]]:
         """Dangle filtering: collect legal candidates per dangle.
 
@@ -3568,15 +3562,6 @@ class FillLineGaps:
                 if str(cand["near_fc_key"]) == str(lines_key) and int(
                     cand["near_fid"]
                 ) == int(parent_id):
-                    continue
-
-                # Candidate whose connector crosses an existing feature is illegal.
-                cand_key = (dangle_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))
-                if cand_key in crossing_conflict_keys:
-                    if collect_diags:
-                        _step1a_illegal.append(
-                            (dangle_oid, parent_id, cand, "crosses_existing_feature")
-                        )
                     continue
 
                 is_legal = self._candidate_is_legal(
@@ -4133,8 +4118,8 @@ class FillLineGaps:
         set[int],         # kruskal_rejected_oids (cycle-based)
         set[int],         # kruskal_crossing_rejected_oids
         dict[int, str],   # gap_source_by_dangle
-        list[Any],        # accepted_connector_geoms (original untrimmed, for resnap re-check)
-        dict[int, int],   # kruskal_rank_by_dangle_oid
+        list[_AcceptedConnectorRaw],  # accepted_connector_raw (for resnap crossing re-check)
+        dict[int, int],               # kruskal_rank_by_dangle_oid
     ]:
         """Global selection: Kruskal cycle prevention across accepted connections.
 
@@ -4143,40 +4128,81 @@ class FillLineGaps:
           - Cycle rejection: UF finds src_node and tgt_node already in the same
             component (reason: lost_kruskal_selection).
           - Crossing rejection (when reject_crossing_connectors is True): the
-            candidate's trimmed connector intersects the original geometry of an
-            already-accepted connector (reason: crosses_accepted_connector).
+            candidate's trimmed connector is within connectivity_tolerance_meters
+            of an already-accepted candidate's trimmed connector
+            (reason: crosses_accepted_connector).
 
-        Crossing check uses trimmed_connector_cache (built in _find_crossing_conflict_keys)
-        to avoid re-trimming.  Accepted connector geometries are stored in
-        original (untrimmed) form because the accepted connectors' full bodies
-        are real output geometry; any intersection of the new trimmed candidate
-        with that body — including endpoints — is a genuine crossing conflict.
+        Crossing uses a single pre-loop GenerateNearTable of all candidate trimmed
+        connectors against themselves to build a conflict lookup.  During the loop,
+        _crossing_blocked consults that lookup instead of running live geometry
+        checks.
 
         Note on deferred displacement inaccuracy:
             When a deferred connector's (resnap capture's) final geometry causes
             a previously accepted connector to be displaced during the resnap
             re-check (see _recheck_resnap_crossings), the Union-Find state built
-            here becomes stale.  Two consequences follow: (1) components merged
-            by the displaced connector become disconnected in output, and (2)
-            candidates rejected here as cycle-forming may in hindsight have been
-            valid.  Both are accepted inaccuracies — the scenario is rare enough
-            that a full mock-Kruskal + mock-deferred pass to eliminate it is not
+            here becomes stale.  Both are accepted inaccuracies — the scenario is
+            rare enough that a full mock-Kruskal + mock-deferred pass is not
             justified.
 
         Returns (proposals, accepted_dangle_oids, kruskal_rejected_oids,
                  kruskal_crossing_rejected_oids, gap_source_by_dangle,
-                 accepted_connector_geoms, kruskal_rank_by_dangle_oid).
+                 accepted_connector_raw, kruskal_rank_by_dangle_oid).
         """
         reject_crossing = crossing_spatial_reference is not None
         scope = topology.scope
         _global_proposals: list[_GlobalWithSource] = []
         kruskal_crossing_rejected_oids: set[int] = set()
-        # Stores (geometry, extent) pairs so _connector_intersects_any can apply
-        # the bounding-box pre-filter without re-fetching extents each call.
-        accepted_connector_geoms: list[tuple[Any, Any]] = []
-        accepted_connector_dangle_oids: list[int] = []
+        accepted_keys: set[tuple[int, str, int]] = set()
+        accepted_connector_raw: list[_AcceptedConnectorRaw] = []
         kruskal_rank_by_dangle_oid: dict[int, int] = {}
         rank_counter = 0
+
+        # --- Pre-loop: build candidate-vs-candidate conflict lookup ---
+        conflict_lookup: dict[tuple[int, str, int], set[tuple[int, str, int]]] = {}
+        if reject_crossing:
+            _kruskal_cands: list[tuple[tuple[int, str, int], Any]] = []
+            for prop, _ in global_winners:
+                _key = (
+                    int(prop.ctx.dangle_oid),
+                    str(prop.ctx.near_fc_key),
+                    int(prop.ctx.near_fid),
+                )
+                _trimmed = trimmed_connector_cache.get(_key)
+                if _trimmed is not None:
+                    _kruskal_cands.append((_key, _trimmed))
+
+            if _kruskal_cands:
+                _kruskal_fc = "memory/crossing_check_kruskal_cands"
+                _kruskal_near = "memory/crossing_check_kruskal_near"
+                _kruskal_oid_to_key = self._write_trimmed_cands_fc(
+                    cands_with_keys=_kruskal_cands,
+                    fc_path=_kruskal_fc,
+                    spatial_reference=crossing_spatial_reference,
+                )
+                if arcpy.Exists(_kruskal_near):
+                    arcpy.management.Delete(_kruskal_near)
+                arcpy.analysis.GenerateNearTable(
+                    in_features=_kruskal_fc,
+                    near_features=[_kruskal_fc],
+                    out_table=_kruskal_near,
+                    search_radius=self._connectivity_tolerance_linear_unit(),
+                    location="NO_LOCATION",
+                    angle="NO_ANGLE",
+                    closest="ALL",
+                    closest_count=0,
+                    method="PLANAR",
+                )
+                with arcpy.da.SearchCursor(_kruskal_near, ["IN_FID", "NEAR_FID"]) as _cur:
+                    for _in_fid, _near_fid in _cur:
+                        if int(_in_fid) == int(_near_fid):
+                            continue
+                        _key_in = _kruskal_oid_to_key.get(int(_in_fid))
+                        _key_near = _kruskal_oid_to_key.get(int(_near_fid))
+                        if _key_in is not None and _key_near is not None:
+                            conflict_lookup.setdefault(_key_in, set()).add(_key_near)
+                arcpy.management.Delete(_kruskal_near)
+                arcpy.management.Delete(_kruskal_fc)
 
         def _accept(prop: Any, gap_source: Any) -> None:
             nonlocal rank_counter
@@ -4185,21 +4211,15 @@ class FillLineGaps:
                 rank_counter += 1
                 d_oid = int(prop.ctx.dangle_oid)
                 kruskal_rank_by_dangle_oid[d_oid] = rank_counter
-                accepted_connector_dangle_oids.append(d_oid)
-                geom = arcpy.Polyline(
-                    arcpy.Array(
-                        [
-                            arcpy.Point(
-                                float(prop.ctx.dangle_x), float(prop.ctx.dangle_y)
-                            ),
-                            arcpy.Point(
-                                float(prop.ctx.near_x), float(prop.ctx.near_y)
-                            ),
-                        ]
-                    ),
-                    crossing_spatial_reference,
-                )
-                accepted_connector_geoms.append((geom, geom.extent))
+                _key = (d_oid, str(prop.ctx.near_fc_key), int(prop.ctx.near_fid))
+                accepted_keys.add(_key)
+                accepted_connector_raw.append((
+                    d_oid,
+                    float(prop.ctx.dangle_x),
+                    float(prop.ctx.dangle_y),
+                    float(prop.ctx.near_x),
+                    float(prop.ctx.near_y),
+                ))
 
         def _crossing_blocked(prop: Any) -> bool:
             if not reject_crossing:
@@ -4209,10 +4229,10 @@ class FillLineGaps:
                 str(prop.ctx.near_fc_key),
                 int(prop.ctx.near_fid),
             )
-            trimmed = trimmed_connector_cache.get(key)
-            if trimmed is None:
+            if trimmed_connector_cache.get(key) is None:
                 return False
-            return self._connector_intersects_any(trimmed, accepted_connector_geoms)
+            return bool(conflict_lookup.get(key, set()) & accepted_keys)
+
         if scope in (
             logic_config.ConnectivityScope.INPUT_LINES,
             logic_config.ConnectivityScope.ONE_DEGREE,
@@ -4277,7 +4297,7 @@ class FillLineGaps:
             kruskal_rejected_oids,
             kruskal_crossing_rejected_oids,
             gap_source_by_dangle,
-            accepted_connector_geoms,
+            accepted_connector_raw,
             kruskal_rank_by_dangle_oid,
         )
 
@@ -4319,7 +4339,7 @@ class FillLineGaps:
         self,
         *,
         resnap_plan: dict[int, dict],
-        accepted_connector_geoms: list[Any],
+        accepted_connector_raw: list[_AcceptedConnectorRaw],
         kruskal_rank_by_dangle_oid: dict[int, int],
         trim_distance: float,
         spatial_reference: Any,
@@ -4327,7 +4347,9 @@ class FillLineGaps:
         """Re-check resnap captures against accepted connector geometries.
 
         Called after _resnap_connections resolves final geometry for deferred
-        connectors.  Uses rank-based conflict resolution:
+        connectors.  Uses GenerateNearTable (trimmed resnap connectors vs trimmed
+        accepted connectors) as the source of truth for crossing conflicts, then
+        applies rank-based conflict resolution:
 
           - If the resnap capture has a worse (higher) rank than the best-ranked
             conflicting accepted connector → the resnap capture loses; its plan
@@ -4340,24 +4362,14 @@ class FillLineGaps:
         Returns (resnap_plan, resnap_crossing_rejected_oids,
                  resnap_crossing_displaced_oids).
         """
-        if not accepted_connector_geoms:
+        if not accepted_connector_raw:
             return resnap_plan, set(), set()
 
-        # Build reverse lookup: index in accepted_connector_geoms → dangle_oid
-        # (populated alongside accepted_connector_geoms in _run_kruskal)
-        # We recover this from kruskal_rank_by_dangle_oid: rank = index + 1.
-        rank_to_dangle_oid: dict[int, int] = {
-            rank: d_oid for d_oid, rank in kruskal_rank_by_dangle_oid.items()
-        }
-
-        resnap_crossing_rejected_oids: set[int] = set()
-        resnap_crossing_displaced_oids: set[int] = set()
-
+        # Build trimmed resnap connectors: key = parent_id (unique per resnap entry).
+        resnap_cands: list[tuple[Any, Any]] = []
         for parent_id, entry in resnap_plan.items():
             if entry.get("skip", False):
                 continue
-
-            dangle_oid = int(entry["dangle_oid"])
             trimmed = self._build_trimmed_connector(
                 from_x=float(entry["dangle_x"]),
                 from_y=float(entry["dangle_y"]),
@@ -4366,40 +4378,92 @@ class FillLineGaps:
                 trim_distance=trim_distance,
                 spatial_reference=spatial_reference,
             )
-            if trimmed is None:
+            if trimmed is not None:
+                resnap_cands.append((parent_id, trimmed))
+
+        if not resnap_cands:
+            return resnap_plan, set(), set()
+
+        # Build trimmed accepted connectors: key = dangle_oid.
+        accepted_cands: list[tuple[Any, Any]] = []
+        for acc_doid, ax, ay, bx, by in accepted_connector_raw:
+            trimmed = self._build_trimmed_connector(
+                from_x=ax,
+                from_y=ay,
+                to_x=bx,
+                to_y=by,
+                trim_distance=trim_distance,
+                spatial_reference=spatial_reference,
+            )
+            if trimmed is not None:
+                accepted_cands.append((acc_doid, trimmed))
+
+        if not accepted_cands:
+            return resnap_plan, set(), set()
+
+        _resnap_fc = "memory/resnap_crossing_trimmed"
+        _accepted_fc = "memory/resnap_crossing_accepted"
+        _near_table = "memory/resnap_crossing_near"
+
+        oid_to_parent_id = self._write_trimmed_cands_fc(
+            cands_with_keys=resnap_cands,
+            fc_path=_resnap_fc,
+            spatial_reference=spatial_reference,
+        )
+        oid_to_accepted_doid = self._write_trimmed_cands_fc(
+            cands_with_keys=accepted_cands,
+            fc_path=_accepted_fc,
+            spatial_reference=spatial_reference,
+        )
+
+        if arcpy.Exists(_near_table):
+            arcpy.management.Delete(_near_table)
+        arcpy.analysis.GenerateNearTable(
+            in_features=_resnap_fc,
+            near_features=[_accepted_fc],
+            out_table=_near_table,
+            search_radius=self._connectivity_tolerance_linear_unit(),
+            location="NO_LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=0,
+            method="PLANAR",
+        )
+
+        # {parent_id: set of conflicting accepted dangle_oids}
+        conflicts_by_parent: dict[int, set[int]] = {}
+        with arcpy.da.SearchCursor(_near_table, ["IN_FID", "NEAR_FID"]) as cur:
+            for in_fid, near_fid in cur:
+                parent_id = oid_to_parent_id.get(int(in_fid))
+                acc_doid = oid_to_accepted_doid.get(int(near_fid))
+                if parent_id is not None and acc_doid is not None:
+                    conflicts_by_parent.setdefault(parent_id, set()).add(int(acc_doid))
+
+        arcpy.management.Delete(_near_table)
+        arcpy.management.Delete(_resnap_fc)
+        arcpy.management.Delete(_accepted_fc)
+
+        resnap_crossing_rejected_oids: set[int] = set()
+        resnap_crossing_displaced_oids: set[int] = set()
+
+        for parent_id, entry in resnap_plan.items():
+            if entry.get("skip", False):
                 continue
 
-            # Find indices of conflicting accepted connectors (extent pre-filter).
-            trimmed_ext = trimmed.extent
-            conflict_indices = [
-                i
-                for i, (geom, ext) in enumerate(accepted_connector_geoms)
-                if not (
-                    trimmed_ext.XMax < ext.XMin or trimmed_ext.XMin > ext.XMax
-                    or trimmed_ext.YMax < ext.YMin or trimmed_ext.YMin > ext.YMax
-                )
-                and not trimmed.disjoint(geom)
-            ]
-            if not conflict_indices:
+            conflicting_doids = conflicts_by_parent.get(parent_id)
+            if not conflicting_doids:
                 continue
 
-            # Rank of the resnap capture; default to +inf if somehow absent.
+            dangle_oid = int(entry["dangle_oid"])
             resnap_rank = kruskal_rank_by_dangle_oid.get(dangle_oid, float("inf"))
-
-            # Best (lowest) rank among conflicting accepted connectors.
             best_conflict_rank = min(
-                kruskal_rank_by_dangle_oid.get(
-                    rank_to_dangle_oid.get(i + 1, -1), float("inf")
-                )
-                for i in conflict_indices
+                kruskal_rank_by_dangle_oid.get(aoid, float("inf"))
+                for aoid in conflicting_doids
             )
 
             if resnap_rank <= best_conflict_rank:
                 # Resnap capture wins: displace the conflicting accepted connectors.
-                for i in conflict_indices:
-                    conflict_d_oid = rank_to_dangle_oid.get(i + 1)
-                    if conflict_d_oid is not None:
-                        resnap_crossing_displaced_oids.add(conflict_d_oid)
+                resnap_crossing_displaced_oids.update(conflicting_doids)
             else:
                 # Resnap capture loses: skip the corrected-geometry application.
                 entry["skip"] = True
@@ -5267,7 +5331,7 @@ class FillLineGaps:
         if self.candidate_connections_output is not None:
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
-        plan, resnap_captures, diagnostics, accepted_connector_geoms, kruskal_rank_by_dangle_oid = (
+        plan, resnap_captures, diagnostics, accepted_connector_raw, kruskal_rank_by_dangle_oid = (
             self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
         )
 
@@ -5288,13 +5352,13 @@ class FillLineGaps:
                 snap_source_dangle_xy=snap_source_dangle_xy,
             )
 
-            if self.reject_crossing_connectors and resnap_plan and accepted_connector_geoms:
+            if self.reject_crossing_connectors and resnap_plan and accepted_connector_raw:
                 resnap_plan, resnap_crossing_rejected_oids, resnap_crossing_displaced_oids = (
                     self._recheck_resnap_crossings(
                         resnap_plan=resnap_plan,
-                        accepted_connector_geoms=accepted_connector_geoms,
+                        accepted_connector_raw=accepted_connector_raw,
                         kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
-                        trim_distance=float(self.connectivity_tolerance_meters),
+                        trim_distance=2.0 * float(self.connectivity_tolerance_meters),
                         spatial_reference=arcpy.SpatialReference(
                             self.crossing_check_spatial_reference
                         ),

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -41,6 +41,74 @@ class EditOp(str, Enum):
     EXTEND = "extend"
 
 
+class GapSource(str, Enum):
+    """How a connection was chosen.
+
+    default: single-ended selection. The dangle picked a target on its own, nothing
+        on the target side voted to pair back.
+    pair_dangle: both endpoints are true dangles that prefer each other's parent
+        line. A SNAP edit moves one endpoint onto the other, fusing the pair.
+    pair_line: two network nodes each have a proposal pointing at the other. An
+        EXTEND edit attaches the source onto the target line.
+    """
+
+    DEFAULT = "default"
+    PAIR_DANGLE = "pair_dangle"
+    PAIR_LINE = "pair_line"
+
+
+@dataclass(frozen=True)
+class NearCandidate:
+    """One row from the GenerateNearTable output, already keyed against the canonical
+    dataset keys (line-like targets collapsed onto a single ``lines_key``).
+
+    near_fc_key_raw preserves the original dataset key before normalization; kept for
+    debugging only.
+    """
+
+    near_fc_key: str
+    near_fid: int
+    near_dist: float
+    near_x: float
+    near_y: float
+    near_fc_key_raw: str
+
+
+@dataclass(frozen=True)
+class PlanEntryMeta:
+    """Optional diagnostic metadata attached to a PlanEntry when
+    ``write_output_metadata`` is enabled."""
+
+    bonus_applied: bool
+    src_connector_diff: Optional[float]
+    connector_target_diff: Optional[float]
+    src_target_diff: Optional[float]
+    connector_transition_diff: Optional[float]
+    angle_metric_deg: Optional[float]
+    best_fit_score: Optional[float]
+
+
+@dataclass
+class PlanEntry:
+    """One scheduled edit for a parent line. Mutable so _apply_plan can flip
+    ``processed`` and _apply_pair_symmetric_skip / _recheck_resnap_crossings can
+    flip ``skip``."""
+
+    dangle_oid: int
+    dangle_x: float
+    dangle_y: float
+    near_x: float
+    near_y: float
+    chosen_near_fc_key: str
+    chosen_near_fid: int
+    gap_source: GapSource
+    edit_op: EditOp
+    pair_parent: Optional[int] = None
+    processed: bool = False
+    skip: bool = False
+    meta: Optional[PlanEntryMeta] = None
+
+
 class _UnionFind:
     def __init__(self) -> None:
         self._parent: dict[EntityKey, EntityKey] = {}
@@ -860,7 +928,7 @@ class _ResnappedCapture:
     dangle_oid: int
     forced_target_parent: int  # target_parent_id of the accepted connection
     proposal: "_GlobalProposal"
-    gap_source: str
+    gap_source: GapSource
 
 
 @dataclass(frozen=True)
@@ -961,11 +1029,9 @@ class CandidateDiagnostic:
 # ---------------------------------------------------------------------------
 _DangleXYsByParent: TypeAlias = dict[int, list[tuple[float, float]]]
 _IllegalTargets: TypeAlias = dict[int, dict[str, set[int]]]
-_CandRow: TypeAlias = dict[str, Any]
-_Grouped: TypeAlias = dict[int, list[_CandRow]]
 _NormZByDangle: TypeAlias = dict[int, Optional[float]]
-_ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, str]
-_GlobalWithSource: TypeAlias = tuple[_GlobalProposal, str]
+_ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, GapSource]
+_GlobalWithSource: TypeAlias = tuple[_GlobalProposal, GapSource]
 # (dangle_oid, dangle_x, dangle_y, near_x, near_y)
 _AcceptedConnectorRaw: TypeAlias = tuple[int, float, float, float, float]
 
@@ -975,7 +1041,7 @@ class _CandidateIllegalA(NamedTuple):
 
     dangle_oid: int
     parent_id: int
-    cand: _CandRow
+    cand: NearCandidate
     reason: str
 
 
@@ -984,7 +1050,7 @@ class _CandidateIllegalB(NamedTuple):
 
     dangle_oid: int
     parent_id: int
-    cand: _CandRow
+    cand: NearCandidate
     assess: AngleAssessment
     reason: str
     start_z: Optional[float]
@@ -996,7 +1062,7 @@ class _CandidateScored(NamedTuple):
 
     dangle_oid: int
     parent_id: int
-    cand: _CandRow
+    cand: NearCandidate
     assess: AngleAssessment
     raw_distance: float
     best_fit: float
@@ -1021,10 +1087,36 @@ class _DiagnosticsState:
     kruskal_rejected_oids: set[int]
     kruskal_crossing_rejected_oids: set[int]
     accepted_dangle_oids: set[int]
-    gap_source_by_dangle: dict[int, str]
+    gap_source_by_dangle: dict[int, GapSource]
     dangle_norm_z_by_dangle: _NormZByDangle
     connection_norm_z_by_dangle: _NormZByDangle
     global_norm_z_by_dangle: _NormZByDangle
+
+
+# Per-parent plan: each parent line carries a list of planned edits, applied in
+# order by _apply_plan.
+PlanByParent: TypeAlias = dict[int, list[PlanEntry]]
+
+
+@dataclass(frozen=True)
+class BuildPlanResult:
+    """Bundle of everything _build_plan hands back to run()."""
+
+    plan_by_parent: PlanByParent
+    resnap_captures: list["_ResnappedCapture"]
+    diagnostics: list["CandidateDiagnostic"]
+    accepted_connector_raw: list[_AcceptedConnectorRaw]
+    kruskal_rank_by_dangle_oid: dict[int, int]
+
+    @classmethod
+    def empty(cls, diagnostics: list["CandidateDiagnostic"]) -> "BuildPlanResult":
+        return cls(
+            plan_by_parent={},
+            resnap_captures=[],
+            diagnostics=diagnostics,
+            accepted_connector_raw=[],
+            kruskal_rank_by_dangle_oid={},
+        )
 
 
 class FillLineGaps:
@@ -1033,10 +1125,6 @@ class FillLineGaps:
     # Change output fields
     FIELD_GAP_DIST_M = "gap_dist_m"
     FIELD_GAP_SOURCE = "gap_source"
-
-    GAP_SOURCE_DEFAULT = "default"
-    GAP_SOURCE_PAIR_DANGLE = "pair_dangle"
-    GAP_SOURCE_PAIR_LINE = "pair_line"
 
     # Near table fields
     F_IN_FID = "IN_FID"
@@ -1205,7 +1293,7 @@ class FillLineGaps:
                 out[int(oid)] = int(original_id)
         return out
 
-    def _resolve_edit_op(self, *, gap_source: str) -> EditOp:
+    def _resolve_edit_op(self, *, gap_source: GapSource) -> EditOp:
         method = self.edit_method
 
         if method == logic_config.EditMethod.FORCED_SNAP:
@@ -1214,7 +1302,7 @@ class FillLineGaps:
             return EditOp.EXTEND
 
         # AUTO
-        if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE:
+        if gap_source is GapSource.PAIR_DANGLE:
             return EditOp.SNAP
         return EditOp.EXTEND
 
@@ -1303,14 +1391,14 @@ class FillLineGaps:
 
         return arcpy.Polyline(arcpy.Array(points), shape.spatialReference)
 
-    def _candidate_sort_key(self, cand: dict) -> tuple:
+    def _candidate_sort_key(self, cand: NearCandidate) -> tuple:
         # Deterministic ordering for candidate rows within a dangle
         return (
-            float(cand.get("near_dist", float("inf"))),
-            str(cand.get("near_fc_key", "")),
-            int(cand.get("near_fid", -1)),
-            float(cand.get("near_x", 0.0)),
-            float(cand.get("near_y", 0.0)),
+            cand.near_dist,
+            cand.near_fc_key,
+            cand.near_fid,
+            cand.near_x,
+            cand.near_y,
         )
 
     def _unordered_pair_key(
@@ -1348,7 +1436,7 @@ class FillLineGaps:
     def _best_legal_line_target_parent(
         self,
         *,
-        legal_rows: list[dict],
+        legal_rows: list[NearCandidate],
         lines_fc_key: str,
     ) -> Optional[int]:
         """
@@ -1357,8 +1445,8 @@ class FillLineGaps:
         `legal_rows` must already be sorted by raw candidate order.
         """
         for cand in legal_rows:
-            if str(cand["near_fc_key"]) == str(lines_fc_key):
-                return int(cand["near_fid"])
+            if cand.near_fc_key == lines_fc_key:
+                return cand.near_fid
         return None
 
     def _mutual_dangle_preference(
@@ -1388,7 +1476,7 @@ class FillLineGaps:
         self,
         *,
         dangle_oid: int,
-        cand: dict,
+        cand: NearCandidate,
         dangles_fc_key: str,
         dangle_parent: dict[int, int],
         best_line_parent_by_dangle: dict[int, int],
@@ -1410,7 +1498,7 @@ class FillLineGaps:
         if extra <= 0:
             return False
 
-        if str(cand["near_fc_key"]) != str(dangles_fc_key):
+        if cand.near_fc_key != dangles_fc_key:
             return False
 
         if not self.require_mutual_dangle_preference_for_bonus:
@@ -1418,7 +1506,7 @@ class FillLineGaps:
 
         return self._mutual_dangle_preference(
             dangle_oid=dangle_oid,
-            other_dangle_oid=int(cand["near_fid"]),
+            other_dangle_oid=cand.near_fid,
             dangle_parent=dangle_parent,
             best_line_parent_by_dangle=best_line_parent_by_dangle,
         )
@@ -1428,13 +1516,13 @@ class FillLineGaps:
         *,
         dangle_oid: int,
         parent_id: int,
-        cand: dict,
+        cand: NearCandidate,
         dangles_fc_key: str,
         dangle_parent: dict[int, int],
         best_line_parent_by_dangle: dict[int, int],
         bonus_allowed: bool = True,
     ) -> tuple[float, float, bool, tuple[float, int, float, int, int, str, int]]:
-        raw_distance = float(cand["near_dist"])
+        raw_distance = cand.near_dist
 
         bonus_applied = False
         if bonus_allowed:
@@ -1461,8 +1549,8 @@ class FillLineGaps:
             float(raw_distance),
             int(parent_id),
             int(dangle_oid),
-            str(cand["near_fc_key"]),
-            int(cand["near_fid"]),
+            cand.near_fc_key,
+            cand.near_fid,
         )
 
         return raw_distance, effective_distance, bool(bonus_applied), score
@@ -1974,7 +2062,7 @@ class FillLineGaps:
     def _find_crossing_conflict_keys(
         self,
         *,
-        legal_rows_by_dangle: "_Grouped",
+        legal_rows_by_dangle: dict[int, list[NearCandidate]],
         dangle_xy: dict[int, tuple[float, float]],
         check_feature_layers: list[str],
         trim_distance: float,
@@ -2008,15 +2096,13 @@ class FillLineGaps:
             from_x, from_y = xy
 
             for cand in candidates:
-                near_fc_key = str(cand["near_fc_key"])
-                near_fid = int(cand["near_fid"])
-                key = (dangle_oid, near_fc_key, near_fid)
+                key = (dangle_oid, cand.near_fc_key, cand.near_fid)
 
                 trimmed = self._build_trimmed_connector(
                     from_x=from_x,
                     from_y=from_y,
-                    to_x=float(cand["near_x"]),
-                    to_y=float(cand["near_y"]),
+                    to_x=cand.near_x,
+                    to_y=cand.near_y,
                     trim_distance=trim_distance,
                     spatial_reference=spatial_reference,
                 )
@@ -2050,7 +2136,7 @@ class FillLineGaps:
     def _find_barrier_crossing_keys(
         self,
         *,
-        legal_rows_by_dangle: "_Grouped",
+        legal_rows_by_dangle: dict[int, list[NearCandidate]],
         dangle_xy: dict[int, tuple[float, float]],
         barrier_layers: list[str] | None,
         trim_distance: float,
@@ -2073,12 +2159,12 @@ class FillLineGaps:
                 continue
             from_x, from_y = xy
             for cand in candidates:
-                key = (dangle_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))
+                key = (dangle_oid, cand.near_fc_key, cand.near_fid)
                 trimmed = self._build_trimmed_connector(
                     from_x=from_x,
                     from_y=from_y,
-                    to_x=float(cand["near_x"]),
-                    to_y=float(cand["near_y"]),
+                    to_x=cand.near_x,
+                    to_y=cand.near_y,
                     trim_distance=trim_distance,
                     spatial_reference=spatial_reference,
                 )
@@ -2355,21 +2441,21 @@ class FillLineGaps:
     def _find_specific_line_candidate(
         self,
         *,
-        candidates_sorted: list[dict],
+        candidates_sorted: list[NearCandidate],
         lines_fc_keys: set[str],
         other_parent_id: int,
         base_tol: float,
-    ) -> Optional[dict]:
+    ) -> Optional[NearCandidate]:
         """
         Find the row that explicitly targets the other *parent line* (lines_copy),
         within base_tol.
         """
         for cand in candidates_sorted:
-            if cand["near_fc_key"] not in lines_fc_keys:
+            if cand.near_fc_key not in lines_fc_keys:
                 continue
-            if int(cand["near_fid"]) != int(other_parent_id):
+            if cand.near_fid != int(other_parent_id):
                 continue
-            if float(cand["near_dist"]) <= float(base_tol):
+            if cand.near_dist <= float(base_tol):
                 return cand
         return None
 
@@ -2406,9 +2492,9 @@ class FillLineGaps:
         target_self_key: str,
         lines_copy_oid_to_orig: dict[int, int],
         target_self_oid_to_orig: dict[int, int],
-    ) -> dict[int, list[dict]]:
+    ) -> dict[int, list[NearCandidate]]:
 
-        grouped: dict[int, list[dict]] = {}
+        grouped: dict[int, list[NearCandidate]] = {}
 
         # Canonical key for “input lines”
         lines_key = self._dataset_key(self.lines_copy)
@@ -2452,14 +2538,14 @@ class FillLineGaps:
                     continue
 
                 grouped.setdefault(in_id, []).append(
-                    {
-                        "near_fc_key_raw": raw_key,  # optional: keep for debugging
-                        "near_fc_key": near_fc_key,  # normalized key
-                        "near_fid": nf_id,
-                        "near_dist": dist,
-                        "near_x": float(near_x),
-                        "near_y": float(near_y),
-                    }
+                    NearCandidate(
+                        near_fc_key=near_fc_key,
+                        near_fid=nf_id,
+                        near_dist=dist,
+                        near_x=float(near_x),
+                        near_y=float(near_y),
+                        near_fc_key_raw=raw_key,
+                    )
                 )
 
         return grouped
@@ -2477,14 +2563,14 @@ class FillLineGaps:
         lines_fc_key: str,
         line_like_ds_keys: set[str],
         parent_id: int,
-        cand: dict,
+        cand: NearCandidate,
         base_tol: float,
         dangle_candidate_tol: float,
         topology: TopologyModel | None = None,
     ) -> bool:
-        ds_key = cand["near_fc_key"]
-        oid = int(cand["near_fid"])
-        dist = float(cand["near_dist"])
+        ds_key = cand.near_fc_key
+        oid = cand.near_fid
+        dist = cand.near_dist
 
         if ds_key == dangles_fc_key:
             if dist > float(dangle_candidate_tol):
@@ -2553,15 +2639,15 @@ class FillLineGaps:
         lines_fc_key: str,
         line_like_ds_keys: set[str],
         parent_id: int,
-        cand: dict,
+        cand: NearCandidate,
         base_tol: float,
         dangle_candidate_tol: float,
         topology: "TopologyModel | None",
     ) -> str:
         """Return the legality-failure reason for a candidate, mirroring _candidate_is_legal."""
-        ds_key = cand["near_fc_key"]
-        oid = int(cand["near_fid"])
-        dist = float(cand["near_dist"])
+        ds_key = cand.near_fc_key
+        oid = cand.near_fid
+        dist = cand.near_dist
 
         if ds_key == dangles_fc_key:
             if dist > float(dangle_candidate_tol):
@@ -2603,14 +2689,14 @@ class FillLineGaps:
 
     def _resolve_target_parent_id(
         self,
-        cand: dict,
+        cand: NearCandidate,
         dangle_parent: dict[int, int],
         dangles_fc_key: str,
         lines_fc_key: str,
     ) -> Optional[int]:
         """Return the target parent original ID for a candidate, or None for external targets."""
-        ds_key = str(cand["near_fc_key"])
-        near_fid = int(cand["near_fid"])
+        ds_key = cand.near_fc_key
+        near_fid = cand.near_fid
         if ds_key == dangles_fc_key:
             return dangle_parent.get(near_fid)
         if ds_key == lines_fc_key:
@@ -2624,7 +2710,7 @@ class FillLineGaps:
         dangle_x: float,
         dangle_y: float,
         src_angle_deg: Optional[float],
-        cand: dict,
+        cand: NearCandidate,
         dangles_fc_key: str,
         lines_fc_key: str,
         dangle_parent: dict[int, int],
@@ -2634,10 +2720,10 @@ class FillLineGaps:
         is_external_line_like: dict[str, bool],
         dangle_xys_by_parent: Optional[_DangleXYsByParent] = None,
     ) -> AngleAssessment:
-        ds_key = str(cand["near_fc_key"])
-        near_fid = int(cand["near_fid"])
-        near_x = float(cand["near_x"])
-        near_y = float(cand["near_y"])
+        ds_key = cand.near_fc_key
+        near_fid = cand.near_fid
+        near_x = cand.near_x
+        near_y = cand.near_y
 
         connector_angle = self._connector_angle_deg(
             from_x=dangle_x, from_y=dangle_y, to_x=near_x, to_y=near_y
@@ -2892,14 +2978,14 @@ class FillLineGaps:
         dangle_parent: dict[int, int],
         dangles_fc_key: str,
         lines_fc_keys: set[str],
-        cand: dict,
+        cand: NearCandidate,
     ) -> Optional[int]:
         """
         Returns the *other parent line id* if this candidate represents “the other side”
         of a potential dangle pair (either via dangle feature or via line feature).
         """
-        ds_key = cand["near_fc_key"]
-        oid = int(cand["near_fid"])
+        ds_key = cand.near_fc_key
+        oid = cand.near_fid
 
         if ds_key == dangles_fc_key:
             other_parent = dangle_parent.get(oid)
@@ -2913,7 +2999,7 @@ class FillLineGaps:
     def _select_first_legal_candidate(
         self,
         *,
-        candidates_sorted: list[dict],
+        candidates_sorted: list[NearCandidate],
         illegal: dict[int, dict[str, set[int]]],
         dangle_parent: dict[int, int],
         dangles_fc_key: str,
@@ -2921,7 +3007,7 @@ class FillLineGaps:
         parent_id: int,
         base_tol: float,
         topology: TopologyModel | None = None,
-    ) -> Optional[dict]:
+    ) -> Optional[NearCandidate]:
         for cand in candidates_sorted:
             if self._candidate_is_legal(
                 illegal=illegal,
@@ -2941,31 +3027,31 @@ class FillLineGaps:
     def _find_best_dangle_candidate_to_parent(
         self,
         *,
-        candidates_sorted: list[dict],
+        candidates_sorted: list[NearCandidate],
         dangles_fc_key: str,
         dangle_parent: dict[int, int],
         target_parent_id: int,
         dangle_tol: float,
-    ) -> Optional[dict]:
+    ) -> Optional[NearCandidate]:
         """
         From A's candidate rows, find the closest dangle feature that belongs to target_parent_id.
         This handles "target parent has 2 dangles" correctly by selecting the closest.
         """
-        best = None
+        best: Optional[NearCandidate] = None
         best_dist = float("inf")
 
         for cand in candidates_sorted:
-            if cand["near_fc_key"] != dangles_fc_key:
+            if cand.near_fc_key != dangles_fc_key:
                 continue
 
-            other_dangle_oid = int(cand["near_fid"])
+            other_dangle_oid = cand.near_fid
             other_parent = dangle_parent.get(other_dangle_oid)
             if other_parent is None:
                 continue
             if int(other_parent) != int(target_parent_id):
                 continue
 
-            dist = float(cand["near_dist"])
+            dist = cand.near_dist
             if dist <= float(dangle_tol) and dist < best_dist:
                 best = cand
                 best_dist = dist
@@ -3016,21 +3102,21 @@ class FillLineGaps:
     def _find_specific_dangle_candidate(
         self,
         *,
-        candidates_sorted: list[dict],
+        candidates_sorted: list[NearCandidate],
         dangles_fc_key: str,
         other_dangle_oid: int,
         dangle_tol: float,
-    ) -> Optional[dict]:
+    ) -> Optional[NearCandidate]:
         """
         Find candidate row that targets a specific dangle OID (within dangle_tol).
         """
         for cand in candidates_sorted:
-            if cand["near_fc_key"] != dangles_fc_key:
+            if cand.near_fc_key != dangles_fc_key:
                 continue
-            if int(cand["near_fid"]) != int(other_dangle_oid):
+            if cand.near_fid != int(other_dangle_oid):
                 continue
 
-            dist = float(cand["near_dist"])
+            dist = cand.near_dist
             if dist <= float(dangle_tol):
                 return cand
         return None
@@ -3096,15 +3182,9 @@ class FillLineGaps:
     # Build plan (two-phase: detect pairs first, then decide moves)
     # ----------------------------
 
-    def _build_plan(self, *, dangles_fc: str, target_layers: list[str]) -> tuple[
-        dict[int, list[dict]],
-        list["_ResnappedCapture"],
-        list["CandidateDiagnostic"],
-        list[
-            _AcceptedConnectorRaw
-        ],  # accepted_connector_raw (for resnap crossing re-check)
-        dict[int, int],  # kruskal_rank_by_dangle_oid (for resnap crossing re-check)
-    ]:
+    def _build_plan(
+        self, *, dangles_fc: str, target_layers: list[str]
+    ) -> BuildPlanResult:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
@@ -3166,7 +3246,7 @@ class FillLineGaps:
         )
 
         if not grouped:
-            return {}, [], [], [], {}
+            return BuildPlanResult.empty(diagnostics=[])
 
         collect_diags = self.candidate_connections_output is not None
 
@@ -3265,13 +3345,9 @@ class FillLineGaps:
             if _barrier_keys:
                 for _dangle_oid in list(legal_rows_by_dangle.keys()):
                     _parent_id = parent_id_by_dangle[_dangle_oid]
-                    _remaining: list[dict] = []
+                    _remaining: list[NearCandidate] = []
                     for _cand in legal_rows_by_dangle[_dangle_oid]:
-                        _cand_key = (
-                            _dangle_oid,
-                            str(_cand["near_fc_key"]),
-                            int(_cand["near_fid"]),
-                        )
+                        _cand_key = (_dangle_oid, _cand.near_fc_key, _cand.near_fid)
                         if _cand_key in _barrier_keys:
                             if collect_diags:
                                 _step1a_illegal.append(
@@ -3305,13 +3381,9 @@ class FillLineGaps:
             if crossing_conflict_keys:
                 for _dangle_oid in list(legal_rows_by_dangle.keys()):
                     _parent_id = parent_id_by_dangle[_dangle_oid]
-                    _remaining: list[dict] = []
+                    _remaining: list[NearCandidate] = []
                     for _cand in legal_rows_by_dangle[_dangle_oid]:
-                        _cand_key = (
-                            _dangle_oid,
-                            str(_cand["near_fc_key"]),
-                            int(_cand["near_fid"]),
-                        )
+                        _cand_key = (_dangle_oid, _cand.near_fc_key, _cand.near_fid)
                         if _cand_key in crossing_conflict_keys:
                             if collect_diags:
                                 _step1a_illegal.append(
@@ -3326,10 +3398,8 @@ class FillLineGaps:
                         parent_id_by_dangle.pop(_dangle_oid, None)
 
         if not legal_rows_by_dangle:
-            return (
-                {},
-                [],
-                self._assemble_diagnostics(
+            return BuildPlanResult.empty(
+                diagnostics=self._assemble_diagnostics(
                     collect_diags=collect_diags,
                     state=_DiagnosticsState(
                         step1a_illegal=_step1a_illegal,
@@ -3349,8 +3419,6 @@ class FillLineGaps:
                     dangles_key=dangles_key,
                     lines_key=lines_key,
                 ),
-                [],
-                {},
             )
 
         # ----------------------------
@@ -3382,7 +3450,7 @@ class FillLineGaps:
             best_score = None
 
             for cand in legal_rows_by_dangle[dangle_oid]:
-                if str(cand["near_fc_key"]) != str(lines_key):
+                if cand.near_fc_key != lines_key:
                     continue
 
                 assess = self._assess_angle(
@@ -3402,7 +3470,7 @@ class FillLineGaps:
                 if assess.blocks:
                     continue
 
-                raw_dist = float(cand["near_dist"])
+                raw_dist = cand.near_dist
                 _tol = float(self.gap_tolerance_meters) or 1.0
                 eff = self._compute_best_fit_score(
                     norm_dist=raw_dist / _tol, assess=assess
@@ -3412,7 +3480,7 @@ class FillLineGaps:
                 score = (float(eff), float(raw_dist), self._candidate_sort_key(cand))
                 if best_score is None or score < best_score:
                     best_score = score
-                    best = int(cand["near_fid"])
+                    best = cand.near_fid
 
             if best is not None:
                 best_line_parent_by_dangle[int(dangle_oid)] = int(best)
@@ -3440,10 +3508,8 @@ class FillLineGaps:
         )
 
         if not _dangle_proposals:
-            return (
-                {},
-                [],
-                self._assemble_diagnostics(
+            return BuildPlanResult.empty(
+                diagnostics=self._assemble_diagnostics(
                     collect_diags=collect_diags,
                     state=_DiagnosticsState(
                         step1a_illegal=_step1a_illegal,
@@ -3463,8 +3529,6 @@ class FillLineGaps:
                     dangles_key=dangles_key,
                     lines_key=lines_key,
                 ),
-                [],
-                {},
             )
 
         # ----------------------------
@@ -3474,10 +3538,8 @@ class FillLineGaps:
         # ----------------------------
         active: list[_DangleProposal] = list(_dangle_proposals.values())
         if not active:
-            return (
-                {},
-                [],
-                self._assemble_diagnostics(
+            return BuildPlanResult.empty(
+                diagnostics=self._assemble_diagnostics(
                     collect_diags=collect_diags,
                     state=_DiagnosticsState(
                         step1a_illegal=_step1a_illegal,
@@ -3497,8 +3559,6 @@ class FillLineGaps:
                     dangles_key=dangles_key,
                     lines_key=lines_key,
                 ),
-                [],
-                {},
             )
         active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
 
@@ -3565,10 +3625,8 @@ class FillLineGaps:
         )
 
         if not _global_proposals:
-            return (
-                {},
-                [],
-                self._assemble_diagnostics(
+            return BuildPlanResult.empty(
+                diagnostics=self._assemble_diagnostics(
                     collect_diags=collect_diags,
                     state=_DiagnosticsState(
                         step1a_illegal=_step1a_illegal,
@@ -3588,8 +3646,6 @@ class FillLineGaps:
                     dangles_key=dangles_key,
                     lines_key=lines_key,
                 ),
-                [],
-                {},
             )
 
         # ----------------------------
@@ -3602,10 +3658,10 @@ class FillLineGaps:
         # ----------------------------
         plan_by_parent = self._assemble_plan_entries(_global_proposals)
 
-        return (
-            plan_by_parent,
-            resnap_captures,
-            self._assemble_diagnostics(
+        return BuildPlanResult(
+            plan_by_parent=plan_by_parent,
+            resnap_captures=resnap_captures,
+            diagnostics=self._assemble_diagnostics(
                 collect_diags=collect_diags,
                 state=_DiagnosticsState(
                     step1a_illegal=_step1a_illegal,
@@ -3625,14 +3681,14 @@ class FillLineGaps:
                 dangles_key=dangles_key,
                 lines_key=lines_key,
             ),
-            accepted_connector_raw,
-            kruskal_rank_by_dangle_oid,
+            accepted_connector_raw=accepted_connector_raw,
+            kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
         )
 
     def _filter_legal_candidates(
         self,
         *,
-        grouped: _Grouped,
+        grouped: dict[int, list[NearCandidate]],
         dangle_parent: dict[int, int],
         illegal: _IllegalTargets,
         dangles_key: str,
@@ -3643,12 +3699,12 @@ class FillLineGaps:
         topology: TopologyModel,
         collect_diags: bool,
         directed_source_illegal_oids: set[int],
-    ) -> tuple[_Grouped, dict[int, int], list[_CandidateIllegalA]]:
+    ) -> tuple[dict[int, list[NearCandidate]], dict[int, int], list[_CandidateIllegalA]]:
         """Dangle filtering: collect legal candidates per dangle.
 
         Returns (legal_rows_by_dangle, parent_id_by_dangle, step1a_illegal).
         """
-        legal_rows_by_dangle: dict[int, list[dict]] = {}
+        legal_rows_by_dangle: dict[int, list[NearCandidate]] = {}
         parent_id_by_dangle: dict[int, int] = {}
         _step1a_illegal: list[_CandidateIllegalA] = []
 
@@ -3666,9 +3722,7 @@ class FillLineGaps:
             if dangle_oid in directed_source_illegal_oids:
                 if collect_diags:
                     for cand in candidates:
-                        if str(cand["near_fc_key"]) == str(lines_key) and int(
-                            cand["near_fid"]
-                        ) == int(parent_id):
+                        if cand.near_fc_key == lines_key and cand.near_fid == parent_id:
                             continue
                         _step1a_illegal.append(
                             _CandidateIllegalA(dangle_oid, parent_id, cand, "directed_start_node")
@@ -3677,12 +3731,10 @@ class FillLineGaps:
 
             rows = sorted(candidates, key=self._candidate_sort_key)
 
-            legal_rows: list[dict] = []
+            legal_rows: list[NearCandidate] = []
             for cand in rows:
                 # Self-parent candidates are excluded from the plan and from diagnostics.
-                if str(cand["near_fc_key"]) == str(lines_key) and int(
-                    cand["near_fid"]
-                ) == int(parent_id):
+                if cand.near_fc_key == lines_key and cand.near_fid == parent_id:
                     continue
 
                 is_legal = self._candidate_is_legal(
@@ -3725,7 +3777,7 @@ class FillLineGaps:
     def _select_dangle_proposals(
         self,
         *,
-        legal_rows_by_dangle: _Grouped,
+        legal_rows_by_dangle: dict[int, list[NearCandidate]],
         parent_id_by_dangle: dict[int, int],
         dangle_xy: dict[int, tuple[float, float]],
         dangles_key: str,
@@ -3799,8 +3851,8 @@ class FillLineGaps:
                 for _i, _c in enumerate(legal_rows):
                     _ez = geometry_tools.local_z_at_xy(
                         self._raster_handles,
-                        float(_c["near_x"]),
-                        float(_c["near_y"]),
+                        _c.near_x,
+                        _c.near_y,
                     )
                     end_z_by_cand_index[_i] = _ez
 
@@ -3854,9 +3906,9 @@ class FillLineGaps:
                 # 2) Expanded tolerance gating (angle_extra_dangle_threshold_degrees)
                 # Applies to dangle targets and line-like targets that are only in range
                 # because of the expanded tolerance — angle must permit extra-dangle behavior.
-                is_dangle_target = str(cand["near_fc_key"]) == str(dangles_key)
-                is_line_like_target = str(cand["near_fc_key"]) in line_like_ds_keys
-                dist = float(cand["near_dist"])
+                is_dangle_target = cand.near_fc_key == dangles_key
+                is_line_like_target = cand.near_fc_key in line_like_ds_keys
+                dist = cand.near_dist
 
                 if (
                     (is_dangle_target or is_line_like_target)
@@ -3876,8 +3928,8 @@ class FillLineGaps:
                         if _cand_end_z is not None
                         else geometry_tools.local_z_at_xy(
                             self._raster_handles,
-                            float(cand["near_x"]),
-                            float(cand["near_y"]),
+                            cand.near_x,
+                            cand.near_y,
                         )
                     )
                     if (
@@ -4021,8 +4073,8 @@ class FillLineGaps:
             target_parent_id: Optional[int] = None
             target_dangle_oid: Optional[int] = None
 
-            ds_key = str(chosen["near_fc_key"])
-            near_fid = int(chosen["near_fid"])
+            ds_key = str(chosen.near_fc_key)
+            near_fid = int(chosen.near_fid)
 
             if ds_key == dangles_key:
                 target_dangle_oid = near_fid
@@ -4063,8 +4115,8 @@ class FillLineGaps:
                 near_fid=near_fid,
                 dangle_x=float(d_x),
                 dangle_y=float(d_y),
-                near_x=float(chosen["near_x"]),
-                near_y=float(chosen["near_y"]),
+                near_x=chosen.near_x,
+                near_y=chosen.near_y,
                 raw_distance=float(raw_distance),
                 bonus_applied=bool(bonus_applied),
                 start_z=start_z,
@@ -4153,13 +4205,13 @@ class FillLineGaps:
                 winner.ctx.target_dangle_oid is not None
                 and int(winner.ctx.dangle_oid) in dangle_mutual_oids
             ):
-                gap_source = self.GAP_SOURCE_PAIR_DANGLE
+                gap_source = GapSource.PAIR_DANGLE
             elif mutual_network:
-                gap_source = self.GAP_SOURCE_PAIR_LINE
+                gap_source = GapSource.PAIR_LINE
             else:
-                gap_source = self.GAP_SOURCE_DEFAULT
+                gap_source = GapSource.DEFAULT
 
-            _connection_proposals.append((winner, str(gap_source)))
+            _connection_proposals.append((winner, gap_source))
 
         connection_loser_oids: set[int] = set()
         if collect_diags:
@@ -4217,7 +4269,7 @@ class FillLineGaps:
         set[int],  # accepted_dangle_oids
         set[int],  # kruskal_rejected_oids (cycle-based)
         set[int],  # kruskal_crossing_rejected_oids
-        dict[int, str],  # gap_source_by_dangle
+        dict[int, GapSource],  # gap_source_by_dangle
         list[
             _AcceptedConnectorRaw
         ],  # accepted_connector_raw (for resnap crossing re-check)
@@ -4293,7 +4345,7 @@ class FillLineGaps:
                             conflict_lookup.setdefault(_key_in, set()).add(_key_near)
                 arcpy.management.Delete(_kruskal_fc)
 
-        def _accept(prop: Any, gap_source: Any) -> None:
+        def _accept(prop: _GlobalProposal, gap_source: GapSource) -> None:
             nonlocal rank_counter
             _global_proposals.append((prop, gap_source))
             if reject_crossing:
@@ -4368,7 +4420,7 @@ class FillLineGaps:
 
         accepted_dangle_oids: set[int] = set()
         kruskal_rejected_oids: set[int] = set()
-        gap_source_by_dangle: dict[int, str] = {}
+        gap_source_by_dangle: dict[int, GapSource] = {}
         if collect_diags and _global_proposals:
             _accepted_oids = {int(prop.ctx.dangle_oid) for prop, _ in _global_proposals}
             accepted_dangle_oids.update(_accepted_oids)
@@ -4379,7 +4431,7 @@ class FillLineGaps:
                 and int(prop.ctx.dangle_oid) not in kruskal_crossing_rejected_oids
             )
             gap_source_by_dangle.update(
-                {int(prop.ctx.dangle_oid): str(gs) for prop, gs in _global_proposals}
+                {int(prop.ctx.dangle_oid): gs for prop, gs in _global_proposals}
             )
 
         return (
@@ -4400,7 +4452,7 @@ class FillLineGaps:
 
         A connection A→B needs resnap if:
           1. B is the target_parent_id of A's accepted connection
-          2. Another accepted connection B→T exists with GAP_SOURCE_PAIR_DANGLE
+          2. Another accepted connection B→T exists with GapSource.PAIR_DANGLE
              (i.e. B's dangle endpoint will move when B snaps to T)
           3. A's near-point lies on B's last segment — checked in _resnap_connections
              using post-apply geometry (this block is a cheap pre-filter only).
@@ -4408,7 +4460,7 @@ class FillLineGaps:
         snap_source_parents: set[int] = {
             int(prop.ctx.src_parent_id)
             for prop, gap_source in global_proposals
-            if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE
+            if gap_source is GapSource.PAIR_DANGLE
         }
         resnap_captures: list[_ResnappedCapture] = []
         for prop, gap_source in global_proposals:
@@ -4421,7 +4473,7 @@ class FillLineGaps:
                     dangle_oid=int(prop.ctx.dangle_oid),
                     forced_target_parent=int(tp),
                     proposal=prop,
-                    gap_source=str(gap_source),
+                    gap_source=gap_source,
                 )
             )
         return resnap_captures
@@ -4429,12 +4481,12 @@ class FillLineGaps:
     def _recheck_resnap_crossings(
         self,
         *,
-        resnap_plan: dict[int, dict],
+        resnap_plan: dict[int, PlanEntry],
         accepted_connector_raw: list[_AcceptedConnectorRaw],
         kruskal_rank_by_dangle_oid: dict[int, int],
         trim_distance: float,
         spatial_reference: Any,
-    ) -> tuple[dict[int, dict], set[int], set[int], set[int]]:
+    ) -> tuple[dict[int, PlanEntry], set[int], set[int], set[int]]:
         """Re-check resnap captures against accepted connector geometries.
 
         Called after _resnap_connections resolves final geometry for deferred
@@ -4461,13 +4513,13 @@ class FillLineGaps:
         # Build trimmed resnap connectors: key = parent_id (unique per resnap entry).
         resnap_cands: list[tuple[Any, Any]] = []
         for parent_id, entry in resnap_plan.items():
-            if entry.get("skip", False):
+            if entry.skip:
                 continue
             trimmed = self._build_trimmed_connector(
-                from_x=float(entry["dangle_x"]),
-                from_y=float(entry["dangle_y"]),
-                to_x=float(entry["near_x"]),
-                to_y=float(entry["near_y"]),
+                from_x=entry.dangle_x,
+                from_y=entry.dangle_y,
+                to_x=entry.near_x,
+                to_y=entry.near_y,
                 trim_distance=trim_distance,
                 spatial_reference=spatial_reference,
             )
@@ -4529,14 +4581,14 @@ class FillLineGaps:
         resnap_crossing_winner_oids: set[int] = set()
 
         for parent_id, entry in resnap_plan.items():
-            if entry.get("skip", False):
+            if entry.skip:
                 continue
 
             conflicting_doids = conflicts_by_parent.get(parent_id)
             if not conflicting_doids:
                 continue
 
-            dangle_oid = int(entry["dangle_oid"])
+            dangle_oid = entry.dangle_oid
             resnap_rank = kruskal_rank_by_dangle_oid.get(dangle_oid, float("inf"))
             best_conflict_rank = min(
                 kruskal_rank_by_dangle_oid.get(aoid, float("inf"))
@@ -4549,7 +4601,7 @@ class FillLineGaps:
                 resnap_crossing_winner_oids.add(dangle_oid)
             else:
                 # Resnap capture loses: skip the corrected-geometry application.
-                entry["skip"] = True
+                entry.skip = True
                 resnap_crossing_rejected_oids.add(dangle_oid)
 
         return (
@@ -4562,23 +4614,29 @@ class FillLineGaps:
     def _assemble_plan_entries(
         self,
         global_proposals: list[_GlobalWithSource],
-    ) -> dict[int, list[dict[str, Any]]]:
+    ) -> PlanByParent:
         """Assemble plan_by_parent from accepted global proposals."""
-        tmp: dict[int, list[tuple[tuple[Any, ...], dict[str, Any]]]] = {}
+        tmp: dict[int, list[tuple[tuple[Any, ...], PlanEntry]]] = {}
 
         for prop, gap_source in sorted(global_proposals, key=lambda t: t[0].sort_key()):
+            # near_dist is filled from prop.ctx.raw_distance so the NearCandidate is
+            # self-consistent; near_fc_key_raw is unused downstream so we reuse the
+            # normalized key.
+            chosen = NearCandidate(
+                near_fc_key=str(prop.ctx.near_fc_key),
+                near_fid=int(prop.ctx.near_fid),
+                near_dist=float(prop.ctx.raw_distance),
+                near_x=float(prop.ctx.near_x),
+                near_y=float(prop.ctx.near_y),
+                near_fc_key_raw=str(prop.ctx.near_fc_key),
+            )
             entry = self._make_plan_entry(
                 parent_id=int(prop.ctx.src_parent_id),
                 dangle_oid=int(prop.ctx.dangle_oid),
                 dangle_x=float(prop.ctx.dangle_x),
                 dangle_y=float(prop.ctx.dangle_y),
-                chosen={
-                    "near_x": float(prop.ctx.near_x),
-                    "near_y": float(prop.ctx.near_y),
-                    "near_fc_key": str(prop.ctx.near_fc_key),
-                    "near_fid": int(prop.ctx.near_fid),
-                },
-                gap_source=str(gap_source),
+                chosen=chosen,
+                gap_source=gap_source,
                 bonus_applied=prop.ctx.bonus_applied,
                 assess=prop.ctx.assess,
                 best_fit_score=prop.score.composite,
@@ -4588,19 +4646,17 @@ class FillLineGaps:
                 (prop.sort_key(), entry)
             )
 
-        plan_by_parent: dict[int, list[dict]] = {}
+        plan_by_parent: PlanByParent = {}
         for pid, items in tmp.items():
             # Deterministic per-parent order
-            ordered = sorted(
-                items, key=lambda t: (t[0], int(t[1].get("dangle_oid", 0)))
-            )
+            ordered = sorted(items, key=lambda t: (t[0], t[1].dangle_oid))
             plan_by_parent[int(pid)] = [entry for _, entry in ordered]
 
         return plan_by_parent
 
     def _make_base_diag_fields(
         self,
-        cand: _CandRow,
+        cand: NearCandidate,
         dangle_oid: int,
         parent_id: int,
         xy: tuple[float, float],
@@ -4614,11 +4670,11 @@ class FillLineGaps:
             dangle_oid=dangle_oid,
             dangle_x=float(xy[0]),
             dangle_y=float(xy[1]),
-            near_fc_key=str(cand["near_fc_key"]),
-            near_fid=int(cand["near_fid"]),
-            near_x=float(cand["near_x"]),
-            near_y=float(cand["near_y"]),
-            raw_distance=float(cand["near_dist"]),
+            near_fc_key=cand.near_fc_key,
+            near_fid=cand.near_fid,
+            near_x=cand.near_x,
+            near_y=cand.near_y,
+            raw_distance=cand.near_dist,
             target_parent_id=self._resolve_target_parent_id(
                 cand, dangle_parent, dangles_key, lines_key
             ),
@@ -4657,7 +4713,7 @@ class FillLineGaps:
             xy = dangle_xy.get(int(entry.dangle_oid))
             if xy is None:
                 continue
-            _sz, _ez = _z_pair(xy, entry.cand["near_x"], entry.cand["near_y"])
+            _sz, _ez = _z_pair(xy, entry.cand.near_x, entry.cand.near_y)
             cand_scope = ScopeRecord(status=entry.reason)
             result.append(
                 CandidateDiagnostic(
@@ -4712,7 +4768,7 @@ class FillLineGaps:
         rank_map: dict[tuple[int, str, int], int] = {}
         for d_oid, entries in scored_by_dangle.items():
             for rank, entry in enumerate(sorted(entries, key=lambda e: e.score_tuple), start=1):
-                rank_map[(d_oid, str(entry.cand["near_fc_key"]), int(entry.cand["near_fid"]))] = rank
+                rank_map[(d_oid, entry.cand.near_fc_key, entry.cand.near_fid)] = rank
 
         # Step-1B scored candidates
         for entry in state.step1b_scored:
@@ -4720,7 +4776,7 @@ class FillLineGaps:
             if xy is None:
                 continue
             rank = rank_map.get(
-                (entry.dangle_oid, str(entry.cand["near_fc_key"]), int(entry.cand["near_fid"]))
+                (entry.dangle_oid, entry.cand.near_fc_key, entry.cand.near_fid)
             )
             d_oid = int(entry.dangle_oid)
             cand_scope = ScopeRecord(status="scored", norm_z=entry.dangle_norm_z)
@@ -4770,7 +4826,8 @@ class FillLineGaps:
                     norm_z=state.global_norm_z_by_dangle.get(d_oid),
                 )
                 final_scope = kru_scope
-                final_gs = state.gap_source_by_dangle.get(d_oid)
+                gs = state.gap_source_by_dangle.get(d_oid)
+                final_gs = gs.value if gs is not None else None
             else:
                 # Local winner that didn't reach proposal construction
                 # (e.g. target dangle had no resolvable parent)
@@ -4807,61 +4864,65 @@ class FillLineGaps:
         dangle_oid: int,
         dangle_x: float,
         dangle_y: float,
-        chosen: dict,
-        gap_source: str,
+        chosen: NearCandidate,
+        gap_source: GapSource,
         bonus_applied: bool = False,
         assess: "Optional[AngleAssessment]" = None,
         best_fit_score: Optional[float] = None,
-    ) -> dict:
-        edit_op = self._resolve_edit_op(gap_source=str(gap_source))
-        entry: dict = {
-            "processed": False,
-            "skip": False,
-            "gap_source": str(gap_source),
-            "edit_op": str(edit_op.value),
-            "dangle_oid": int(dangle_oid),
-            "dangle_x": float(dangle_x),
-            "dangle_y": float(dangle_y),
-            "near_x": float(chosen["near_x"]),
-            "near_y": float(chosen["near_y"]),
-            "chosen_near_fc_key": str(chosen["near_fc_key"]),
-            "chosen_near_fid": int(chosen["near_fid"]),
-        }
-        if self.write_output_metadata:
-            entry["meta_bonus_applied"] = int(bonus_applied)
-            if assess is not None:
-                entry["meta_src_connector_diff"] = assess.src_connector_diff
-                entry["meta_connector_target_diff"] = assess.connector_target_diff
-                entry["meta_src_target_diff"] = assess.src_target_diff
-                entry["meta_connector_transition_diff"] = (
-                    assess.connector_transition_diff
-                )
-                entry["meta_angle_metric_deg"] = assess.angle_metric_deg
-                entry["meta_best_fit_score"] = best_fit_score
-        return entry
+    ) -> PlanEntry:
+        edit_op = self._resolve_edit_op(gap_source=gap_source)
 
-    def _apply_pair_symmetric_skip(self, decided_by_parent: dict[int, dict]) -> None:
+        meta: Optional[PlanEntryMeta] = None
+        if self.write_output_metadata:
+            meta = PlanEntryMeta(
+                bonus_applied=bool(bonus_applied),
+                src_connector_diff=assess.src_connector_diff if assess else None,
+                connector_target_diff=assess.connector_target_diff if assess else None,
+                src_target_diff=assess.src_target_diff if assess else None,
+                connector_transition_diff=(
+                    assess.connector_transition_diff if assess else None
+                ),
+                angle_metric_deg=assess.angle_metric_deg if assess else None,
+                best_fit_score=best_fit_score,
+            )
+
+        return PlanEntry(
+            dangle_oid=int(dangle_oid),
+            dangle_x=float(dangle_x),
+            dangle_y=float(dangle_y),
+            near_x=chosen.near_x,
+            near_y=chosen.near_y,
+            chosen_near_fc_key=chosen.near_fc_key,
+            chosen_near_fid=chosen.near_fid,
+            gap_source=gap_source,
+            edit_op=edit_op,
+            meta=meta,
+        )
+
+    def _apply_pair_symmetric_skip(
+        self, decided_by_parent: dict[int, PlanEntry]
+    ) -> None:
         """
         If A and B are marked as pair parents, move only one of them.
         Keep the smaller parent id by default.
         """
         for a_parent, entry in list(decided_by_parent.items()):
-            b_parent = entry.get("pair_parent")
+            b_parent = entry.pair_parent
             if b_parent is None:
                 continue
             b_parent = int(b_parent)
 
             other = decided_by_parent.get(b_parent)
-            if not other:
+            if other is None:
                 continue
-            if int(other.get("pair_parent") or -1) != int(a_parent):
+            if (other.pair_parent or -1) != a_parent:
                 continue
 
             keep = min(int(a_parent), int(b_parent))
             drop = max(int(a_parent), int(b_parent))
 
-            decided_by_parent[drop]["skip"] = True
-            decided_by_parent[keep]["skip"] = False
+            decided_by_parent[drop].skip = True
+            decided_by_parent[keep].skip = False
 
     # ----------------------------
     # Resnap pass
@@ -4873,7 +4934,7 @@ class FillLineGaps:
         captures: "list[_ResnappedCapture]",
         dangles_fc: str,
         snap_source_dangle_xy: "dict[int, tuple[float, float]]",
-    ) -> dict[int, dict]:
+    ) -> dict[int, PlanEntry]:
         """
         Re-resolve the near-point for connections whose target line endpoint moved
         during _apply_plan (SNAP operations).
@@ -5012,7 +5073,7 @@ class FillLineGaps:
         # --- 4. Build updated plan entries ---
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc)
         lines_key = self._dataset_key(self.lines_copy)
-        out: dict[int, dict] = {}
+        out: dict[int, PlanEntry] = {}
 
         for cap in filtered:
             hit = best_xy.get((cap.dangle_oid, cap.forced_target_parent))
@@ -5021,17 +5082,20 @@ class FillLineGaps:
             dangle_coords = dangle_xy.get(cap.dangle_oid)
             if dangle_coords is None:
                 continue
+            resnap_cand = NearCandidate(
+                near_fc_key=lines_key,
+                near_fid=cap.forced_target_parent,
+                near_dist=float(hit[2]),
+                near_x=float(hit[0]),
+                near_y=float(hit[1]),
+                near_fc_key_raw=lines_key,
+            )
             out[cap.parent_id] = self._make_plan_entry(
                 parent_id=cap.parent_id,
                 dangle_oid=cap.dangle_oid,
                 dangle_x=float(dangle_coords[0]),
                 dangle_y=float(dangle_coords[1]),
-                chosen={
-                    "near_x": float(hit[0]),
-                    "near_y": float(hit[1]),
-                    "near_fc_key": lines_key,
-                    "near_fid": cap.forced_target_parent,
-                },
+                chosen=resnap_cand,
                 gap_source=cap.gap_source,
                 bonus_applied=cap.proposal.ctx.bonus_applied,
                 assess=cap.proposal.ctx.assess,
@@ -5093,8 +5157,8 @@ class FillLineGaps:
         near_x: float,
         near_y: float,
         spatial_reference,
-        gap_source: str,
-        meta: Optional[dict] = None,
+        gap_source: GapSource,
+        meta: Optional[PlanEntryMeta] = None,
     ):
         dist = ((dangle_x - near_x) ** 2 + (dangle_y - near_y) ** 2) ** 0.5
         if dist == 0.0:
@@ -5104,17 +5168,17 @@ class FillLineGaps:
             [arcpy.Point(dangle_x, dangle_y), arcpy.Point(near_x, near_y)]
         )
         geom = arcpy.Polyline(arr, spatial_reference)
-        row = [geom, int(original_id), float(dist), str(gap_source)]
+        row: list[Any] = [geom, int(original_id), float(dist), gap_source.value]
         if meta is not None:
             row.extend(
                 [
-                    meta.get("meta_src_connector_diff"),
-                    meta.get("meta_connector_target_diff"),
-                    meta.get("meta_src_target_diff"),
-                    meta.get("meta_connector_transition_diff"),
-                    meta.get("meta_angle_metric_deg"),
-                    meta.get("meta_best_fit_score"),
-                    meta.get("meta_bonus_applied"),
+                    meta.src_connector_diff,
+                    meta.connector_target_diff,
+                    meta.src_target_diff,
+                    meta.connector_transition_diff,
+                    meta.angle_metric_deg,
+                    meta.best_fit_score,
+                    int(meta.bonus_applied),
                 ]
             )
         return tuple(row)
@@ -5274,102 +5338,61 @@ class FillLineGaps:
                 geom = arcpy.Polyline(arr, spatial_reference)
                 cur.insertRow(self._diag_row(d, geom))
 
-    def _apply_plan(self, plan) -> None:
+    def _apply_plan(self, plan: PlanByParent) -> None:
         if not plan:
             return
 
         spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
         change_rows: list[tuple] = []
 
-        def _as_entries(value) -> list[dict]:
-            # Backwards compatible: allow dict (single) or list[dict] (multi)
-            if value is None:
-                return []
-            if isinstance(value, list):
-                return [v for v in value if isinstance(v, dict)]
-            if isinstance(value, dict):
-                return [value]
-            return []
-
         with arcpy.da.UpdateCursor(
             self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"]
         ) as cur:
             for original_id, shape in cur:
                 pid = int(original_id)
-                entries = _as_entries(plan.get(pid))
+                entries = plan.get(pid, [])
                 if not entries:
                     continue
 
-                pending = [
-                    e
-                    for e in entries
-                    if not e.get("skip", False) and not e.get("processed", False)
-                ]
+                pending = [e for e in entries if not e.skip and not e.processed]
                 if not pending:
                     continue
 
                 current_shape = shape
 
                 for info in pending:
-                    edit_op = str(info.get("edit_op", EditOp.EXTEND.value))
-
-                    if edit_op == EditOp.SNAP.value:
+                    if info.edit_op is EditOp.SNAP:
                         current_shape = self._snap_endpoint(
                             shape=current_shape,
-                            dangle_x=float(info["dangle_x"]),
-                            dangle_y=float(info["dangle_y"]),
-                            near_x=float(info["near_x"]),
-                            near_y=float(info["near_y"]),
+                            dangle_x=info.dangle_x,
+                            dangle_y=info.dangle_y,
+                            near_x=info.near_x,
+                            near_y=info.near_y,
                         )
                     else:
                         current_shape = self._extend_endpoint(
                             shape=current_shape,
-                            dangle_x=float(info["dangle_x"]),
-                            dangle_y=float(info["dangle_y"]),
-                            near_x=float(info["near_x"]),
-                            near_y=float(info["near_y"]),
+                            dangle_x=info.dangle_x,
+                            dangle_y=info.dangle_y,
+                            near_x=info.near_x,
+                            near_y=info.near_y,
                         )
 
-                    info["processed"] = True
+                    info.processed = True
 
                     if (
                         self.line_changes_output is not None
                         and self.write_output_metadata
                     ):
-                        meta = (
-                            {
-                                k: info.get(k)
-                                for k in (
-                                    "meta_src_connector_diff",
-                                    "meta_connector_target_diff",
-                                    "meta_src_target_diff",
-                                    "meta_connector_transition_diff",
-                                    "meta_angle_metric_deg",
-                                    "meta_best_fit_score",
-                                    "meta_bonus_applied",
-                                )
-                            }
-                            if any(
-                                k in info
-                                for k in (
-                                    "meta_src_connector_diff",
-                                    "meta_angle_metric_deg",
-                                    "meta_bonus_applied",
-                                )
-                            )
-                            else None
-                        )
                         row = self._build_change_row(
                             original_id=pid,
-                            dangle_x=float(info["dangle_x"]),
-                            dangle_y=float(info["dangle_y"]),
-                            near_x=float(info["near_x"]),
-                            near_y=float(info["near_y"]),
+                            dangle_x=info.dangle_x,
+                            dangle_y=info.dangle_y,
+                            near_x=info.near_x,
+                            near_y=info.near_y,
                             spatial_reference=spatial_reference,
-                            gap_source=str(
-                                info.get("gap_source", self.GAP_SOURCE_DEFAULT)
-                            ),
-                            meta=meta,
+                            gap_source=info.gap_source,
+                            meta=info.meta,
                         )
                         if row is not None:
                             change_rows.append(row)
@@ -5439,20 +5462,19 @@ class FillLineGaps:
         if self.candidate_connections_output is not None:
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
-        (
-            plan,
-            resnap_captures,
-            diagnostics,
-            accepted_connector_raw,
-            kruskal_rank_by_dangle_oid,
-        ) = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
+        result = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
+        plan = result.plan_by_parent
+        resnap_captures = result.resnap_captures
+        diagnostics = result.diagnostics
+        accepted_connector_raw = result.accepted_connector_raw
+        kruskal_rank_by_dangle_oid = result.kruskal_rank_by_dangle_oid
 
         # Capture snap-source dangle endpoints before _apply_plan moves them.
         snap_source_dangle_xy: dict[int, tuple[float, float]] = {
-            parent_id: (float(info["dangle_x"]), float(info["dangle_y"]))
+            parent_id: (info.dangle_x, info.dangle_y)
             for parent_id, entries in plan.items()
             for info in entries
-            if str(info.get("edit_op")) == EditOp.SNAP.value
+            if info.edit_op is EditOp.SNAP
         }
 
         self._apply_plan(plan)
@@ -5488,15 +5510,13 @@ class FillLineGaps:
                 resnap_crossing_displaced_oids: set[int] = set()
                 resnap_crossing_winner_oids: set[int] = set()
 
-            self._apply_plan(resnap_plan)
+            self._apply_plan({pid: [entry] for pid, entry in resnap_plan.items()})
 
             if self.candidate_connections_output is not None and diagnostics:
                 resnapped_dangle_oids = {
-                    int(v["dangle_oid"])
+                    v.dangle_oid
                     for v in resnap_plan.values()
-                    if isinstance(v, dict)
-                    and "dangle_oid" in v
-                    and not v.get("skip", False)
+                    if not v.skip
                 }
                 for diag in diagnostics:
                     d_oid = int(diag.dangle_oid)

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from enum import Enum
 
 from typing import Optional, Callable, Iterable
 
@@ -30,6 +31,11 @@ class TopologyModel:
     # DIRECT_CONNECTION only (required); allowed to be None otherwise
     direct_neighbors_by_parent: Optional[dict[int, set[int]]]
     direct_optionals_by_parent: Optional[dict[int, set[OptionalKey]]]
+
+
+class EditOp(str, Enum):
+    SNAP = "snap"
+    EXTEND = "extend"
 
 
 class _UnionFind:
@@ -816,18 +822,18 @@ class FillLineGaps:
                 out[int(oid)] = int(original_id)
         return out
 
-    def _resolve_edit_op(self, *, gap_source: str) -> logic_config.EditOp:
+    def _resolve_edit_op(self, *, gap_source: str) -> EditOp:
         method = self.edit_method
 
         if method == logic_config.EditMethod.FORCED_SNAP:
-            return logic_config.EditOp.SNAP
+            return EditOp.SNAP
         if method == logic_config.EditMethod.FORCED_EXTEND:
-            return logic_config.EditOp.EXTEND
+            return EditOp.EXTEND
 
         # AUTO
         if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE:
-            return logic_config.EditOp.SNAP
-        return logic_config.EditOp.EXTEND
+            return EditOp.SNAP
+        return EditOp.EXTEND
 
     def _same_network(
         self,
@@ -1817,26 +1823,6 @@ class FillLineGaps:
             target_self_oid_to_orig=target_self_oid_to_orig,
         )
 
-        # ... rest unchanged (except passing topology further down)
-
-        # DEBUG: inspect first candidates
-        lines_key = self._dataset_key(self.lines_copy)
-        zero = 0
-        line = 0
-        total = 0
-
-        for in_id, rows in list(grouped.items())[:2000]:  # sample
-            if not rows:
-                continue
-            r0 = min(rows, key=lambda r: r["near_dist"])
-            total += 1
-            if float(r0["near_dist"]) == 0.0:
-                zero += 1
-            if r0["near_fc_key"] == lines_key:
-                line += 1
-
-        arcpy.AddMessage(f"DEBUG sample={total} zero_dist={zero} line_key={line}")
-
         if not grouped:
             return {}
 
@@ -2382,9 +2368,9 @@ class FillLineGaps:
                 ):
                     continue
 
-                edit_op = str(info.get("edit_op", logic_config.EditOp.EXTEND.value))
+                edit_op = str(info.get("edit_op", EditOp.EXTEND.value))
 
-                if edit_op == logic_config.EditOp.SNAP.value:
+                if edit_op == EditOp.SNAP.value:
                     new_shape = self._snap_endpoint(
                         shape=shape,
                         dangle_x=float(info["dangle_x"]),

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -690,7 +690,7 @@ class FillLineGaps:
         parent_id: int,
         cand: dict,
         base_tol: float,
-        dangle_tol: float,
+        dangle_candidate_tol: float,  # NEW
         component_id: dict[int, int] | None = None,
     ) -> bool:
         ds_key = cand["near_fc_key"]
@@ -700,19 +700,18 @@ class FillLineGaps:
         a_comp = component_id.get(int(parent_id)) if component_id is not None else None
 
         if ds_key == dangles_fc_key:
-            if dist > dangle_tol:
+            # IMPORTANT: use dangle_candidate_tol, not expanded tolerance by default
+            if dist > float(dangle_candidate_tol):
                 return False
 
             other_parent = dangle_parent.get(int(oid))
             if other_parent is None:
                 return False
 
-            # NEW: disallow snapping to a dangle whose parent is in the same connected component
             if a_comp is not None and component_id is not None:
                 if component_id.get(int(other_parent)) == a_comp:
                     return False
 
-            # existing illegal check (treat as snapping to that parent line)
             if self._is_illegal(
                 illegal=illegal,
                 parent_id=parent_id,
@@ -723,14 +722,13 @@ class FillLineGaps:
 
             return True
 
-        # non-dangle
-        if dist > base_tol:
+        # non-dangle always uses base_tol
+        if dist > float(base_tol):
             return False
 
         if ds_key == lines_fc_key and int(oid) == int(parent_id):
             return False
 
-        # NEW: disallow snapping to a line in the same connected component
         if ds_key == lines_fc_key and a_comp is not None and component_id is not None:
             if component_id.get(int(oid)) == a_comp:
                 return False
@@ -779,7 +777,6 @@ class FillLineGaps:
         lines_fc_key: str,
         parent_id: int,
         base_tol: float,
-        dangle_tol: float,
         component_id: dict[int, int] | None = None,
     ) -> Optional[dict]:
         for cand in candidates_sorted:
@@ -791,7 +788,7 @@ class FillLineGaps:
                 parent_id=parent_id,
                 cand=cand,
                 base_tol=base_tol,
-                dangle_tol=dangle_tol,
+                dangle_candidate_tol=base_tol,
                 component_id=component_id,
             ):
                 return cand
@@ -940,7 +937,6 @@ class FillLineGaps:
                 lines_fc_key=lines_key,
                 parent_id=int(parent_id),
                 base_tol=base_tol,
-                dangle_tol=dangle_tol,
                 component_id=component_id,
             )
             if first_legal is None:
@@ -1120,7 +1116,7 @@ class FillLineGaps:
                 parent_id=int(a_parent),
                 cand=a_to_b_line,
                 base_tol=float(base_tol),
-                dangle_tol=float(dangle_tol),
+                dangle_candidate_tol=base_tol,
                 component_id=component_id,
             ):
                 a_to_b_line = None
@@ -1133,7 +1129,7 @@ class FillLineGaps:
                 parent_id=int(b_parent),
                 cand=b_to_a_line,
                 base_tol=float(base_tol),
-                dangle_tol=float(dangle_tol),
+                dangle_candidate_tol=base_tol,
                 component_id=component_id,
             ):
                 b_to_a_line = None

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1026,17 +1026,9 @@ class FillLineGaps:
             )
 
         # ----------------------------
-        # Source direction mode
+        # Source line direction
         # ----------------------------
-        self.source_direction_mode = logic_config.SourceDirectionMode(
-            adv.source_direction_mode
-        )
-        self.min_anchor_z_drop_meters: float = float(adv.min_anchor_z_drop_meters)
-        self.min_confident_flip_meters: Optional[float] = (
-            float(adv.min_confident_flip_meters)
-            if adv.min_confident_flip_meters is not None
-            else None
-        )
+        self.lines_are_directed: bool = bool(adv.lines_are_directed)
 
         # ----------------------------
         # Angle config
@@ -1053,14 +1045,10 @@ class FillLineGaps:
         )
         self.best_fit_weights = adv.best_fit_weights
 
-        if (
-            self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
-            and self.best_fit_weights.angle == 0.0
-        ):
+        if self.lines_are_directed and self.best_fit_weights.angle == 0.0:
             raise ValueError(
-                f"source_direction_mode={self.source_direction_mode.value!r} requires "
-                f"best_fit_weights.angle > 0.0 — directional scoring has no effect when "
-                f"angle weight is zero."
+                "lines_are_directed=True requires best_fit_weights.angle > 0.0 — "
+                "directional scoring has no effect when angle weight is zero."
             )
 
         self.angle_local_half_window_m = float(
@@ -1095,15 +1083,6 @@ class FillLineGaps:
         self.dangle_pair_apply_connector_diff: bool = bool(
             adv.dangle_pair_apply_connector_diff
         )
-
-        if (
-            self.source_direction_mode
-            == logic_config.SourceDirectionMode.RASTER_DERIVED
-            and not self.raster_paths
-        ):
-            raise ValueError(
-                "source_direction_mode='raster_derived' requires raster_paths to be set."
-            )
 
         # Local angle cache (dataset_key, oid, rx, ry) -> Optional[float]
         self._local_angle_cache: dict[tuple[str, int, int, int], Optional[float]] = {}
@@ -1619,33 +1598,6 @@ class FillLineGaps:
     # Source direction orientation
     # ----------------------------
 
-    def _z_orient_mode_for_scope(self) -> logic_config.LineZOrientMode:
-        """Derive LineZOrientMode from connectivity_scope.
-        Point-to-point scopes (NONE, DIRECT_CONNECTION) use INDIVIDUAL orientation;
-        network-aware scopes use NETWORK orientation.
-        """
-        individual_scopes = (
-            ConnectivityScope.NONE,
-            ConnectivityScope.DIRECT_CONNECTION,
-        )
-        if self.connectivity_scope in individual_scopes:
-            return logic_config.LineZOrientMode.INDIVIDUAL
-        return logic_config.LineZOrientMode.NETWORK
-
-    def _orient_feature_class_by_raster(self, feature_class: str) -> None:
-        """Run LineZOrientTool on *feature_class* in-place using the shared raster
-        config. Called for lines_copy and any external line-like working copies when
-        source_direction_mode == RASTER_DERIVED.
-        """
-        orient_config = logic_config.LineZOrientConfig(
-            input_lines=feature_class,
-            raster_paths=self.raster_paths,
-            orientation_mode=self._z_orient_mode_for_scope(),
-            min_anchor_z_drop_meters=self.min_anchor_z_drop_meters,
-            connectivity_tolerance_meters=self.connectivity_tolerance_meters,
-            min_confident_flip_meters=self.min_confident_flip_meters,
-        )
-        geometry_tools.LineZOrientTool(config=orient_config).run()
 
     def _local_angle_cache_key(
         self, *, dataset_key: str, oid: int, x: float, y: float
@@ -1848,9 +1800,9 @@ class FillLineGaps:
         run antiparallel to the source line's digitization direction, breaking topology.
         Only end-node dangles are valid sources.
 
-        Returns an empty set when source_direction_mode == UNDIRECTED.
+        Returns an empty set when lines_are_directed is False.
         """
-        if self.source_direction_mode == logic_config.SourceDirectionMode.UNDIRECTED:
+        if not self.lines_are_directed:
             return set()
 
         start_oids: set[int] = set()
@@ -2772,11 +2724,11 @@ class FillLineGaps:
             )
 
         # Use directional diff (0–180°, src_target_diff as metric) when:
-        # - source lines are known/assumed to be oriented (PRE_ORIENTED or RASTER_DERIVED), or
-        # - comparing dangle-pair / dangle-parent-line targets in UNDIRECTED mode, to avoid
+        # - lines_are_directed, or
+        # - comparing dangle-pair / dangle-parent-line targets in undirected mode, to avoid
         #   collapsing anti-parallel lines to zero diff.
         _use_directional = (
-            self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
+            self.lines_are_directed
             or _is_dangle_pair
             or _is_dangle_parent_line
         )
@@ -2786,41 +2738,34 @@ class FillLineGaps:
             angle_max_deg = 180.0
 
             src_poly_for_norm = polyline_by_parent.get(int(src_parent_id))
-            _is_directional = (
-                self.source_direction_mode
-                != logic_config.SourceDirectionMode.UNDIRECTED
-            )
             _endpoint_snap = _is_dangle_pair or _is_dangle_parent_line
-            # In directional mode: always use raw forward direction (no flip).
+            # In directed mode: always use raw forward direction (no flip).
             # The topology check handles endpoint snaps; for mid-line snaps, raw angles
             # give consistent directionality across all target types.
-            # In UNDIRECTED mode: flip if at start so src points "exit toward gap"
+            # In undirected mode: flip if at start so src points "exit toward gap"
             # for symmetric dangle-pair scoring.
             if src_poly_for_norm is not None and src_angle_deg is not None:
-                if not _is_directional:
+                if not self.lines_are_directed:
                     if self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y):
                         src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
 
-            # In UNDIRECTED mode (_use_directional triggered by dangle-pair / dangle-parent-line):
+            # In undirected mode (_use_directional triggered by dangle-pair / dangle-parent-line):
             # normalise target_angle to "entry direction into target interior" so that both
             # dangles in a pair score symmetrically (0° for a good collinear fill).
-            # In PRE_ORIENTED / RASTER_DERIVED mode: leave target_angle as the raw flow
-            # direction of the target line at the snap point. The source exits toward the gap;
-            # the target should flow in the same direction for a good match — flipping would
-            # collapse the score to 0° for both dangles regardless of their relative orientation.
-            if (
-                self.source_direction_mode
-                == logic_config.SourceDirectionMode.UNDIRECTED
-            ):
+            # In directed mode: leave target_angle as the raw flow direction of the target
+            # line at the snap point. The source exits toward the gap; the target should flow
+            # in the same direction for a good match — flipping would collapse the score to
+            # 0° for both dangles regardless of their relative orientation.
+            if not self.lines_are_directed:
                 _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
                 _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
                 if not self._xy_is_at_line_start(tgt_poly, _tgt_snap_x, _tgt_snap_y):
                     target_angle = (float(target_angle) + 180.0) % 360.0
-            # In directional mode, override src_connector_diff to use directional diff
+            # In directed mode, override src_connector_diff to use directional diff
             # so that anti-parallel src/connector (e.g. west vs east) reports 180° (BAD)
             # rather than collapsing to 0° under orientation_diff.
-            # UNDIRECTED mode keeps the orientation-based value computed at line ~2286.
-            if _is_directional:
+            # Undirected mode keeps the orientation-based value computed earlier.
+            if self.lines_are_directed:
                 src_connector_diff = self._directional_diff(
                     float(src_angle_deg), float(connector_angle)
                 )
@@ -2842,7 +2787,7 @@ class FillLineGaps:
         )
 
         if _use_directional:
-            if _is_directional and _endpoint_snap:
+            if self.lines_are_directed and _endpoint_snap:
                 # Topology-aware metric: only end→start is a valid directional connection.
                 # "Opposite attracts": src_is_end AND target_is_start → use direction diff.
                 # All other combinations (end→end, start→start, start→end) → 180° (BAD).
@@ -2863,12 +2808,12 @@ class FillLineGaps:
                     )
                 else:
                     metric = 180.0
-            elif _is_directional:
+            elif self.lines_are_directed:
                 # Non-endpoint line-like target: worst of angular alignment vs connector
                 # direction — a bad score on either component makes the candidate bad.
                 metric = max(float(src_target_diff), float(src_connector_diff))
             else:
-                # UNDIRECTED dangle-pair / dangle-parent-line after both normalizations.
+                # Undirected dangle-pair / dangle-parent-line after both normalizations.
                 metric = float(src_target_diff)
         else:
             metric = float(src_connector_diff)
@@ -5414,25 +5359,8 @@ class FillLineGaps:
         self._copy_input_lines()
         self._build_raster_handles()
         self._add_original_id_field()
-
-        if (
-            self.source_direction_mode
-            == logic_config.SourceDirectionMode.RASTER_DERIVED
-        ):
-            self._orient_feature_class_by_raster(self.lines_copy)
-
         self._create_dangles()
-
         self._build_external_target_layers_once()
-
-        if (
-            self.source_direction_mode
-            == logic_config.SourceDirectionMode.RASTER_DERIVED
-        ):
-            for ext_layer in self.external_target_layers:
-                if self._is_polyline_fc(ext_layer):
-                    self._orient_feature_class_by_raster(ext_layer)
-
         targets = self._select_targets_within_tolerance_of_dangles()
 
         # Keep only dangles that have any candidate within base tolerance

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -3017,14 +3017,14 @@ class FillLineGaps:
     # Build plan (two-phase: detect pairs first, then decide moves)
     # ----------------------------
 
-    def _build_plan(
-        self, *, dangles_fc: str, target_layers: list[str]
-    ) -> tuple[
+    def _build_plan(self, *, dangles_fc: str, target_layers: list[str]) -> tuple[
         dict[int, list[dict]],
         list["_ResnappedCapture"],
         list["CandidateDiagnostic"],
-        list[_AcceptedConnectorRaw],  # accepted_connector_raw (for resnap crossing re-check)
-        dict[int, int],               # kruskal_rank_by_dangle_oid (for resnap crossing re-check)
+        list[
+            _AcceptedConnectorRaw
+        ],  # accepted_connector_raw (for resnap crossing re-check)
+        dict[int, int],  # kruskal_rank_by_dangle_oid (for resnap crossing re-check)
     ]:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
@@ -3170,9 +3170,7 @@ class FillLineGaps:
         # ----------------------------
         trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
         if self.reject_crossing_connectors and legal_rows_by_dangle:
-            _crossing_sr = arcpy.SpatialReference(
-                self.crossing_check_spatial_reference
-            )
+            _crossing_sr = arcpy.SpatialReference(self.crossing_check_spatial_reference)
             # lines_copy provides self-line geometries; external polyline layers
             # whose ds_key is in polyline_by_external were loaded as angle caches.
             _check_layers: list[str] = [self.lines_copy]
@@ -4116,12 +4114,14 @@ class FillLineGaps:
         crossing_spatial_reference: Any,  # arcpy.SpatialReference | None
     ) -> tuple[
         list[_GlobalWithSource],
-        set[int],         # accepted_dangle_oids
-        set[int],         # kruskal_rejected_oids (cycle-based)
-        set[int],         # kruskal_crossing_rejected_oids
-        dict[int, str],   # gap_source_by_dangle
-        list[_AcceptedConnectorRaw],  # accepted_connector_raw (for resnap crossing re-check)
-        dict[int, int],               # kruskal_rank_by_dangle_oid
+        set[int],  # accepted_dangle_oids
+        set[int],  # kruskal_rejected_oids (cycle-based)
+        set[int],  # kruskal_crossing_rejected_oids
+        dict[int, str],  # gap_source_by_dangle
+        list[
+            _AcceptedConnectorRaw
+        ],  # accepted_connector_raw (for resnap crossing re-check)
+        dict[int, int],  # kruskal_rank_by_dangle_oid
     ]:
         """Global selection: Kruskal cycle prevention across accepted connections.
 
@@ -4195,7 +4195,9 @@ class FillLineGaps:
                     closest_count=0,
                     method="PLANAR",
                 )
-                with arcpy.da.SearchCursor(_kruskal_near, ["IN_FID", "NEAR_FID", "NEAR_DIST"]) as _cur:
+                with arcpy.da.SearchCursor(
+                    _kruskal_near, ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+                ) as _cur:
                     for _in_fid, _near_fid, _near_dist in _cur:
                         if int(_in_fid) == int(_near_fid):
                             continue
@@ -4217,13 +4219,15 @@ class FillLineGaps:
                 kruskal_rank_by_dangle_oid[d_oid] = rank_counter
                 _key = (d_oid, str(prop.ctx.near_fc_key), int(prop.ctx.near_fid))
                 accepted_keys.add(_key)
-                accepted_connector_raw.append((
-                    d_oid,
-                    float(prop.ctx.dangle_x),
-                    float(prop.ctx.dangle_y),
-                    float(prop.ctx.near_x),
-                    float(prop.ctx.near_y),
-                ))
+                accepted_connector_raw.append(
+                    (
+                        d_oid,
+                        float(prop.ctx.dangle_x),
+                        float(prop.ctx.dangle_y),
+                        float(prop.ctx.near_x),
+                        float(prop.ctx.near_y),
+                    )
+                )
 
         def _crossing_blocked(prop: Any) -> bool:
             if not reject_crossing:
@@ -4436,7 +4440,9 @@ class FillLineGaps:
 
         # {parent_id: set of conflicting accepted dangle_oids}
         conflicts_by_parent: dict[int, set[int]] = {}
-        with arcpy.da.SearchCursor(_near_table, ["IN_FID", "NEAR_FID", "NEAR_DIST"]) as cur:
+        with arcpy.da.SearchCursor(
+            _near_table, ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+        ) as cur:
             for in_fid, near_fid, near_dist in cur:
                 if near_dist != 0.0:
                     continue
@@ -4475,7 +4481,11 @@ class FillLineGaps:
                 entry["skip"] = True
                 resnap_crossing_rejected_oids.add(dangle_oid)
 
-        return resnap_plan, resnap_crossing_rejected_oids, resnap_crossing_displaced_oids
+        return (
+            resnap_plan,
+            resnap_crossing_rejected_oids,
+            resnap_crossing_displaced_oids,
+        )
 
     def _assemble_plan_entries(
         self,
@@ -5337,9 +5347,13 @@ class FillLineGaps:
         if self.candidate_connections_output is not None:
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
-        plan, resnap_captures, diagnostics, accepted_connector_raw, kruskal_rank_by_dangle_oid = (
-            self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
-        )
+        (
+            plan,
+            resnap_captures,
+            diagnostics,
+            accepted_connector_raw,
+            kruskal_rank_by_dangle_oid,
+        ) = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
 
         # Capture snap-source dangle endpoints before _apply_plan moves them.
         snap_source_dangle_xy: dict[int, tuple[float, float]] = {
@@ -5358,17 +5372,23 @@ class FillLineGaps:
                 snap_source_dangle_xy=snap_source_dangle_xy,
             )
 
-            if self.reject_crossing_connectors and resnap_plan and accepted_connector_raw:
-                resnap_plan, resnap_crossing_rejected_oids, resnap_crossing_displaced_oids = (
-                    self._recheck_resnap_crossings(
-                        resnap_plan=resnap_plan,
-                        accepted_connector_raw=accepted_connector_raw,
-                        kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
-                        trim_distance=2.0 * float(self.connectivity_tolerance_meters),
-                        spatial_reference=arcpy.SpatialReference(
-                            self.crossing_check_spatial_reference
-                        ),
-                    )
+            if (
+                self.reject_crossing_connectors
+                and resnap_plan
+                and accepted_connector_raw
+            ):
+                (
+                    resnap_plan,
+                    resnap_crossing_rejected_oids,
+                    resnap_crossing_displaced_oids,
+                ) = self._recheck_resnap_crossings(
+                    resnap_plan=resnap_plan,
+                    accepted_connector_raw=accepted_connector_raw,
+                    kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
+                    trim_distance=2.0 * float(self.connectivity_tolerance_meters),
+                    spatial_reference=arcpy.SpatialReference(
+                        self.crossing_check_spatial_reference
+                    ),
                 )
             else:
                 resnap_crossing_rejected_oids: set[int] = set()
@@ -5380,7 +5400,8 @@ class FillLineGaps:
                 resnapped_dangle_oids = {
                     int(v["dangle_oid"])
                     for v in resnap_plan.values()
-                    if isinstance(v, dict) and "dangle_oid" in v
+                    if isinstance(v, dict)
+                    and "dangle_oid" in v
                     and not v.get("skip", False)
                 }
                 for diag in diagnostics:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
+import math
 
-from typing import Optional, Callable, Iterable
+from typing import Optional, Callable, Iterable, Any
 
 import arcpy
 
@@ -11,6 +12,7 @@ from custom_tools.general_tools import custom_arcpy, file_utilities
 from file_manager import WorkFileManager
 from composition_configs import logic_config
 from composition_configs.logic_config import ConnectivityScope, LineConnectivityMode
+from custom_tools.general_tools import geometry_tools
 
 
 OptionalKey = tuple[str, int]  # (dataset_key, oid)  -- oid is SOURCE oid
@@ -728,6 +730,23 @@ class Proposal:
     target_dangle_oid: Optional[int]  # only if chosen is a dangle target
 
 
+@dataclass(frozen=True)
+class AngleAssessment:
+    # Primary decisions
+    available: bool
+    blocks: bool
+    allow_extra_dangle: bool  # expanded dangle tol + edge-case bonus
+    angle_metric_deg: Optional[float]
+    angle_penalty_m: float
+
+    # Diagnostics (optional)
+    src_connector_diff: Optional[float] = None
+    connector_target_diff: Optional[float] = None
+    src_target_diff: Optional[float] = None
+    connector_transition_diff: Optional[float] = None
+    line_match_diff: Optional[float] = None
+
+
 class FillLineGaps:
     ORIGINAL_ID = "line_gap_original_id"
 
@@ -773,6 +792,45 @@ class FillLineGaps:
                 "Invalid config: fill_gaps_on_self cannot be False when connect_to_features is None."
             )
 
+        # ----------------------------
+        # Angle config
+        # ----------------------------
+        self.angle_block_threshold_degrees = (
+            None
+            if adv.angle_block_threshold_degrees is None
+            else float(adv.angle_block_threshold_degrees)
+        )
+        self.angle_extra_dangle_threshold_degrees = (
+            None
+            if adv.angle_extra_dangle_threshold_degrees is None
+            else float(adv.angle_extra_dangle_threshold_degrees)
+        )
+        self.angle_penalty_max_meters = (
+            None
+            if adv.angle_penalty_max_meters is None
+            else float(adv.angle_penalty_max_meters)
+        )
+
+        w = float(getattr(adv, "line_alignment_weight", 0.6))
+        self.line_alignment_weight = max(0.0, min(1.0, w))
+
+        self.angle_local_half_window_m = float(
+            getattr(adv, "angle_local_half_window_m", 2.0)
+        )
+
+        # Raw config map (may be keyed by path or dataset_key(path))
+        self._connect_to_features_angle_mode_raw = (
+            adv.connect_to_features_angle_mode or {}
+        )
+
+        # Filled during _build_external_target_layers_once:
+        # dataset_key(output_layer) -> AngleTargetMode
+        self._angle_mode_by_external_ds_key: dict[str, logic_config.AngleTargetMode] = (
+            {}
+        )
+
+        # Local angle cache (dataset_key, oid, rx, ry) -> Optional[float]
+        self._local_angle_cache: dict[tuple[str, int, int, int], Optional[float]] = {}
         self.write_work_files_to_memory = (
             line_gap_config.work_file_manager_config.write_to_memory
         )
@@ -1056,24 +1114,19 @@ class FillLineGaps:
         dangles_fc_key: str,
         dangle_parent: dict[int, int],
         best_line_parent_by_dangle: dict[int, int],
+        bonus_allowed: bool = True,
     ) -> tuple[float, float, bool, tuple[float, int, float, int, int, str, int]]:
-        """
-        Returns:
-        - raw_distance
-        - effective_distance
-        - bonus_applied
-        - deterministic score tuple
-
-        Negative effective distances are allowed intentionally.
-        """
         raw_distance = float(cand["near_dist"])
-        bonus_applied = self._edge_case_bonus_applies(
-            dangle_oid=int(dangle_oid),
-            cand=cand,
-            dangles_fc_key=dangles_fc_key,
-            dangle_parent=dangle_parent,
-            best_line_parent_by_dangle=best_line_parent_by_dangle,
-        )
+
+        bonus_applied = False
+        if bonus_allowed:
+            bonus_applied = self._edge_case_bonus_applies(
+                dangle_oid=int(dangle_oid),
+                cand=cand,
+                dangles_fc_key=dangles_fc_key,
+                dangle_parent=dangle_parent,
+                best_line_parent_by_dangle=best_line_parent_by_dangle,
+            )
 
         if bonus_applied:
             effective_distance = raw_distance - float(
@@ -1082,8 +1135,6 @@ class FillLineGaps:
         else:
             effective_distance = raw_distance
 
-        # If effective distances tie, prefer the bonus-applied candidate.
-        # That preserves the intended "prioritize the dangle" behavior at the boundary.
         bonus_rank = 0 if bonus_applied else 1
 
         score = (
@@ -1123,6 +1174,90 @@ class FillLineGaps:
             self.lines_copy, self.dangles, "DANGLE"
         )
 
+    def _build_polyline_by_parent_id(self) -> dict[int, Any]:
+        out: dict[int, Any] = {}
+        with arcpy.da.SearchCursor(
+            self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"]
+        ) as cur:
+            for pid, shape in cur:
+                if shape is None:
+                    continue
+                out[int(pid)] = shape
+        return out
+
+    def _build_polyline_by_oid(self, fc: str) -> dict[int, Any]:
+        oid_field = arcpy.Describe(fc).OIDFieldName
+        out: dict[int, Any] = {}
+        with arcpy.da.SearchCursor(fc, [oid_field, "SHAPE@"]) as cur:
+            for oid, shape in cur:
+                if shape is None:
+                    continue
+                out[int(oid)] = shape
+        return out
+
+    def _is_polyline_fc(self, fc: str) -> bool:
+        try:
+            desc = arcpy.Describe(fc)
+            # ArcGIS commonly uses "Polyline" here
+            return str(getattr(desc, "shapeType", "")).lower() == "polyline"
+        except Exception:
+            return False
+
+    def _orientation(self, angle_deg: float) -> float:
+        return float(angle_deg) % 180.0
+
+    def _orientation_diff(self, a_deg: float, b_deg: float) -> float:
+        a = self._orientation(float(a_deg))
+        b = self._orientation(float(b_deg))
+        raw = abs(a - b)
+        return min(raw, 180.0 - raw)  # 0..90
+
+    def _connector_angle_deg(
+        self, *, from_x: float, from_y: float, to_x: float, to_y: float
+    ) -> Optional[float]:
+        dx = float(to_x) - float(from_x)
+        dy = float(to_y) - float(from_y)
+        if abs(dx) < 1e-12 and abs(dy) < 1e-12:
+            return None
+        ang = math.degrees(math.atan2(dy, dx))
+        if ang < 0.0:
+            ang += 360.0
+        return float(ang)
+
+    def _local_angle_cache_key(
+        self, *, dataset_key: str, oid: int, x: float, y: float
+    ) -> tuple[str, int, int, int]:
+        # integer mill-units in dataset units (deterministic hashing)
+        scale = 1000.0
+        return (
+            str(dataset_key),
+            int(oid),
+            int(round(float(x) * scale)),
+            int(round(float(y) * scale)),
+        )
+
+    def _local_line_angle_cached(
+        self,
+        *,
+        dataset_key: str,
+        oid: int,
+        polyline,
+        x: float,
+        y: float,
+    ) -> Optional[float]:
+        key = self._local_angle_cache_key(dataset_key=dataset_key, oid=oid, x=x, y=y)
+        if key in self._local_angle_cache:
+            return self._local_angle_cache[key]
+
+        angle = geometry_tools.local_line_angle_at_xy(
+            polyline=polyline,
+            x=float(x),
+            y=float(y),
+            desired_half_window_m=float(self.angle_local_half_window_m),
+        )
+        self._local_angle_cache[key] = angle
+        return angle
+
     # ----------------------------
     # Target staging
     # ----------------------------
@@ -1154,6 +1289,21 @@ class FillLineGaps:
                 )
 
             self.external_target_layers.append(output_name)
+            out_key = self._dataset_key(output_name)
+
+            raw_map = self._connect_to_features_angle_mode_raw
+            raw_mode = (
+                raw_map.get(feature_path)
+                or raw_map.get(self._dataset_key(feature_path))
+                or raw_map.get(out_key)
+            )
+
+            if raw_mode is None:
+                mode = logic_config.AngleTargetMode.AUTO
+            else:
+                mode = logic_config.AngleTargetMode(raw_mode)
+
+            self._angle_mode_by_external_ds_key[str(out_key)] = mode
 
     def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
         targets: list[str] = []
@@ -1446,60 +1596,6 @@ class FillLineGaps:
 
         return adjacency
 
-    def _propagate_external_illegal_within_components(
-        self,
-        *,
-        illegal: dict[int, dict[str, set[int]]],
-        adjacency: dict[int, set[int]],
-    ) -> None:
-        """
-        For each connected component of the line network, union external illegal targets
-        and apply to every member.
-
-        External illegal targets = everything except the canonical lines_key (self-line rule).
-        """
-        lines_key = self._dataset_key(self.lines_copy)
-
-        visited: set[int] = set()
-
-        # Ensure we include isolated nodes too
-        all_nodes = set(illegal.keys()) | set(adjacency.keys())
-        for pid in list(all_nodes):
-            pid = int(pid)
-            if pid in visited:
-                continue
-
-            # BFS to get component
-            stack = [pid]
-            component: set[int] = set()
-
-            while stack:
-                cur = int(stack.pop())
-                if cur in visited:
-                    continue
-                visited.add(cur)
-                component.add(cur)
-
-                for nb in adjacency.get(cur, set()):
-                    nb = int(nb)
-                    if nb not in visited:
-                        stack.append(nb)
-
-            # Union external illegal across component
-            union_external: dict[str, set[int]] = {}
-            for member in component:
-                ds_map = illegal.get(int(member), {})
-                for ds_key, ids in ds_map.items():
-                    if ds_key == lines_key:
-                        continue  # keep self-line constraint per member
-                    union_external.setdefault(ds_key, set()).update(ids)
-
-            # Apply union to each member
-            for member in component:
-                illegal.setdefault(int(member), {})
-                for ds_key, ids in union_external.items():
-                    illegal[int(member)].setdefault(ds_key, set()).update(ids)
-
     def _is_illegal(
         self,
         *,
@@ -1728,6 +1824,196 @@ class FillLineGaps:
             return False
 
         return True
+
+    def _assess_angle(
+        self,
+        *,
+        src_parent_id: int,
+        dangle_x: float,
+        dangle_y: float,
+        src_angle_deg: Optional[float],
+        cand: dict,
+        dangles_fc_key: str,
+        lines_fc_key: str,
+        dangle_parent: dict[int, int],
+        dangle_xy: dict[int, tuple[float, float]],
+        polyline_by_parent: dict[int, Any],
+        polyline_by_external: dict[str, dict[int, Any]],
+        is_external_line_like: dict[str, bool],
+    ) -> AngleAssessment:
+        ds_key = str(cand["near_fc_key"])
+        near_fid = int(cand["near_fid"])
+        near_x = float(cand["near_x"])
+        near_y = float(cand["near_y"])
+
+        connector_angle = self._connector_angle_deg(
+            from_x=dangle_x, from_y=dangle_y, to_x=near_x, to_y=near_y
+        )
+
+        # Determine line-like vs non-line
+        if ds_key == lines_fc_key or ds_key == dangles_fc_key:
+            treat_as_line_like = True
+        else:
+            mode = self._angle_mode_by_external_ds_key.get(
+                ds_key, logic_config.AngleTargetMode.AUTO
+            )
+            if mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
+                treat_as_line_like = False
+            else:
+                treat_as_line_like = bool(is_external_line_like.get(ds_key, False))
+
+        # Base requirements
+        if src_angle_deg is None or connector_angle is None:
+            # Angle unavailable => no block, no penalty; conservative extra-dangle policy handled below
+            allow_extra = ds_key != dangles_fc_key  # only relevant for dangle targets
+            return AngleAssessment(
+                available=False,
+                blocks=False,
+                allow_extra_dangle=bool(allow_extra),
+                angle_metric_deg=None,
+                angle_penalty_m=0.0,
+            )
+
+        src_connector_diff = self._orientation_diff(
+            float(src_angle_deg), float(connector_angle)
+        )
+
+        # Non-line targets use src_connector_diff directly
+        if not treat_as_line_like:
+            metric = float(src_connector_diff)
+
+            blocks = self.angle_block_threshold_degrees is not None and metric > float(
+                self.angle_block_threshold_degrees
+            )
+
+            # extra-dangle threshold only affects dangle targets
+            allow_extra = True
+            if ds_key == dangles_fc_key:
+                if self.angle_extra_dangle_threshold_degrees is None:
+                    allow_extra = True
+                else:
+                    allow_extra = metric <= float(
+                        self.angle_extra_dangle_threshold_degrees
+                    )
+
+            penalty = 0.0
+            if self.angle_penalty_max_meters is not None:
+                penalty = (metric / 90.0) * float(self.angle_penalty_max_meters)
+
+            return AngleAssessment(
+                available=True,
+                blocks=bool(blocks),
+                allow_extra_dangle=bool(allow_extra),
+                angle_metric_deg=float(metric),
+                angle_penalty_m=float(penalty),
+                src_connector_diff=float(src_connector_diff),
+            )
+
+        # Line-like targets: need target angle too
+        target_angle: Optional[float] = None
+        connector_target_diff: Optional[float] = None
+        src_target_diff: Optional[float] = None
+        connector_transition_diff: Optional[float] = None
+        line_match_diff: Optional[float] = None
+
+        if ds_key == lines_fc_key:
+            tgt_parent = int(near_fid)
+            tgt_poly = polyline_by_parent.get(tgt_parent)
+            if tgt_poly is not None:
+                target_angle = self._local_line_angle_cached(
+                    dataset_key=lines_fc_key,
+                    oid=tgt_parent,
+                    polyline=tgt_poly,
+                    x=near_x,
+                    y=near_y,
+                )
+
+        elif ds_key == dangles_fc_key:
+            other_dangle_oid = int(near_fid)
+            other_parent = dangle_parent.get(other_dangle_oid)
+            if other_parent is not None:
+                tgt_poly = polyline_by_parent.get(int(other_parent))
+                if tgt_poly is not None:
+                    # Prefer true dangle XY lookup; fall back to near_x/near_y
+                    xy = dangle_xy.get(other_dangle_oid)
+                    tx, ty = xy if xy is not None else (near_x, near_y)
+                    target_angle = self._local_line_angle_cached(
+                        dataset_key=lines_fc_key,
+                        oid=int(other_parent),
+                        polyline=tgt_poly,
+                        x=float(tx),
+                        y=float(ty),
+                    )
+
+        else:
+            ext = polyline_by_external.get(ds_key, {})
+            tgt_poly = ext.get(int(near_fid))
+            if tgt_poly is not None:
+                target_angle = self._local_line_angle_cached(
+                    dataset_key=ds_key,
+                    oid=int(near_fid),
+                    polyline=tgt_poly,
+                    x=near_x,
+                    y=near_y,
+                )
+
+        if target_angle is None:
+            # Unavailable => no block/penalty; conservative extra-dangle policy for dangle targets
+            allow_extra = ds_key != dangles_fc_key
+            return AngleAssessment(
+                available=False,
+                blocks=False,
+                allow_extra_dangle=bool(allow_extra),
+                angle_metric_deg=None,
+                angle_penalty_m=0.0,
+                src_connector_diff=float(src_connector_diff),
+            )
+
+        connector_target_diff = self._orientation_diff(
+            float(connector_angle), float(target_angle)
+        )
+        src_target_diff = self._orientation_diff(
+            float(src_angle_deg), float(target_angle)
+        )
+        connector_transition_diff = 0.5 * (
+            float(src_connector_diff) + float(connector_target_diff)
+        )
+
+        w = float(self.line_alignment_weight)
+        connector_w = 1.0 - w
+        line_match_diff = connector_w * float(connector_transition_diff) + w * float(
+            src_target_diff
+        )
+
+        metric = float(line_match_diff)
+
+        blocks = self.angle_block_threshold_degrees is not None and metric > float(
+            self.angle_block_threshold_degrees
+        )
+
+        allow_extra = True
+        if ds_key == dangles_fc_key:
+            if self.angle_extra_dangle_threshold_degrees is None:
+                allow_extra = True
+            else:
+                allow_extra = metric <= float(self.angle_extra_dangle_threshold_degrees)
+
+        penalty = 0.0
+        if self.angle_penalty_max_meters is not None:
+            penalty = (metric / 90.0) * float(self.angle_penalty_max_meters)
+
+        return AngleAssessment(
+            available=True,
+            blocks=bool(blocks),
+            allow_extra_dangle=bool(allow_extra),
+            angle_metric_deg=float(metric),
+            angle_penalty_m=float(penalty),
+            src_connector_diff=float(src_connector_diff),
+            connector_target_diff=float(connector_target_diff),
+            src_target_diff=float(src_target_diff),
+            connector_transition_diff=float(connector_transition_diff),
+            line_match_diff=float(line_match_diff),
+        )
 
     def _pair_token_from_candidate(
         self,
@@ -2009,7 +2295,6 @@ class FillLineGaps:
         # ----------------------------
         legal_rows_by_dangle: dict[int, list[dict]] = {}
         parent_id_by_dangle: dict[int, int] = {}
-        best_line_parent_by_dangle: dict[int, int] = {}
 
         for dangle_oid in sorted(grouped.keys()):
             candidates = grouped[dangle_oid]
@@ -2032,7 +2317,7 @@ class FillLineGaps:
                     parent_id=parent_id,
                     cand=cand,
                     base_tol=base_tol,
-                    dangle_candidate_tol=dangle_tol,  # expanded tolerance still applies here
+                    dangle_candidate_tol=dangle_tol,
                     topology=topology,
                 ):
                     legal_rows.append(cand)
@@ -2043,18 +2328,104 @@ class FillLineGaps:
             legal_rows_by_dangle[dangle_oid] = legal_rows
             parent_id_by_dangle[dangle_oid] = parent_id
 
-            best_line_parent = self._best_legal_line_target_parent(
-                legal_rows=legal_rows,
-                lines_fc_key=lines_key,
-            )
-            if best_line_parent is not None:
-                best_line_parent_by_dangle[dangle_oid] = int(best_line_parent)
-
         if not legal_rows_by_dangle:
             return {}, {}
+        # ----------------------------
+        # Angle caches (new)
+        # ----------------------------
+        polyline_by_parent = self._build_polyline_by_parent_id()
+
+        # External polyline caches keyed by dataset_key(layer)
+        polyline_by_external: dict[str, dict[int, Any]] = {}
+        is_external_line_like: dict[str, bool] = {}
+
+        line_keys = (
+            self._line_dataset_keys()
+        )  # {dataset_key(lines_copy), dataset_key(target_self)}
+
+        for lyr in target_layers:
+            ds_key = self._dataset_key(lyr)
+
+            # Skip any internal line datasets
+            if ds_key in line_keys:
+                continue
+
+            mode = self._angle_mode_by_external_ds_key.get(
+                ds_key, logic_config.AngleTargetMode.AUTO
+            )
+            if mode == logic_config.AngleTargetMode.FORCE_NON_LINE:
+                is_external_line_like[ds_key] = False
+                continue
+
+            if self._is_polyline_fc(lyr):
+                is_external_line_like[ds_key] = True
+                polyline_by_external[ds_key] = self._build_polyline_by_oid(lyr)
+            else:
+                is_external_line_like[ds_key] = False
 
         # ----------------------------
-        # Step 1B: choose exactly ONE proposal per dangle using edge-case adjusted scoring
+        # Best line parent per dangle (angle-aware)
+        # Used by edge-case bonus detection.
+        # ----------------------------
+        best_line_parent_by_dangle = {}
+
+        for dangle_oid in sorted(legal_rows_by_dangle.keys()):
+            parent_id = int(parent_id_by_dangle[dangle_oid])
+
+            xy = dangle_xy.get(int(dangle_oid))
+            if xy is None:
+                continue
+            d_x, d_y = xy
+
+            src_poly = polyline_by_parent.get(int(parent_id))
+            src_angle = None
+            if src_poly is not None:
+                src_angle = self._local_line_angle_cached(
+                    dataset_key=lines_key,
+                    oid=int(parent_id),
+                    polyline=src_poly,
+                    x=float(d_x),
+                    y=float(d_y),
+                )
+
+            best = None
+            best_score = None
+
+            for cand in legal_rows_by_dangle[dangle_oid]:
+                if str(cand["near_fc_key"]) != str(lines_key):
+                    continue
+
+                assess = self._assess_angle(
+                    src_parent_id=int(parent_id),
+                    dangle_x=float(d_x),
+                    dangle_y=float(d_y),
+                    src_angle_deg=src_angle,
+                    cand=cand,
+                    dangles_fc_key=dangles_key,
+                    lines_fc_key=lines_key,
+                    dangle_parent=dangle_parent,
+                    dangle_xy=dangle_xy,
+                    polyline_by_parent=polyline_by_parent,
+                    polyline_by_external=polyline_by_external,
+                    is_external_line_like=is_external_line_like,
+                )
+                if assess.blocks:
+                    continue
+
+                # Line targets do not use edge-case bonus. Score is raw + angle penalty.
+                raw_dist = float(cand["near_dist"])
+                eff = raw_dist + float(assess.angle_penalty_m)
+
+                # Deterministic tie-break:
+                score = (float(eff), float(raw_dist), self._candidate_sort_key(cand))
+                if best_score is None or score < best_score:
+                    best_score = score
+                    best = int(cand["near_fid"])
+
+            if best is not None:
+                best_line_parent_by_dangle[int(dangle_oid)] = int(best)
+        # ----------------------------
+        # Step 1B: choose exactly ONE proposal per dangle using angle-aware scoring
         # ----------------------------
         proposals_by_dangle: dict[int, Proposal] = {}
 
@@ -2063,17 +2434,73 @@ class FillLineGaps:
             parent_id = int(parent_id_by_dangle[dangle_oid])
             legal_rows = legal_rows_by_dangle[dangle_oid]
 
+            xy = dangle_xy.get(dangle_oid)
+            if xy is None:
+                continue
+            d_x, d_y = xy
+
+            # Source line angle (local at the dangle XY)
+            src_poly = polyline_by_parent.get(int(parent_id))
+            src_angle = None
+            if src_poly is not None:
+                src_angle = self._local_line_angle_cached(
+                    dataset_key=lines_key,  # canonical lines key
+                    oid=int(parent_id),  # ORIGINAL_ID space for parent lines
+                    polyline=src_poly,
+                    x=float(d_x),
+                    y=float(d_y),
+                )
+
             scored_candidates: list[
                 tuple[
-                    tuple[float, int, float, int, int, str, int],
-                    dict,
-                    float,
-                    float,
-                    bool,
+                    tuple[float, int, float, int, int, str, int],  # score tuple
+                    dict,  # candidate
+                    float,  # raw_distance
+                    float,  # effective_distance_for_scoring
+                    bool,  # bonus_applied
                 ]
             ] = []
 
             for cand in legal_rows:
+                assess = self._assess_angle(
+                    src_parent_id=int(parent_id),
+                    dangle_x=float(d_x),
+                    dangle_y=float(d_y),
+                    src_angle_deg=src_angle,
+                    cand=cand,
+                    dangles_fc_key=dangles_key,
+                    lines_fc_key=lines_key,
+                    dangle_parent=dangle_parent,
+                    dangle_xy=dangle_xy,
+                    polyline_by_parent=polyline_by_parent,
+                    polyline_by_external=polyline_by_external,
+                    is_external_line_like=is_external_line_like,
+                )
+
+                # 1) Candidate blocking (angle_block_threshold_degrees)
+                if assess.blocks:
+                    continue
+
+                # 2) Expanded dangle tolerance gating (angle_extra_dangle_threshold_degrees)
+                is_dangle_target = str(cand["near_fc_key"]) == str(dangles_key)
+                dist = float(cand["near_dist"])
+
+                if (
+                    is_dangle_target
+                    and dist > float(base_tol)
+                    and not bool(assess.allow_extra_dangle)
+                ):
+                    # Candidate is only legal due to expanded tolerance; angle disallows it
+                    continue
+
+                # 3) Edge-case bonus eligibility is angle-controlled (and conservative when angle missing)
+                bonus_allowed = True
+                if is_dangle_target:
+                    # conservative policy: if angle is unavailable => no expanded behavior, no bonus
+                    bonus_allowed = bool(assess.available) and bool(
+                        assess.allow_extra_dangle
+                    )
+
                 raw_distance, effective_distance, bonus_applied, score = (
                     self._candidate_score_details(
                         dangle_oid=dangle_oid,
@@ -2082,17 +2509,53 @@ class FillLineGaps:
                         dangles_fc_key=dangles_key,
                         dangle_parent=dangle_parent,
                         best_line_parent_by_dangle=best_line_parent_by_dangle,
+                        bonus_allowed=bool(bonus_allowed),
                     )
                 )
-                scored_candidates.append(
-                    (score, cand, raw_distance, effective_distance, bonus_applied)
+
+                # 4) Distance-equivalent angle penalty integrates into scoring
+                effective_for_scoring = float(effective_distance) + float(
+                    assess.angle_penalty_m
                 )
 
-            score, chosen, raw_distance, effective_distance, bonus_applied = min(
+                # Keep score tuple shape stable; only replace the first element
+                score_with_angle = (
+                    float(effective_for_scoring),
+                    int(score[1]),
+                    float(score[2]),
+                    int(score[3]),
+                    int(score[4]),
+                    str(score[5]),
+                    int(score[6]),
+                )
+
+                scored_candidates.append(
+                    (
+                        score_with_angle,
+                        cand,
+                        float(raw_distance),
+                        float(effective_for_scoring),
+                        bool(bonus_applied),
+                    )
+                )
+
+            if not scored_candidates:
+                continue
+
+            (
+                score,
+                chosen,
+                raw_distance,
+                effective_distance_for_scoring,
+                bonus_applied,
+            ) = min(
                 scored_candidates,
                 key=lambda item: item[0],
             )
 
+            # ----------------------------
+            # Proposal construction (unchanged semantics)
+            # ----------------------------
             src_node = self._node_for_parent(parent_id=parent_id, topology=topology)
 
             target_parent_id: Optional[int] = None
@@ -2134,7 +2597,7 @@ class FillLineGaps:
                 tgt_node=tgt_node,
                 chosen=chosen,
                 raw_distance=float(raw_distance),
-                effective_distance=float(effective_distance),
+                effective_distance=float(effective_distance_for_scoring),
                 bonus_applied=bool(bonus_applied),
                 score=score,
                 pair_key=pair_key,
@@ -2146,11 +2609,9 @@ class FillLineGaps:
             return {}, {}
 
         # ----------------------------
-        # Deferred detection (preserved behavior)
-        # - If A proposes to parent B (via line/dangle target),
-        #   and B has dangles in this run but does NOT propose back to parent A,
-        #   then A is deferred (computed later against updated geometry).
-        # - Keep deferred container shape as dict[parent_id -> dict].
+        # Mutual detection (for labeling)
+        # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
+        # - network mutual: any proposal exists in both directions between the two network nodes
         # ----------------------------
         parents_with_dangles = sorted(set(dangle_parent.values()))
         parents_with_dangles_set = {int(v) for v in parents_with_dangles}
@@ -2201,12 +2662,6 @@ class FillLineGaps:
         ]
         if not active:
             return {}, deferred_by_parent
-
-        # ----------------------------
-        # Mutual detection (for labeling)
-        # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
-        # - network mutual: any proposal exists in both directions between the two network nodes
-        # ----------------------------
         active_by_dangle = {int(p.dangle_oid): p for p in active}
 
         dangle_mutual_oids: set[int] = set()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -11,35 +11,42 @@ from composition_configs import logic_config
 
 
 class FillLineGaps:
-    """
-    What:
-        Fills small gaps by extending dangling endpoints of input lines to the nearest location
-        on target features within a tolerance distance.
-
-    How:
-        - Copies input lines to avoid modifying originals.
-        - Adds ORIGINAL_ID field on the copied lines (set to OID).
-        - Creates dangle points.
-        - Removes lines that produced dangles from the "self target" candidate set.
-        - Selects target features (self + optional external) within tolerance of dangles.
-        - Filters dangles that are within tolerance of any target feature.
-        - Runs Near (LOCATION) to obtain NEAR_X/NEAR_Y.
-        - Updates the correct endpoint of each line to the NEAR_X/NEAR_Y location.
-
-    Why:
-        Used to close small digitizing gaps while keeping edits limited to endpoints.
-    """
-
     ORIGINAL_ID = "line_gap_original_id"
+
+    # Change output fields
+    FIELD_GAP_DIST_M = "gap_dist_m"
+    FIELD_GAP_SOURCE = "gap_source"
+
+    GAP_SOURCE_DEFAULT = "default"
+    GAP_SOURCE_PAIR_DANGLE = "pair_dangle"
+    GAP_SOURCE_PAIR_LINE = "pair_line"
+    GAP_SOURCE_DEFERRED = "deferred"
+
+    # Near table fields
+    F_IN_FID = "IN_FID"
+    F_NEAR_FID = "NEAR_FID"
+    F_NEAR_FC = "NEAR_FC"
+    F_NEAR_DIST = "NEAR_DIST"
+    F_NEAR_X = "NEAR_X"
+    F_NEAR_Y = "NEAR_Y"
 
     def __init__(self, line_gap_config: logic_config.FillLineGapsConfig):
         self.input_lines = line_gap_config.input_lines
         self.output_lines = line_gap_config.output_lines
-        self.line_changes_output = line_gap_config.line_changes_output
-
-        self.gap_tolerance_meters = line_gap_config.gap_tolerance_meters
         self.connect_to_features = line_gap_config.connect_to_features
-        self.fill_gaps_on_self = line_gap_config.fill_gaps_on_self
+        self.gap_tolerance_meters = int(line_gap_config.gap_tolerance_meters)
+
+        adv = line_gap_config.advanced_config
+        self.fill_gaps_on_self = bool(adv.fill_gaps_on_self)
+        self.line_changes_output = adv.line_changes_output
+        self.increased_tolerance_edge_case_distance_meters = int(
+            adv.increased_tolerance_edge_case_distance_meters
+        )
+
+        if self.connect_to_features is None and self.fill_gaps_on_self is False:
+            raise ValueError(
+                "Invalid config: fill_gaps_on_self cannot be False when connect_to_features is None."
+            )
 
         self.write_work_files_to_memory = (
             line_gap_config.work_file_manager_config.write_to_memory
@@ -47,259 +54,993 @@ class FillLineGaps:
         self.keep_work_files = line_gap_config.work_file_manager_config.keep_files
         self.root_file = line_gap_config.work_file_manager_config.root_file
 
-        if self.connect_to_features is None and self.fill_gaps_on_self is False:
-            raise ValueError(
-                "Invalid config: fill_gaps_on_self cannot be False when connect_to_features is None."
-            )
-
         self.wfm = WorkFileManager(config=line_gap_config.work_file_manager_config)
 
+        # Work files (WFM will expand to full unique paths in run())
         self.lines_copy = "lines_copy"
         self.dangles = "dangles"
-        self.input_lines_filtered = "input_lines_filtered"
         self.filtered_dangles = "filtered_dangles"
 
         self.target_self = "target_self"
-        self.target_feature_layers: list[str] = []
+
+        self.near_table = "near_table_all"
+        self.conn_endpoints = "line_endpoints"
+        self.conn_table = "connected_table"
+
+        self.external_target_layers: list[str] = []
 
         self.work_file_list = [
             self.lines_copy,
             self.dangles,
-            self.input_lines_filtered,
             self.filtered_dangles,
             self.target_self,
+            self.near_table,
+            self.conn_endpoints,
+            self.conn_table,
         ]
 
+    # ----------------------------
+    # Units & dataset key
+    # ----------------------------
+
     def _tolerance_linear_unit(self) -> str:
-        return f"{self.gap_tolerance_meters} Meters"
+        return f"{int(self.gap_tolerance_meters)} Meters"
+
+    def _expanded_dangle_tolerance_meters(self) -> int:
+        extra = max(0, int(self.increased_tolerance_edge_case_distance_meters))
+        return int(self.gap_tolerance_meters) + extra
+
+    def _expanded_dangle_tolerance_linear_unit(self) -> str:
+        return f"{int(self._expanded_dangle_tolerance_meters())} Meters"
+
+    def _dataset_key(self, value: str) -> str:
+        text = str(value).replace("\\", "/")
+        return text.split("/")[-1]
+
+    # ----------------------------
+    # Preprocessing
+    # ----------------------------
 
     def _copy_input_lines(self) -> None:
-        arcpy.management.CopyFeatures(
-            in_features=self.input_lines,
-            out_feature_class=self.lines_copy,
-        )
+        arcpy.management.CopyFeatures(self.input_lines, self.lines_copy)
 
     def _add_original_id_field(self) -> None:
-        existing_fields = {
-            field.name for field in arcpy.ListFields(dataset=self.lines_copy)
-        }
-        if self.ORIGINAL_ID not in existing_fields:
-            arcpy.management.AddField(
-                in_table=self.lines_copy,
-                field_name=self.ORIGINAL_ID,
-                field_type="LONG",
-            )
+        existing = {f.name for f in arcpy.ListFields(self.lines_copy)}
+        if self.ORIGINAL_ID not in existing:
+            arcpy.management.AddField(self.lines_copy, self.ORIGINAL_ID, "LONG")
 
         oid_field = arcpy.Describe(self.lines_copy).OIDFieldName
         arcpy.management.CalculateField(
-            in_table=self.lines_copy,
-            field=self.ORIGINAL_ID,
+            self.lines_copy,
+            self.ORIGINAL_ID,
             expression=f"!{oid_field}!",
             expression_type="PYTHON3",
         )
 
     def _create_dangles(self) -> None:
         arcpy.management.FeatureVerticesToPoints(
-            in_features=self.lines_copy,
-            out_feature_class=self.dangles,
-            point_location="DANGLE",
+            self.lines_copy, self.dangles, "DANGLE"
         )
 
-    def _remove_lines_that_produced_dangles(self) -> None:
-        """
-        What:
-            Creates a filtered version of the copied lines where any line that produced
-            a dangle is excluded (so self-targeting does not snap back onto itself).
+    # ----------------------------
+    # Target staging
+    # ----------------------------
 
-        How:
-            - Select lines within tolerance of dangles.
-            - Invert selection to keep only lines not near those dangles.
-        """
-        if self.write_work_files_to_memory:
-            custom_arcpy.select_location_and_make_feature_layer(
-                input_layer=self.lines_copy,
-                overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
-                select_features=self.dangles,
-                output_name=self.input_lines_filtered,
-                inverted=True,
-                search_distance=self._tolerance_linear_unit(),
-            )
+    def _build_external_target_layers_once(self) -> None:
+        if self.external_target_layers:
+            return
+        if self.connect_to_features is None:
+            return
 
-        if not self.write_work_files_to_memory:
-            custom_arcpy.select_location_and_make_permanent_feature(
-                input_layer=self.lines_copy,
-                overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
-                select_features=self.dangles,
-                output_name=self.input_lines_filtered,
-                inverted=True,
-                search_distance=self._tolerance_linear_unit(),
-            )
+        for index, feature_path in enumerate(self.connect_to_features):
+            output_name = self.wfm.build_file_path(file_name=f"target_feature_{index}")
+
+            if self.write_work_files_to_memory:
+                custom_arcpy.select_location_and_make_feature_layer(
+                    input_layer=feature_path,
+                    overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                    select_features=self.dangles,
+                    output_name=output_name,
+                    search_distance=self._tolerance_linear_unit(),
+                )
+            else:
+                custom_arcpy.select_location_and_make_permanent_feature(
+                    input_layer=feature_path,
+                    overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                    select_features=self.dangles,
+                    output_name=output_name,
+                    search_distance=self._tolerance_linear_unit(),
+                )
+
+            self.external_target_layers.append(output_name)
 
     def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
-        """
-        What:
-            Builds the list of target feature datasets to be used by Near.
-
-        How:
-            - If fill_gaps_on_self: select from input_lines_filtered within tolerance of dangles.
-            - For each connect_to_features: select within tolerance of dangles into its own output.
-        """
-        target_layers: list[str] = []
-
+        targets: list[str] = []
         if self.fill_gaps_on_self:
             if self.write_work_files_to_memory:
                 custom_arcpy.select_location_and_make_feature_layer(
-                    input_layer=self.input_lines_filtered,
+                    input_layer=self.lines_copy,
                     overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
                     select_features=self.dangles,
                     output_name=self.target_self,
                     search_distance=self._tolerance_linear_unit(),
                 )
-
-            if not self.write_work_files_to_memory:
+            else:
                 custom_arcpy.select_location_and_make_permanent_feature(
-                    input_layer=self.input_lines_filtered,
+                    input_layer=self.lines_copy,
                     overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
                     select_features=self.dangles,
                     output_name=self.target_self,
                     search_distance=self._tolerance_linear_unit(),
                 )
+            targets.append(self.target_self)
 
-            target_layers.append(self.target_self)
+        targets.extend(self.external_target_layers)
+        return targets
 
-        if self.connect_to_features is not None:
-            for index, feature_path in enumerate(self.connect_to_features):
-                output_name = self.wfm.build_file_path(
-                    file_name=f"target_feature_{index}",
-                )
-
-                if self.write_work_files_to_memory:
-                    custom_arcpy.select_location_and_make_feature_layer(
-                        input_layer=feature_path,
-                        overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
-                        select_features=self.dangles,
-                        output_name=output_name,
-                        search_distance=self._tolerance_linear_unit(),
-                    )
-
-                if not self.write_work_files_to_memory:
-                    custom_arcpy.select_location_and_make_permanent_feature(
-                        input_layer=feature_path,
-                        overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
-                        select_features=self.dangles,
-                        output_name=output_name,
-                        search_distance=self._tolerance_linear_unit(),
-                    )
-
-                self.target_feature_layers.append(output_name)
-                target_layers.append(output_name)
-
-        return target_layers
-
-    def _filter_dangles_within_tolerance_of_targets(
-        self, target_layers: list[str]
-    ) -> None:
+    def _filter_true_dangles(self) -> None:
         """
-        What:
-            Keeps only dangles that are within tolerance of any target feature.
-
-        How:
-            - Creates a layer/view of dangles.
-            - Accumulates selections (ADD_TO_SELECTION) per target.
-            - Writes the selected dangles to filtered_dangles.
+        Keeps only true dangles:
+        - dangles that do NOT intersect any external target features
+        Note:
+        - We do NOT consider self lines here, only non-input layers.
+        - If connect_to_features is None -> all dangles are treated as true.
         """
-        dangles_layer = "dangles_lyr"
-        arcpy.management.MakeFeatureLayer(
-            in_features=self.dangles,
-            out_layer=dangles_layer,
-        )
+        if not self.external_target_layers:
+            # Nothing to filter against; keep all dangles as "true"
+            arcpy.management.CopyFeatures(self.dangles, self.filtered_dangles)
+            return
 
-        arcpy.management.SelectLayerByAttribute(
-            in_layer_or_view=dangles_layer,
-            selection_type="CLEAR_SELECTION",
-        )
+        dangles_lyr = "dangles_true_filter_lyr"
+        arcpy.management.MakeFeatureLayer(self.dangles, dangles_lyr)
 
-        for target in target_layers:
+        arcpy.management.SelectLayerByAttribute(dangles_lyr, "CLEAR_SELECTION")
+
+        # Select dangles that intersect ANY external features
+        for target in self.external_target_layers:
             arcpy.management.SelectLayerByLocation(
-                in_layer=dangles_layer,
-                overlap_type="WITHIN_A_DISTANCE",
+                in_layer=dangles_lyr,
+                overlap_type="INTERSECT",
                 select_features=target,
-                search_distance=self._tolerance_linear_unit(),
                 selection_type="ADD_TO_SELECTION",
             )
 
-        arcpy.management.CopyFeatures(
-            in_features=dangles_layer,
-            out_feature_class=self.filtered_dangles,
+        # Invert -> keep only dangles that do NOT intersect external features
+        arcpy.management.SelectLayerByAttribute(
+            dangles_lyr,
+            selection_type="SWITCH_SELECTION",
         )
 
-    def _run_near(self, target_layers: list[str]) -> None:
-        arcpy.analysis.Near(
-            in_features=self.filtered_dangles,
+        arcpy.management.CopyFeatures(dangles_lyr, self.filtered_dangles)
+
+    # ----------------------------
+    # Dangle lookups
+    # ----------------------------
+
+    def _build_dangle_parent_lookup(self, dangles_fc: str) -> dict[int, int]:
+        oid_field = arcpy.Describe(dangles_fc).OIDFieldName
+        out: dict[int, int] = {}
+        with arcpy.da.SearchCursor(dangles_fc, [oid_field, self.ORIGINAL_ID]) as cur:
+            for dangle_oid, parent_id in cur:
+                out[int(dangle_oid)] = int(parent_id)
+        return out
+
+    def _build_dangle_xy_lookup(
+        self, dangles_fc: str
+    ) -> dict[int, tuple[float, float]]:
+        oid_field = arcpy.Describe(dangles_fc).OIDFieldName
+        out: dict[int, tuple[float, float]] = {}
+        with arcpy.da.SearchCursor(dangles_fc, [oid_field, "SHAPE@XY"]) as cur:
+            for dangle_oid, (x, y) in cur:
+                out[int(dangle_oid)] = (float(x), float(y))
+        return out
+
+    # ----------------------------
+    # Illegal targets detection
+    # ----------------------------
+
+    def detect_illegal_targets(
+        self,
+        *,
+        dangle_parent: dict[int, int],
+        target_layers: list[str],
+    ) -> dict[int, dict[str, set[int]]]:
+        """
+        illegal[parent_id][dataset_key] -> set(objectid)
+
+        Clauses:
+          - self line
+          - objects connected to parent line endpoints
+        """
+        illegal: dict[int, dict[str, set[int]]] = {}
+
+        self._illegal_self_line(
+            illegal=illegal,
+            parent_ids=set(dangle_parent.values()),
+        )
+        self._illegal_connected_features(
+            illegal=illegal,
+            target_layers=target_layers,
+        )
+
+        return illegal
+
+    def _illegal_self_line(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        parent_ids: set[int],
+    ) -> None:
+        lines_key = self._dataset_key(self.lines_copy)
+        for pid in parent_ids:
+            illegal.setdefault(int(pid), {}).setdefault(lines_key, set()).add(int(pid))
+
+    def _illegal_connected_features(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        target_layers: list[str],
+    ) -> None:
+        """
+        Endpoint connectivity:
+          - create BOTH_ENDS points for lines_copy (each carries ORIGINAL_ID)
+          - near-table with radius 0 against the target layers
+          - anything at distance 0 is connected -> illegal
+        """
+        arcpy.management.FeatureVerticesToPoints(
+            self.lines_copy, self.conn_endpoints, "BOTH_ENDS"
+        )
+
+        endpoint_oid = arcpy.Describe(self.conn_endpoints).OIDFieldName
+        endpoint_parent: dict[int, int] = {}
+        with arcpy.da.SearchCursor(
+            self.conn_endpoints, [endpoint_oid, self.ORIGINAL_ID]
+        ) as cur:
+            for eo, pid in cur:
+                endpoint_parent[int(eo)] = int(pid)
+
+        arcpy.analysis.GenerateNearTable(
+            in_features=self.conn_endpoints,
             near_features=target_layers,
-            search_radius=self._tolerance_linear_unit(),
-            location="LOCATION",
+            out_table=self.conn_table,
+            search_radius="0 Meters",
+            location="NO_LOCATION",
             angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=100,
             method="PLANAR",
         )
 
-    def _build_plan(self) -> dict[int, dict]:
-        """
-        What:
-            Builds a dict keyed by ORIGINAL_ID with everything needed to update line endpoints.
-
-        Note:
-            Under current assumptions, each line produces max one dangle.
-            Edge cases (two dangles per line) handled later.
-        """
-        plan: dict[int, dict] = {}
-
-        fields = [
-            self.ORIGINAL_ID,
-            "SHAPE@XY",
-            "NEAR_FID",
-            "NEAR_X",
-            "NEAR_Y",
-        ]
-
-        with arcpy.da.SearchCursor(
-            in_table=self.filtered_dangles,
-            field_names=fields,
-        ) as cursor:
-            for original_id, (dx, dy), near_fid, near_x, near_y in cursor:
-                if near_fid is None:
+        fields = [self.F_IN_FID, self.F_NEAR_FID, self.F_NEAR_FC, self.F_NEAR_DIST]
+        with arcpy.da.SearchCursor(self.conn_table, fields) as cur:
+            for in_fid, near_fid, near_fc, near_dist in cur:
+                if near_fid is None or near_dist is None:
+                    continue
+                if float(near_dist) != 0.0:
                     continue
 
-                plan[int(original_id)] = {
-                    "processed": False,
-                    "dangle_x": float(dx),
-                    "dangle_y": float(dy),
-                    "near_x": float(near_x),
-                    "near_y": float(near_y),
+                pid = endpoint_parent.get(int(in_fid))
+                if pid is None:
+                    continue
+
+                ds_key = self._dataset_key(near_fc)
+                illegal.setdefault(int(pid), {}).setdefault(ds_key, set()).add(
+                    int(near_fid)
+                )
+
+    def _is_illegal(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        parent_id: int,
+        target_fc_key: str,
+        target_oid: int,
+    ) -> bool:
+        ds = illegal.get(int(parent_id))
+        if not ds:
+            return False
+        return int(target_oid) in ds.get(str(target_fc_key), set())
+
+    def _parents_share_illegal_target(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        a_parent: int,
+        b_parent: int,
+    ) -> bool:
+        """
+        Your constraint: dangle-pairs must not share an illegal target object.
+
+        Interpreted as:
+          there exists any (dataset_key, oid) that is illegal for both parents.
+        """
+        a = illegal.get(int(a_parent), {})
+        b = illegal.get(int(b_parent), {})
+        if not a or not b:
+            return False
+
+        for ds_key, a_set in a.items():
+            b_set = b.get(ds_key)
+            if not b_set:
+                continue
+            if a_set.intersection(b_set):
+                return True
+        return False
+
+    def _find_specific_line_candidate(
+        self,
+        *,
+        candidates_sorted: list[dict],
+        lines_fc_key: str,
+        other_parent_id: int,
+        base_tol: float,
+    ) -> Optional[dict]:
+        """
+        Find the row that explicitly targets the other *parent line* (lines_copy),
+        within base_tol.
+        """
+        for cand in candidates_sorted:
+            if cand["near_fc_key"] != lines_fc_key:
+                continue
+            if int(cand["near_fid"]) != int(other_parent_id):
+                continue
+            if float(cand["near_dist"]) <= float(base_tol):
+                return cand
+        return None
+
+    # ----------------------------
+    # Near table reading
+    # ----------------------------
+
+    def _generate_near_table(
+        self,
+        *,
+        in_dangles: str,
+        near_features: list[str],
+        search_radius: str,
+        out_table: str,
+    ) -> None:
+        arcpy.analysis.GenerateNearTable(
+            in_features=in_dangles,
+            near_features=near_features,
+            out_table=out_table,
+            search_radius=search_radius,
+            location="LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=100,
+            method="PLANAR",
+        )
+
+    def _read_near_table_grouped(
+        self,
+        *,
+        near_table: str,
+        dangles_fc_key: str,
+    ) -> dict[int, list[dict]]:
+        """
+        grouped[in_dangle_oid] = list of candidates sorted later by dist.
+        """
+        grouped: dict[int, list[dict]] = {}
+
+        fields = [
+            self.F_IN_FID,
+            self.F_NEAR_FID,
+            self.F_NEAR_FC,
+            self.F_NEAR_DIST,
+            self.F_NEAR_X,
+            self.F_NEAR_Y,
+        ]
+
+        with arcpy.da.SearchCursor(near_table, fields) as cur:
+            for in_fid, near_fid, near_fc, near_dist, near_x, near_y in cur:
+                if near_fid is None or near_dist is None:
+                    continue
+
+                in_id = int(in_fid)
+                nf_id = int(near_fid)
+                dist = float(near_dist)
+
+                near_fc_key = self._dataset_key(near_fc)
+
+                # Defensive guard against self-dangle returning as candidate
+                if near_fc_key == dangles_fc_key and nf_id == in_id:
+                    continue
+
+                grouped.setdefault(in_id, []).append(
+                    {
+                        "near_fc_key": near_fc_key,
+                        "near_fid": nf_id,
+                        "near_dist": dist,
+                        "near_x": float(near_x),
+                        "near_y": float(near_y),
+                    }
+                )
+
+        return grouped
+
+    # ----------------------------
+    # Planning: choose closest legal + detect pairs
+    # ----------------------------
+
+    def _candidate_is_legal(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        dangle_parent: dict[int, int],
+        dangles_fc_key: str,
+        lines_fc_key: str,
+        parent_id: int,
+        cand: dict,
+        base_tol: float,
+        dangle_tol: float,
+    ) -> bool:
+        ds_key = cand["near_fc_key"]
+        oid = int(cand["near_fid"])
+        dist = float(cand["near_dist"])
+
+        if ds_key == dangles_fc_key:
+            if dist > dangle_tol:
+                return False
+
+            # legality of snapping to a dangle is assessed via its parent line
+            other_parent = dangle_parent.get(oid)
+            if other_parent is None:
+                return False
+
+            # treat as snapping to that parent line for illegal checks
+            if self._is_illegal(
+                illegal=illegal,
+                parent_id=parent_id,
+                target_fc_key=lines_fc_key,
+                target_oid=int(other_parent),
+            ):
+                return False
+
+            return True
+
+        # non-dangle
+        if dist > base_tol:
+            return False
+
+        if self._is_illegal(
+            illegal=illegal,
+            parent_id=parent_id,
+            target_fc_key=ds_key,
+            target_oid=oid,
+        ):
+            return False
+
+        return True
+
+    def _pair_token_from_candidate(
+        self,
+        *,
+        dangle_parent: dict[int, int],
+        dangles_fc_key: str,
+        lines_fc_key: str,
+        cand: dict,
+    ) -> Optional[int]:
+        """
+        Returns the *other parent line id* if this candidate represents “the other side”
+        of a potential dangle pair (either via dangle feature or via line feature).
+        """
+        ds_key = cand["near_fc_key"]
+        oid = int(cand["near_fid"])
+
+        if ds_key == dangles_fc_key:
+            other_parent = dangle_parent.get(oid)
+            return int(other_parent) if other_parent is not None else None
+
+        if ds_key == lines_fc_key:
+            return int(oid)
+
+        return None
+
+    def _select_first_legal_candidate(
+        self,
+        *,
+        candidates_sorted: list[dict],
+        illegal: dict[int, dict[str, set[int]]],
+        dangle_parent: dict[int, int],
+        dangles_fc_key: str,
+        lines_fc_key: str,
+        parent_id: int,
+        base_tol: float,
+        dangle_tol: float,
+    ) -> Optional[dict]:
+        for cand in candidates_sorted:
+            if self._candidate_is_legal(
+                illegal=illegal,
+                dangle_parent=dangle_parent,
+                dangles_fc_key=dangles_fc_key,
+                lines_fc_key=lines_fc_key,
+                parent_id=parent_id,
+                cand=cand,
+                base_tol=base_tol,
+                dangle_tol=dangle_tol,
+            ):
+                return cand
+        return None
+
+    def _find_specific_dangle_candidate(
+        self,
+        *,
+        candidates_sorted: list[dict],
+        dangles_fc_key: str,
+        other_dangle_oid: int,
+        dangle_tol: float,
+    ) -> Optional[dict]:
+        """
+        Find the row that explicitly targets the other *dangle* (not its line),
+        within dangle_tol (custom dangle tolerance).
+        """
+        for cand in candidates_sorted:
+            if cand["near_fc_key"] != dangles_fc_key:
+                continue
+            if int(cand["near_fid"]) != int(other_dangle_oid):
+                continue
+            if float(cand["near_dist"]) <= float(dangle_tol):
+                return cand
+        return None
+
+    # ----------------------------
+    # Build plan (two-phase: detect pairs first, then decide moves)
+    # ----------------------------
+
+    def _build_plan(
+        self, *, dangles_fc: str, target_layers: list[str]
+    ) -> dict[int, dict]:
+        dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
+        dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
+
+        illegal = self.detect_illegal_targets(
+            dangle_parent=dangle_parent,
+            target_layers=target_layers,
+        )
+
+        dangles_key = self._dataset_key(self.dangles)
+        lines_key = self._dataset_key(self.lines_copy)
+
+        base_tol = float(self.gap_tolerance_meters)
+        dangle_tol = float(self._expanded_dangle_tolerance_meters())
+
+        # One near-table for everything (expanded radius so we can see dangle pairs)
+        near_features = list(target_layers) + [self.dangles]
+        self._generate_near_table(
+            in_dangles=dangles_fc,
+            near_features=near_features,
+            search_radius=self._expanded_dangle_tolerance_linear_unit(),
+            out_table=self.near_table,
+        )
+
+        grouped = self._read_near_table_grouped(
+            near_table=self.near_table,
+            dangles_fc_key=dangles_key,
+        )
+        if not grouped:
+            return {}
+
+        # ----------------------------
+        # Phase 1: per dangle -> first legal + pair token
+        # ----------------------------
+        per_dangle: dict[int, dict] = {}
+        for dangle_oid, candidates in grouped.items():
+            parent_id = dangle_parent.get(int(dangle_oid))
+            if parent_id is None:
+                continue
+
+            rows = sorted(candidates, key=lambda r: r["near_dist"])
+            first_legal = self._select_first_legal_candidate(
+                candidates_sorted=rows,
+                illegal=illegal,
+                dangle_parent=dangle_parent,
+                dangles_fc_key=dangles_key,
+                lines_fc_key=lines_key,
+                parent_id=int(parent_id),
+                base_tol=base_tol,
+                dangle_tol=dangle_tol,
+            )
+            if first_legal is None:
+                continue
+
+            token = self._pair_token_from_candidate(
+                dangle_parent=dangle_parent,
+                dangles_fc_key=dangles_key,
+                lines_fc_key=lines_key,
+                cand=first_legal,
+            )
+
+            per_dangle[int(dangle_oid)] = {
+                "parent_id": int(parent_id),
+                "rows": rows,
+                "first_legal": first_legal,
+                "pair_token_parent": token,  # other parent id if pair-like
+            }
+
+        if not per_dangle:
+            return {}
+
+        # Helper: parent -> dangle oid (assumes one dangle per line; if not, last wins)
+        parent_to_dangle: dict[int, int] = {}
+        for d_oid, info in per_dangle.items():
+            parent_to_dangle[int(info["parent_id"])] = int(d_oid)
+
+        # ----------------------------
+        # Phase 2: decide moves with pair logic + defer logic
+        # ----------------------------
+        decided_by_parent: dict[int, dict] = {}
+        deferred_by_parent: dict[int, dict] = {}
+        visited_pairs: set[tuple[int, int]] = set()
+
+        for d_oid, info in per_dangle.items():
+            a_parent = int(info["parent_id"])
+            if a_parent in decided_by_parent or a_parent in deferred_by_parent:
+                continue
+
+            token_parent = info["pair_token_parent"]
+            if token_parent is None:
+                chosen = info["first_legal"]
+                dx, dy = dangle_xy[int(d_oid)]
+                decided_by_parent[a_parent] = self._make_plan_entry(
+                    parent_id=a_parent,
+                    dangle_oid=int(d_oid),
+                    dangle_x=dx,
+                    dangle_y=dy,
+                    chosen=chosen,
+                    gap_source=self.GAP_SOURCE_DEFAULT,
+                )
+                continue
+
+            b_parent = int(token_parent)
+            if b_parent == a_parent:
+                chosen = info["first_legal"]
+                dx, dy = dangle_xy[int(d_oid)]
+                decided_by_parent[a_parent] = self._make_plan_entry(
+                    parent_id=a_parent,
+                    dangle_oid=int(d_oid),
+                    dangle_x=dx,
+                    dangle_y=dy,
+                    chosen=chosen,
+                    gap_source=self.GAP_SOURCE_DEFAULT,
+                )
+                continue
+
+            # If the other parent doesn't have a dangle in this run, treat as normal
+            b_dangle = parent_to_dangle.get(b_parent)
+            if b_dangle is None:
+                chosen = info["first_legal"]
+                dx, dy = dangle_xy[int(d_oid)]
+                decided_by_parent[a_parent] = self._make_plan_entry(
+                    parent_id=a_parent,
+                    dangle_oid=int(d_oid),
+                    dangle_x=dx,
+                    dangle_y=dy,
+                    chosen=chosen,
+                    gap_source=self.GAP_SOURCE_DEFAULT,
+                )
+                continue
+
+            # Determine if mutual pair: B's closest legal token points back to A
+            b_info = per_dangle.get(int(b_dangle))
+            if not b_info or int(b_info.get("pair_token_parent") or -1) != int(
+                a_parent
+            ):
+                deferred_by_parent[a_parent] = {
+                    "parent_id": a_parent,
+                    "dangle_oid": int(d_oid),
+                    "forced_target_parent": int(b_parent),
                 }
+                continue
+
+            # Mutual pair
+            pair_key = tuple(sorted((a_parent, b_parent)))
+            if pair_key in visited_pairs:
+                continue
+            visited_pairs.add(pair_key)
+
+            # Pair constraint: they must not share an illegal target object
+            if self._parents_share_illegal_target(
+                illegal=illegal,
+                a_parent=a_parent,
+                b_parent=b_parent,
+            ):
+                # Fall back to normal for each (still mark as pair for symmetric skip)
+                for parent, dangle in [
+                    (a_parent, int(d_oid)),
+                    (b_parent, int(b_dangle)),
+                ]:
+                    ii = per_dangle[dangle]
+                    chosen = ii["first_legal"]
+                    dx, dy = dangle_xy[int(dangle)]
+                    decided_by_parent[parent] = self._make_plan_entry(
+                        parent_id=parent,
+                        dangle_oid=int(dangle),
+                        dangle_x=dx,
+                        dangle_y=dy,
+                        chosen=chosen,
+                        gap_source=self.GAP_SOURCE_DEFAULT,
+                    )
+                decided_by_parent[a_parent]["pair_parent"] = b_parent
+                decided_by_parent[b_parent]["pair_parent"] = a_parent
+                continue
+
+            # ----------------------------
+            # Pair preference:
+            # - We can snap to each other's DANGLE within dangle_tol
+            # - BUT the parent lines must be within base_tol (and legal)
+            # ----------------------------
+
+            # (1) Explicit dangle->dangle rows (within custom dangle tolerance)
+            a_to_b_dangle = self._find_specific_dangle_candidate(
+                candidates_sorted=info["rows"],
+                dangles_fc_key=dangles_key,
+                other_dangle_oid=int(b_dangle),
+                dangle_tol=float(dangle_tol),
+            )
+            b_to_a_dangle = self._find_specific_dangle_candidate(
+                candidates_sorted=b_info["rows"],
+                dangles_fc_key=dangles_key,
+                other_dangle_oid=int(d_oid),
+                dangle_tol=float(dangle_tol),
+            )
+
+            # (2) Explicit parent-line proximity rows (must be within base tolerance)
+            a_to_b_line = self._find_specific_line_candidate(
+                candidates_sorted=info["rows"],
+                lines_fc_key=lines_key,
+                other_parent_id=int(b_parent),
+                base_tol=float(base_tol),
+            )
+            b_to_a_line = self._find_specific_line_candidate(
+                candidates_sorted=b_info["rows"],
+                lines_fc_key=lines_key,
+                other_parent_id=int(a_parent),
+                base_tol=float(base_tol),
+            )
+
+            # (3) Enforce legality for those line candidates too (connected/illegal rules)
+            if a_to_b_line is not None and not self._candidate_is_legal(
+                illegal=illegal,
+                dangle_parent=dangle_parent,
+                dangles_fc_key=dangles_key,
+                lines_fc_key=lines_key,
+                parent_id=int(a_parent),
+                cand=a_to_b_line,
+                base_tol=float(base_tol),
+                dangle_tol=float(dangle_tol),
+            ):
+                a_to_b_line = None
+
+            if b_to_a_line is not None and not self._candidate_is_legal(
+                illegal=illegal,
+                dangle_parent=dangle_parent,
+                dangles_fc_key=dangles_key,
+                lines_fc_key=lines_key,
+                parent_id=int(b_parent),
+                cand=b_to_a_line,
+                base_tol=float(base_tol),
+                dangle_tol=float(dangle_tol),
+            ):
+                b_to_a_line = None
+
+            # Decide chosen targets for each parent
+            if (
+                a_to_b_dangle is not None
+                and b_to_a_dangle is not None
+                and a_to_b_line is not None
+                and b_to_a_line is not None
+            ):
+                # Both can snap to each other’s dangle within custom tolerance,
+                # AND their parent lines are within base tolerance (and legal)
+                a_chosen = a_to_b_dangle
+                b_chosen = b_to_a_dangle
+                a_source = self.GAP_SOURCE_PAIR_DANGLE
+                b_source = self.GAP_SOURCE_PAIR_DANGLE
+            else:
+                # Pair exists but dangle snap not allowed by constraints
+                a_chosen = info["first_legal"]
+                b_chosen = b_info["first_legal"]
+                a_source = self.GAP_SOURCE_PAIR_LINE
+                b_source = self.GAP_SOURCE_PAIR_LINE
+
+            # Write entries (still need symmetric skip: only one moves)
+            for parent, dangle, chosen, source in [
+                (a_parent, int(d_oid), a_chosen, a_source),
+                (b_parent, int(b_dangle), b_chosen, b_source),
+            ]:
+                dx, dy = dangle_xy[int(dangle)]
+                decided_by_parent[int(parent)] = self._make_plan_entry(
+                    parent_id=int(parent),
+                    dangle_oid=int(dangle),
+                    dangle_x=dx,
+                    dangle_y=dy,
+                    chosen=chosen,
+                    gap_source=str(source),
+                )
+
+            decided_by_parent[a_parent]["pair_parent"] = b_parent
+            decided_by_parent[b_parent]["pair_parent"] = a_parent
+
+        # Apply symmetric skip on mutual pairs (only one moves)
+        self._apply_pair_symmetric_skip(decided_by_parent)
+
+        plan = {
+            pid: entry
+            for pid, entry in decided_by_parent.items()
+            if not entry.get("skip", False)
+        }
+
+        # Defer phase (one-sided “closest to a dangle-pair object”)
+        if deferred_by_parent:
+            self._resolve_deferred_moves(
+                plan=plan,
+                deferred=deferred_by_parent,
+            )
 
         return plan
 
-    def _apply_symmetric_pair_skip(self, plan: dict[int, dict]) -> None:
-        """
-        What:
-            Avoids processing a mutual dangle↔dangle pair twice.
+    def _make_plan_entry(
+        self,
+        *,
+        parent_id: int,
+        dangle_oid: int,
+        dangle_x: float,
+        dangle_y: float,
+        chosen: dict,
+        gap_source: str,
+    ) -> dict:
+        return {
+            "processed": False,
+            "skip": False,
+            "gap_source": str(gap_source),
+            "dangle_oid": int(dangle_oid),
+            "dangle_x": float(dangle_x),
+            "dangle_y": float(dangle_y),
+            "near_x": float(chosen["near_x"]),
+            "near_y": float(chosen["near_y"]),
+            "chosen_near_fc_key": str(chosen["near_fc_key"]),
+            "chosen_near_fid": int(chosen["near_fid"]),
+        }
 
-        How:
-            - Only possible/meaningful when dangles are included as near_features.
-            - In this implementation, Near is run against target layers, and may include dangles
-              only if you later decide to add them as a target. Kept here to support your stated intent.
+    def _apply_pair_symmetric_skip(self, decided_by_parent: dict[int, dict]) -> None:
         """
-        _ = plan
+        If A and B are marked as pair parents, move only one of them.
+        Keep the smaller parent id by default.
+        """
+        for a_parent, entry in list(decided_by_parent.items()):
+            b_parent = entry.get("pair_parent")
+            if b_parent is None:
+                continue
+            b_parent = int(b_parent)
+
+            other = decided_by_parent.get(b_parent)
+            if not other:
+                continue
+            if int(other.get("pair_parent") or -1) != int(a_parent):
+                continue
+
+            keep = min(int(a_parent), int(b_parent))
+            drop = max(int(a_parent), int(b_parent))
+
+            decided_by_parent[drop]["skip"] = True
+            decided_by_parent[keep]["skip"] = False
+
+    # ----------------------------
+    # Deferred handling
+    # ----------------------------
+
+    def _resolve_deferred_moves(
+        self,
+        *,
+        plan: dict[int, dict],
+        deferred: dict[int, dict],
+    ) -> None:
+        """
+        Your requirement (simplified, but aligned):
+          - If A “wanted” B as closest but B didn’t want A, A waits.
+          - After other edits, run another near table that finds snap point on B’s line,
+            accepting a much larger tolerance.
+          - Then add A to the plan pointing to the forced target line geometry.
+
+        Implementation:
+          - We force near_features = [lines_copy]
+          - We run GenerateNearTable from the deferred dangles to lines_copy with large radius
+          - For each deferred parent A, we select the row with NEAR_FID == forced_target_parent (B)
+        """
+        # Build a feature layer of deferred dangles (by OBJECTID)
+        dangles_oid = arcpy.Describe(self.filtered_dangles).OIDFieldName
+        ids = [str(int(v["dangle_oid"])) for v in deferred.values()]
+        if not ids:
+            return
+
+        where = f"{arcpy.AddFieldDelimiters(self.filtered_dangles, dangles_oid)} IN ({','.join(ids)})"
+        deferred_lyr = "deferred_dangles_lyr"
+        arcpy.management.MakeFeatureLayer(self.filtered_dangles, deferred_lyr, where)
+
+        # Large tolerance: choose something intentionally generous but bounded.
+        # If you want this configurable later, put it in AdvancedConfig.
+        large_m = max(50, int(self.gap_tolerance_meters) * 10)
+        large_tol = f"{int(large_m)} Meters"
+
+        forced_table = self.wfm.build_file_path(file_name="deferred_forced_table")
+        arcpy.analysis.GenerateNearTable(
+            in_features=deferred_lyr,
+            near_features=[self.lines_copy],
+            out_table=forced_table,
+            search_radius=large_tol,
+            location="LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=100,
+            method="PLANAR",
+        )
+
+        lines_key = self._dataset_key(self.lines_copy)
+
+        # Map in_dangle_oid -> list of (near_fid, near_x, near_y, dist)
+        grouped: dict[int, list[tuple[int, float, float, float]]] = {}
+        fields = [
+            self.F_IN_FID,
+            self.F_NEAR_FID,
+            self.F_NEAR_DIST,
+            self.F_NEAR_X,
+            self.F_NEAR_Y,
+        ]
+        with arcpy.da.SearchCursor(forced_table, fields) as cur:
+            for in_fid, near_fid, near_dist, near_x, near_y in cur:
+                if near_fid is None or near_dist is None:
+                    continue
+                grouped.setdefault(int(in_fid), []).append(
+                    (int(near_fid), float(near_x), float(near_y), float(near_dist))
+                )
+
+        if not grouped:
+            return
+
+        # For each deferred parent, locate the row for its forced target parent line id
+        for a_parent, info in deferred.items():
+            a_parent = int(a_parent)
+            if a_parent in plan:
+                continue  # already moved via other logic
+
+            dangle_oid_val = int(info["dangle_oid"])
+            forced_parent = int(info["forced_target_parent"])
+
+            rows = grouped.get(dangle_oid_val, [])
+            chosen_row = None
+            for near_fid, near_x, near_y, dist in rows:
+                if int(near_fid) == int(forced_parent):
+                    chosen_row = (near_x, near_y)
+                    break
+
+            if chosen_row is None:
+                continue
+
+            # Need dangle XY from current dangle feature (it might be unchanged, but safer)
+            xy_lookup = self._build_dangle_xy_lookup(self.filtered_dangles)
+            dangle_x, dangle_y = xy_lookup.get(dangle_oid_val, (None, None))
+            if dangle_x is None:
+                continue
+
+            plan[a_parent] = {
+                "processed": False,
+                "skip": False,
+                "gap_source": self.GAP_SOURCE_DEFERRED,
+                "dangle_oid": dangle_oid_val,
+                "dangle_x": float(dangle_x),
+                "dangle_y": float(dangle_y),
+                "near_x": float(chosen_row[0]),
+                "near_y": float(chosen_row[1]),
+                "chosen_near_fc_key": lines_key,
+                "chosen_near_fid": forced_parent,
+            }
+
+    # ----------------------------
+    # Change output + edits (unchanged from your current version except gap_source field)
+    # ----------------------------
 
     def _setup_line_changes_output(self) -> None:
-        """
-        What:
-            Ensures line_changes_output exists (if configured) and has required fields.
-
-        Why:
-            Avoids insert operations while an UpdateCursor transaction is active.
-        """
         if self.line_changes_output is None:
             return
 
@@ -308,22 +1049,19 @@ class FillLineGaps:
             new_feature=self.line_changes_output,
         )
 
-        existing_fields = {
-            field.name for field in arcpy.ListFields(dataset=self.line_changes_output)
-        }
+        existing = {f.name for f in arcpy.ListFields(self.line_changes_output)}
 
-        if self.ORIGINAL_ID not in existing_fields:
+        if self.ORIGINAL_ID not in existing:
             arcpy.management.AddField(
-                in_table=self.line_changes_output,
-                field_name=self.ORIGINAL_ID,
-                field_type="LONG",
+                self.line_changes_output, self.ORIGINAL_ID, "LONG"
             )
-
-        if "gap_dist_m" not in existing_fields:
+        if self.FIELD_GAP_DIST_M not in existing:
             arcpy.management.AddField(
-                in_table=self.line_changes_output,
-                field_name="gap_dist_m",
-                field_type="DOUBLE",
+                self.line_changes_output, self.FIELD_GAP_DIST_M, "DOUBLE"
+            )
+        if self.FIELD_GAP_SOURCE not in existing:
+            arcpy.management.AddField(
+                self.line_changes_output, self.FIELD_GAP_SOURCE, "TEXT", field_length=20
             )
 
     def _build_change_row(
@@ -334,39 +1072,23 @@ class FillLineGaps:
         near_x: float,
         near_y: float,
         spatial_reference,
+        gap_source: str,
     ):
-        """
-        What:
-            Builds a single insert row tuple for the change output, or returns None if no change.
-        """
         dist = ((dangle_x - near_x) ** 2 + (dangle_y - near_y) ** 2) ** 0.5
         if dist == 0.0:
             return None
 
         arr = arcpy.Array(
-            [arcpy.Point(X=dangle_x, Y=dangle_y), arcpy.Point(X=near_x, Y=near_y)]
+            [arcpy.Point(dangle_x, dangle_y), arcpy.Point(near_x, near_y)]
         )
-        geom = arcpy.Polyline(
-            inputs=arr,
-            spatial_reference=spatial_reference,
-        )
-
-        return (geom, int(original_id), float(dist))
+        geom = arcpy.Polyline(arr, spatial_reference)
+        return (geom, int(original_id), float(dist), str(gap_source))
 
     def _move_endpoint(
         self, shape, dangle_x: float, dangle_y: float, near_x: float, near_y: float
     ):
-        """
-        What:
-            Moves the endpoint vertex that corresponds to the dangle point to NEAR_X/NEAR_Y.
-
-        Assumptions:
-            - No multipart polylines in input.
-            - Dangle point equals one endpoint (within a small tolerance).
-        """
         if shape is None:
             return shape
-
         part = shape.getPart(0)
         points = [pt for pt in part]
         if len(points) < 2:
@@ -380,31 +1102,20 @@ class FillLineGaps:
         def matches(point, x: float, y: float) -> bool:
             return abs(point.X - x) <= tol and abs(point.Y - y) <= tol
 
-        if matches(point=first, x=dangle_x, y=dangle_y):
-            points[0] = arcpy.Point(X=near_x, Y=near_y)
-        elif matches(point=last, x=dangle_x, y=dangle_y):
-            points[-1] = arcpy.Point(X=near_x, Y=near_y)
+        if matches(first, dangle_x, dangle_y):
+            points[0] = arcpy.Point(near_x, near_y)
+        elif matches(last, dangle_x, dangle_y):
+            points[-1] = arcpy.Point(near_x, near_y)
         else:
-            # Fallback: choose closer endpoint to the dangle XY
             d_first = (first.X - dangle_x) ** 2 + (first.Y - dangle_y) ** 2
             d_last = (last.X - dangle_x) ** 2 + (last.Y - dangle_y) ** 2
-            if d_first <= d_last:
-                points[0] = arcpy.Point(X=near_x, Y=near_y)
-            else:
-                points[-1] = arcpy.Point(X=near_x, Y=near_y)
+            points[0 if d_first <= d_last else -1] = arcpy.Point(near_x, near_y)
 
-        new_array = arcpy.Array(points)
-        return arcpy.Polyline(
-            inputs=new_array,
-            spatial_reference=shape.spatialReference,
-        )
+        return arcpy.Polyline(arcpy.Array(points), shape.spatialReference)
 
     def _apply_edits(self, plan: dict[int, dict]) -> None:
         if not plan:
-            arcpy.management.CopyFeatures(
-                in_features=self.lines_copy,
-                out_feature_class=self.output_lines,
-            )
+            arcpy.management.CopyFeatures(self.lines_copy, self.output_lines)
             return
 
         if self.line_changes_output is not None:
@@ -413,59 +1124,60 @@ class FillLineGaps:
         spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
         change_rows: list[tuple] = []
 
-        fields = [self.ORIGINAL_ID, "SHAPE@"]
-
         with arcpy.da.UpdateCursor(
-            in_table=self.lines_copy,
-            field_names=fields,
-        ) as update_cursor:
-            for original_id, shape in update_cursor:
-                original_id_int = int(original_id)
-                if original_id_int not in plan:
+            self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"]
+        ) as cur:
+            for original_id, shape in cur:
+                pid = int(original_id)
+                info = plan.get(pid)
+                if not info:
                     continue
-
-                info = plan[original_id_int]
-                if info["processed"] is True:
+                if (
+                    info.get("skip", False) is True
+                    or info.get("processed", False) is True
+                ):
                     continue
-
-                dangle_x = float(info["dangle_x"])
-                dangle_y = float(info["dangle_y"])
-                near_x = float(info["near_x"])
-                near_y = float(info["near_y"])
 
                 new_shape = self._move_endpoint(
                     shape=shape,
-                    dangle_x=dangle_x,
-                    dangle_y=dangle_y,
-                    near_x=near_x,
-                    near_y=near_y,
+                    dangle_x=float(info["dangle_x"]),
+                    dangle_y=float(info["dangle_y"]),
+                    near_x=float(info["near_x"]),
+                    near_y=float(info["near_y"]),
                 )
-                update_cursor.updateRow((original_id, new_shape))
+                cur.updateRow((original_id, new_shape))
 
                 if self.line_changes_output is not None:
                     row = self._build_change_row(
-                        original_id=original_id_int,
-                        dangle_x=dangle_x,
-                        dangle_y=dangle_y,
-                        near_x=near_x,
-                        near_y=near_y,
+                        original_id=pid,
+                        dangle_x=float(info["dangle_x"]),
+                        dangle_y=float(info["dangle_y"]),
+                        near_x=float(info["near_x"]),
+                        near_y=float(info["near_y"]),
                         spatial_reference=spatial_reference,
+                        gap_source=str(info.get("gap_source", self.GAP_SOURCE_DEFAULT)),
                     )
                     if row is not None:
                         change_rows.append(row)
 
         if self.line_changes_output is not None and change_rows:
             with arcpy.da.InsertCursor(
-                in_table=self.line_changes_output,
-                field_names=["SHAPE@", self.ORIGINAL_ID, "gap_dist_m"],
-            ) as insert_cursor:
+                self.line_changes_output,
+                [
+                    "SHAPE@",
+                    self.ORIGINAL_ID,
+                    self.FIELD_GAP_DIST_M,
+                    self.FIELD_GAP_SOURCE,
+                ],
+            ) as icur:
                 for row in change_rows:
-                    insert_cursor.insertRow(row)
+                    icur.insertRow(row)
 
-        arcpy.management.CopyFeatures(
-            in_features=self.lines_copy,
-            out_feature_class=self.output_lines,
-        )
+        arcpy.management.CopyFeatures(self.lines_copy, self.output_lines)
+
+    # ----------------------------
+    # Run
+    # ----------------------------
 
     def run(self) -> None:
         environment_setup.main()
@@ -479,15 +1191,14 @@ class FillLineGaps:
         self._add_original_id_field()
         self._create_dangles()
 
-        self._remove_lines_that_produced_dangles()
+        self._build_external_target_layers_once()
+        targets = self._select_targets_within_tolerance_of_dangles()
 
-        target_layers = self._select_targets_within_tolerance_of_dangles()
-        self._filter_dangles_within_tolerance_of_targets(target_layers=target_layers)
+        # Keep only dangles that have any candidate within base tolerance
+        self._filter_true_dangles()
+        dangles_for_plan = self.filtered_dangles
 
-        self._run_near(target_layers=target_layers)
-
-        plan = self._build_plan()
-        self._apply_symmetric_pair_skip(plan=plan)
-        self._apply_edits(plan=plan)
+        plan = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
+        self._apply_edits(plan)
 
         self.wfm.delete_created_files()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -808,20 +808,20 @@ class _GlobalProposal:
 
 
 @dataclass(frozen=True)
-class DeferredCapture:
+class _ResnappedCapture:
     """
-    Original proposal metadata captured when a proposal is marked deferred.
+    Metadata for an accepted connection whose near-point may land on a segment
+    that moves when another accepted SNAP connection applies.
 
-    Carries both the routing information (which dangle, which forced target) and
-    the original _DangleProposal from the main plan phase.  The geometry is
-    resolved later from post-pass-1 line positions, but the metadata here
-    answers *why* the connection was chosen.
+    Identified after Stage B; geometry is re-resolved in _resnap_connections
+    using post-apply lines_copy geometry.
     """
 
     parent_id: int
     dangle_oid: int
-    forced_target_parent: int
-    proposal: "_DangleProposal"
+    forced_target_parent: int   # target_parent_id of the accepted connection
+    proposal: "_GlobalProposal"
+    gap_source: str
 
 
 @dataclass(frozen=True)
@@ -849,8 +849,8 @@ class CandidateDiagnostic:
     Diagnostic record for one candidate connection evaluated during the main planning phase.
 
     One record exists per (dangle, target) pair, excluding the self parent line target.
-    The dataclass is mutable so that deferred-acceptance outcomes can be patched by
-    run() after _build_deferred_plan resolves.
+    The dataclass is mutable so that resnap outcomes can be patched by run()
+    after _resnap_connections resolves.
 
     candidate_status values:
         "illegal"             — failed legality or angle blocking; could not be selected
@@ -865,9 +865,8 @@ class CandidateDiagnostic:
                               blocked_by_angle | expanded_dangle_angle_disallowed |
                               blocked_by_z_drop
         legal_not_selected:   outscored_within_dangle
-        selected_for_dangle:  deferred | lost_pair_competition | lost_cycle_prevention |
-                              deferred_rejected_connectivity
-        applied_to_output:    applied_main | applied_deferred
+        selected_for_dangle:  lost_pair_competition | lost_cycle_prevention
+        applied_to_output:    applied_main | applied_resnapped
     """
 
     parent_id: int
@@ -904,7 +903,6 @@ class FillLineGaps:
     GAP_SOURCE_DEFAULT = "default"
     GAP_SOURCE_PAIR_DANGLE = "pair_dangle"
     GAP_SOURCE_PAIR_LINE = "pair_line"
-    GAP_SOURCE_DEFERRED = "deferred"
 
     # Near table fields
     F_IN_FID = "IN_FID"
@@ -2603,7 +2601,7 @@ class FillLineGaps:
 
     def _build_plan(
         self, *, dangles_fc: str, target_layers: list[str]
-    ) -> tuple[dict[int, list[dict]], dict[int, dict], list[CandidateDiagnostic]]:
+    ) -> tuple[dict[int, list[dict]], list[_ResnappedCapture], list[CandidateDiagnostic]]:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
@@ -2683,7 +2681,6 @@ class FillLineGaps:
         # Pipeline stage fate sets — populated as _build_plan progresses;
         # _assemble_diagnostics captures them by reference so early-return calls
         # always see whatever has been filled in at that point.
-        deferred_dangles: set[int] = set()         # dangle_oids routed to deferred pass
         stage_a_loser_oids: set[int] = set()       # local winners that lost Stage-A pair competition
         stage_b_rejected_oids: set[int] = set()    # Stage-A winners dropped by Kruskal
         accepted_dangle_oids: set[int] = set()     # proposals that made it into the main plan
@@ -2808,12 +2805,6 @@ class FillLineGaps:
                     final_gs: Optional[str] = None
                     net_nz: Optional[float] = None
                     glob_nz: Optional[float] = None
-                elif int(d_oid) in deferred_dangles:
-                    status = "selected_for_dangle"
-                    reason = "deferred"
-                    final_gs = None
-                    net_nz = None
-                    glob_nz = None
                 elif int(d_oid) in stage_a_loser_oids:
                     status = "selected_for_dangle"
                     reason = "lost_pair_competition"
@@ -3334,62 +3325,16 @@ class FillLineGaps:
             dangle_norm_z_by_dangle[dangle_oid] = winner_norm_z
 
         if not _dangle_proposals:
-            return {}, {}, _assemble_diagnostics()
+            return {}, [], _assemble_diagnostics()
 
         # ----------------------------
         # Mutual detection (for labeling)
         # - dangle mutual pairs: D1 targets D2 AND D2 targets D1 (both dangle targets)
         # - network mutual: any proposal exists in both directions between the two network nodes
         # ----------------------------
-        parents_with_dangles = sorted(set(dangle_parent.values()))
-        parents_with_dangles_set = {int(v) for v in parents_with_dangles}
-
-        outgoing_parent_targets: dict[int, set[int]] = {}
-        for p in _dangle_proposals.values():
-            if p.ctx.target_parent_id is None:
-                continue
-            outgoing_parent_targets.setdefault(int(p.ctx.src_parent_id), set()).add(
-                int(p.ctx.target_parent_id)
-            )
-
-        deferred_by_parent: dict[int, DeferredCapture] = {}
-        deferred_sort_key_by_parent: dict[int, tuple] = {}
-
-        for p in _dangle_proposals.values():
-            b_parent = p.ctx.target_parent_id
-            if b_parent is None:
-                continue
-            b_parent = int(b_parent)
-
-            # Only defer when the target parent has dangles in this run
-            if b_parent not in parents_with_dangles_set:
-                continue
-
-            # No reciprocal proposal from B -> A (parent-id space)
-            b_out = outgoing_parent_targets.get(b_parent, set())
-            if int(p.ctx.src_parent_id) in b_out:
-                continue
-
-            # Keep only one deferred per parent (deterministic: best sort key)
-            cur_best = deferred_sort_key_by_parent.get(int(p.ctx.src_parent_id))
-            if cur_best is None or p.sort_key() < cur_best:
-                deferred_by_parent[int(p.ctx.src_parent_id)] = DeferredCapture(
-                    parent_id=int(p.ctx.src_parent_id),
-                    dangle_oid=int(p.ctx.dangle_oid),
-                    forced_target_parent=int(b_parent),
-                    proposal=p,
-                )
-                deferred_sort_key_by_parent[int(p.ctx.src_parent_id)] = p.sort_key()
-                deferred_dangles.add(int(p.ctx.dangle_oid))
-
-        # Active proposals exclude deferred dangles (no fallback)
-        active: list[_DangleProposal] = [
-            p
-            for d_oid, p in _dangle_proposals.items()
-            if int(d_oid) not in deferred_dangles
-        ]
+        active: list[_DangleProposal] = list(_dangle_proposals.values())
         if not active:
-            return {}, deferred_by_parent, _assemble_diagnostics()
+            return {}, [], _assemble_diagnostics()
         active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
 
         dangle_mutual_oids: set[int] = set()
@@ -3542,7 +3487,34 @@ class FillLineGaps:
             )
 
         if not _global_proposals:
-            return {}, deferred_by_parent, _assemble_diagnostics()
+            return {}, [], _assemble_diagnostics()
+
+        # ----------------------------
+        # Resnap candidate identification
+        # A connection A→B needs resnap if:
+        #   1. B is the target_parent_id of A's accepted connection
+        #   2. Another accepted connection B→T exists with GAP_SOURCE_PAIR_DANGLE
+        #      (i.e. B's dangle endpoint will move when B snaps to T)
+        #   3. A's near-point lies on B's last segment — checked in _resnap_connections
+        #      using post-apply geometry (this block is a cheap pre-filter only).
+        # ----------------------------
+        snap_source_parents: set[int] = {
+            int(prop.ctx.src_parent_id)
+            for prop, gap_source in _global_proposals
+            if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE
+        }
+        resnap_captures: list[_ResnappedCapture] = []
+        for prop, gap_source in _global_proposals:
+            tp = prop.ctx.target_parent_id
+            if tp is None or int(tp) not in snap_source_parents:
+                continue
+            resnap_captures.append(_ResnappedCapture(
+                parent_id=int(prop.ctx.src_parent_id),
+                dangle_oid=int(prop.ctx.dangle_oid),
+                forced_target_parent=int(tp),
+                proposal=prop,
+                gap_source=str(gap_source),
+            ))
 
         # ----------------------------
         # Build plan_by_parent: parent_id -> list[plan_entry]
@@ -3577,7 +3549,7 @@ class FillLineGaps:
             )
             plan_by_parent[int(pid)] = [entry for _, entry in ordered]
 
-        return plan_by_parent, deferred_by_parent, _assemble_diagnostics()
+        return plan_by_parent, resnap_captures, _assemble_diagnostics()
 
     def _make_plan_entry(
         self,
@@ -3644,140 +3616,109 @@ class FillLineGaps:
             decided_by_parent[keep]["skip"] = False
 
     # ----------------------------
-    # Deferred handling
+    # Resnap pass
     # ----------------------------
 
-    def _rebuild_topology_for_deferred(
-        self, *, captures: "dict[int, DeferredCapture]"
-    ) -> "TopologyModel":
-        """
-        Rebuild topology from the post-pass-1 lines_copy so that deferred
-        connectivity checks reflect the updated network state.
-        """
-        relevant: set[int] = set()
-        for cap in captures.values():
-            relevant.add(int(cap.parent_id))
-            relevant.add(int(cap.forced_target_parent))
-
-        return TopologyBuilder(
-            lines_fc=self.lines_copy,
-            original_id_field=self.ORIGINAL_ID,
-            connect_to_features=self.connect_to_features,
-            dataset_key_fn=self._dataset_key,
-            wfm=self.wfm,
-            write_work_files_to_memory=self.write_work_files_to_memory,
-            connectivity_tolerance_meters=self.connectivity_tolerance_meters,
-            line_connectivity_mode=self.line_connectivity_mode,
-            file_name_prefix="deferred_",
-        ).build(
-            scope=self.connectivity_scope,
-            relevant_parent_ids=relevant,
-        )
-
-    def _accept_deferred_candidates(
+    def _resnap_connections(
         self,
         *,
-        candidates: "list[tuple[DeferredCapture, float, float]]",
-        updated_topology: "TopologyModel",
-    ) -> "list[tuple[DeferredCapture, float, float]]":
-        """
-        Validate and accept deferred candidates against the post-pass-1 topology.
-
-        Per-candidate: reject if src and forced-target are now in the same network.
-        For component scopes: greedy Kruskal acceptance ordered by original
-        proposal.score so the result is deterministic and cycle-free.
-
-        Each entry is (capture, near_x, near_y).
-        """
-        valid = [
-            (cap, nx, ny)
-            for cap, nx, ny in candidates
-            if not self._same_network(
-                a_parent=cap.parent_id,
-                b_parent=cap.forced_target_parent,
-                topology=updated_topology,
-            )
-        ]
-
-        if not valid:
-            return []
-
-        scope = updated_topology.scope
-        if scope not in (
-            logic_config.ConnectivityScope.INPUT_LINES,
-            logic_config.ConnectivityScope.ONE_DEGREE,
-            logic_config.ConnectivityScope.TRANSITIVE,
-        ):
-            # NONE / DIRECT_CONNECTION: per-candidate check is sufficient
-            return valid
-
-        # Component scopes: greedy acceptance to prevent deferred candidates
-        # from creating cycles among themselves, ordered by original score.
-        sorted_valid = sorted(valid, key=lambda t: t[0].proposal.sort_key())
-        uf = _UnionFind()
-        accepted: list[tuple[DeferredCapture, float, float]] = []
-        for cap, nx, ny in sorted_valid:
-            src_node = self._node_for_parent(
-                parent_id=cap.parent_id, topology=updated_topology
-            )
-            tgt_node = self._node_for_parent(
-                parent_id=cap.forced_target_parent, topology=updated_topology
-            )
-            if uf.find(src_node) == uf.find(tgt_node):
-                continue
-            uf.union(src_node, tgt_node)
-            accepted.append((cap, nx, ny))
-
-        return accepted
-
-    def _build_deferred_plan(
-        self,
-        *,
-        deferred: "dict[int, DeferredCapture]",
+        captures: "list[_ResnappedCapture]",
         dangles_fc: str,
+        snap_source_dangle_xy: "dict[int, tuple[float, float]]",
     ) -> dict[int, dict]:
         """
-        Resolve deferred connections in three stages:
-        1. Geometry lookup — find the best near-point on each forced target line,
-           using updated post-pass-1 geometry.
-        2. Connectivity validation — rebuild topology from updated lines_copy and
-           reject any candidate that would now create a forbidden connection.
-        3. Plan entry construction — reuse original proposal/assess metadata so
-           the output correctly reflects why the connection was chosen.
+        Re-resolve the near-point for connections whose target line endpoint moved
+        during _apply_plan (SNAP operations).
+
+        Steps:
+        1. Read the last segment of each target line (B) from post-apply lines_copy.
+           V_prev is the vertex adjacent to B's dangle end; V_end is the original
+           dangle position from snap_source_dangle_xy (before the snap moved it).
+        2. Project A's original near-point onto [V_prev, V_end]. Discard captures
+           whose near-point is not on that segment (unaffected by the snap).
+        3. Run GenerateNearTable on the surviving captures against the updated
+           target lines to get the new near-point.
+        4. Build and return plan entries keyed by parent_id.
         """
-        dangle_oids = sorted({int(cap.dangle_oid) for cap in deferred.values()})
-        if not dangle_oids:
+        # --- 1. Read V_prev for each forced-target line from updated geometry ---
+        forced_target_parents = {int(cap.forced_target_parent) for cap in captures}
+        where_l = (
+            f"{arcpy.AddFieldDelimiters(self.lines_copy, self.ORIGINAL_ID)}"
+            f" IN ({','.join(map(str, sorted(forced_target_parents)))})"
+        )
+        v_prev_by_parent: dict[int, tuple[float, float]] = {}
+        with arcpy.da.SearchCursor(self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"], where_l) as cur:
+            for pid, shape in cur:
+                part = shape.getPart(0)
+                pts = [pt for pt in part if pt is not None]
+                if len(pts) < 2:
+                    continue
+                orig_v_end = snap_source_dangle_xy.get(int(pid))
+                if orig_v_end is None:
+                    continue
+                # Determine which end was the dangle by proximity to the original
+                # dangle position (dangle end has moved; non-dangle end is unchanged).
+                d_first = (pts[0].X - orig_v_end[0]) ** 2 + (pts[0].Y - orig_v_end[1]) ** 2
+                d_last = (pts[-1].X - orig_v_end[0]) ** 2 + (pts[-1].Y - orig_v_end[1]) ** 2
+                if d_first <= d_last:
+                    v_prev_by_parent[int(pid)] = (pts[1].X, pts[1].Y)
+                else:
+                    v_prev_by_parent[int(pid)] = (pts[-2].X, pts[-2].Y)
+
+        # --- 2. Segment projection: keep captures whose near-point is on [V_prev, V_end] ---
+        filtered: list[_ResnappedCapture] = []
+        for cap in captures:
+            tp = int(cap.forced_target_parent)
+            v_prev = v_prev_by_parent.get(tp)
+            v_end = snap_source_dangle_xy.get(tp)
+            if v_prev is None or v_end is None:
+                continue
+            nx = float(cap.proposal.ctx.near_x)
+            ny = float(cap.proposal.ctx.near_y)
+            dx = v_end[0] - v_prev[0]
+            dy = v_end[1] - v_prev[1]
+            seg_len_sq = dx * dx + dy * dy
+            if seg_len_sq == 0.0:
+                continue
+            t = ((nx - v_prev[0]) * dx + (ny - v_prev[1]) * dy) / seg_len_sq
+            if 0.0 <= t <= 1.0:
+                filtered.append(cap)
+
+        if not filtered:
             return {}
 
-        # --- 1a. Feature layers for near-table lookup ---
-        dangles_oid = arcpy.Describe(dangles_fc).OIDFieldName
-        where_d = f"{arcpy.AddFieldDelimiters(dangles_fc, dangles_oid)} IN ({','.join(map(str, dangle_oids))})"
-        deferred_lyr = "deferred_dangles_lyr"
-        arcpy.management.MakeFeatureLayer(dangles_fc, deferred_lyr, where_d)
+        # --- 3. GenerateNearTable against updated target-line geometry ---
+        dangle_oids = sorted({int(cap.dangle_oid) for cap in filtered})
+        forced_parents_filtered = sorted({int(cap.forced_target_parent) for cap in filtered})
 
-        forced_parents = sorted(
-            {int(cap.forced_target_parent) for cap in deferred.values()}
+        dangles_oid_field = arcpy.Describe(dangles_fc).OIDFieldName
+        where_d = (
+            f"{arcpy.AddFieldDelimiters(dangles_fc, dangles_oid_field)}"
+            f" IN ({','.join(map(str, dangle_oids))})"
         )
-        where_l = f"{arcpy.AddFieldDelimiters(self.lines_copy, self.ORIGINAL_ID)} IN ({','.join(map(str, forced_parents))})"
-        forced_lines_lyr = "forced_lines_lyr"
-        arcpy.management.MakeFeatureLayer(self.lines_copy, forced_lines_lyr, where_l)
+        resnap_dangles_lyr = "resnap_dangles_lyr"
+        arcpy.management.MakeFeatureLayer(dangles_fc, resnap_dangles_lyr, where_d)
 
-        lines_oid = arcpy.Describe(forced_lines_lyr).OIDFieldName
+        where_l2 = (
+            f"{arcpy.AddFieldDelimiters(self.lines_copy, self.ORIGINAL_ID)}"
+            f" IN ({','.join(map(str, forced_parents_filtered))})"
+        )
+        resnap_lines_lyr = "resnap_lines_lyr"
+        arcpy.management.MakeFeatureLayer(self.lines_copy, resnap_lines_lyr, where_l2)
+
+        lines_oid_field = arcpy.Describe(resnap_lines_lyr).OIDFieldName
         near_oid_to_parent: dict[int, int] = {}
-        with arcpy.da.SearchCursor(
-            forced_lines_lyr, [lines_oid, self.ORIGINAL_ID]
-        ) as cur:
+        with arcpy.da.SearchCursor(resnap_lines_lyr, [lines_oid_field, self.ORIGINAL_ID]) as cur:
             for oid, pid in cur:
                 near_oid_to_parent[int(oid)] = int(pid)
 
-        # --- 1b. GenerateNearTable against updated forced-target geometry ---
-        large_m = max(50, int(self.gap_tolerance_meters) * 10)
-        forced_table = self.wfm.build_file_path(file_name="deferred_forced_table")
+        search_radius = 2 * self.connectivity_tolerance_meters + self.gap_tolerance_meters
+        resnap_table = self.wfm.build_file_path(file_name="resnap_near_table")
         arcpy.analysis.GenerateNearTable(
-            in_features=deferred_lyr,
-            near_features=[forced_lines_lyr],
-            out_table=forced_table,
-            search_radius=f"{int(large_m)} Meters",
+            in_features=resnap_dangles_lyr,
+            near_features=[resnap_lines_lyr],
+            out_table=resnap_table,
+            search_radius=f"{search_radius} Meters",
             location="LOCATION",
             angle="NO_ANGLE",
             closest="ALL",
@@ -3785,15 +3726,9 @@ class FillLineGaps:
             method="PLANAR",
         )
 
-        best_xy: dict[tuple[int, int], tuple[float, float]] = {}
-        fields = [
-            self.F_IN_FID,
-            self.F_NEAR_FID,
-            self.F_NEAR_DIST,
-            self.F_NEAR_X,
-            self.F_NEAR_Y,
-        ]
-        with arcpy.da.SearchCursor(forced_table, fields) as cur:
+        best_xy: dict[tuple[int, int], tuple[float, float, float]] = {}
+        fields = [self.F_IN_FID, self.F_NEAR_FID, self.F_NEAR_DIST, self.F_NEAR_X, self.F_NEAR_Y]
+        with arcpy.da.SearchCursor(resnap_table, fields) as cur:
             for in_fid, near_fid, near_dist, near_x, near_y in cur:
                 if near_fid is None or near_dist is None:
                     continue
@@ -3801,56 +3736,37 @@ class FillLineGaps:
                 if near_parent is None:
                     continue
                 key = (int(in_fid), int(near_parent))
-                prev_dist = best_xy.get(key, (0.0, 0.0, float("inf")))[2]  # type: ignore[misc]
-                if float(near_dist) < prev_dist:
-                    best_xy[key] = (float(near_x), float(near_y), float(near_dist))  # type: ignore[assignment]
+                prev = best_xy.get(key)
+                if prev is None or float(near_dist) < prev[2]:
+                    best_xy[key] = (float(near_x), float(near_y), float(near_dist))
 
         if not best_xy:
             return {}
 
+        # --- 4. Build updated plan entries ---
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc)
-
-        # --- 1c. Pair each capture with its resolved near-point ---
-        candidates: list[tuple[DeferredCapture, float, float]] = []
-        for cap in deferred.values():
-            hit = best_xy.get((cap.dangle_oid, cap.forced_target_parent))
-            if hit is None:
-                continue
-            if dangle_xy.get(cap.dangle_oid) is None:
-                continue
-            candidates.append((cap, float(hit[0]), float(hit[1])))
-
-        if not candidates:
-            return {}
-
-        # --- 2. Validate against post-pass-1 connectivity ---
-        updated_topology = self._rebuild_topology_for_deferred(captures=deferred)
-        accepted = self._accept_deferred_candidates(
-            candidates=candidates,
-            updated_topology=updated_topology,
-        )
-
-        if not accepted:
-            return {}
-
-        # --- 3. Build plan entries with preserved original metadata ---
         lines_key = self._dataset_key(self.lines_copy)
         out: dict[int, dict] = {}
 
-        for cap, near_x, near_y in accepted:
-            dangle_x, dangle_y = dangle_xy[cap.dangle_oid]
+        for cap in filtered:
+            hit = best_xy.get((cap.dangle_oid, cap.forced_target_parent))
+            if hit is None:
+                continue
+            dangle_coords = dangle_xy.get(cap.dangle_oid)
+            if dangle_coords is None:
+                continue
             out[cap.parent_id] = self._make_plan_entry(
                 parent_id=cap.parent_id,
                 dangle_oid=cap.dangle_oid,
-                dangle_x=float(dangle_x),
-                dangle_y=float(dangle_y),
+                dangle_x=float(dangle_coords[0]),
+                dangle_y=float(dangle_coords[1]),
                 chosen={
-                    "near_x": float(near_x),
-                    "near_y": float(near_y),
+                    "near_x": float(hit[0]),
+                    "near_y": float(hit[1]),
                     "near_fc_key": lines_key,
                     "near_fid": cap.forced_target_parent,
                 },
-                gap_source=self.GAP_SOURCE_DEFERRED,
+                gap_source=cap.gap_source,
                 bonus_applied=cap.proposal.ctx.bonus_applied,
                 assess=cap.proposal.ctx.assess,
                 best_fit_score=cap.proposal.score.composite,
@@ -4216,37 +4132,40 @@ class FillLineGaps:
         if self.candidate_connections_output is not None:
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
-        plan, deferred, diagnostics = self._build_plan(
+        plan, resnap_captures, diagnostics = self._build_plan(
             dangles_fc=dangles_for_plan, target_layers=targets
         )
 
+        # Capture snap-source dangle endpoints before _apply_plan moves them.
+        snap_source_dangle_xy: dict[int, tuple[float, float]] = {
+            parent_id: (float(info["dangle_x"]), float(info["dangle_y"]))
+            for parent_id, entries in plan.items()
+            for info in entries
+            if str(info.get("edit_op")) == EditOp.SNAP.value
+        }
+
         self._apply_plan(plan)
 
-        if deferred:
-            deferred_plan = self._build_deferred_plan(
-                deferred=deferred, dangles_fc=dangles_for_plan
+        if resnap_captures:
+            resnap_plan = self._resnap_connections(
+                captures=resnap_captures,
+                dangles_fc=dangles_for_plan,
+                snap_source_dangle_xy=snap_source_dangle_xy,
             )
-            self._apply_plan(deferred_plan)
+            self._apply_plan(resnap_plan)
 
-            # Patch diagnostic status for deferred candidates now that we know
-            # which ones were accepted vs rejected by _build_deferred_plan.
-            if self.candidate_connections_output is not None and diagnostics:
-                applied_deferred_dangle_oids = {
+            if self.candidate_connections_output is not None and diagnostics and resnap_plan:
+                resnapped_dangle_oids = {
                     int(v["dangle_oid"])
-                    for v in deferred_plan.values()
+                    for v in resnap_plan.values()
                     if isinstance(v, dict) and "dangle_oid" in v
                 }
                 for diag in diagnostics:
                     if (
-                        diag.candidate_status == "selected_for_dangle"
-                        and diag.status_reason == "deferred"
+                        diag.candidate_status == "applied_to_output"
+                        and int(diag.dangle_oid) in resnapped_dangle_oids
                     ):
-                        if int(diag.dangle_oid) in applied_deferred_dangle_oids:
-                            diag.candidate_status = "applied_to_output"
-                            diag.status_reason = "applied_deferred"
-                            diag.final_gap_source = self.GAP_SOURCE_DEFERRED
-                        else:
-                            diag.status_reason = "deferred_rejected_connectivity"
+                        diag.status_reason = "applied_resnapped"
 
         if self.candidate_connections_output is not None and diagnostics:
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1002,10 +1002,19 @@ class FillLineGaps:
         self.gap_tolerance_meters = int(line_gap_config.gap_tolerance_meters)
 
         adv = line_gap_config.advanced_config
-        self.fill_gaps_on_self = bool(adv.fill_gaps_on_self)
-        self.line_changes_output = adv.line_changes_output
-        self.write_output_metadata = bool(adv.write_output_metadata)
-        self.candidate_connections_output = adv.candidate_connections_output
+        out = line_gap_config.output_config
+        ang = line_gap_config.angle_config
+        z = line_gap_config.z_config
+        cross = line_gap_config.crossing_config
+        conn = line_gap_config.connectivity_config
+
+        self.fill_gaps_on_self = bool(line_gap_config.fill_gaps_on_self)
+        self.best_fit_weights = line_gap_config.best_fit_weights
+
+        self.line_changes_output = out.line_changes_output
+        self.write_output_metadata = bool(out.write_output_metadata)
+        self.candidate_connections_output = out.candidate_connections_output
+
         self.increased_tolerance_edge_case_distance_meters = int(
             adv.increased_tolerance_edge_case_distance_meters
         )
@@ -1014,10 +1023,10 @@ class FillLineGaps:
         )
         self.edit_method = logic_config.EditMethod(adv.edit_method)
 
-        self.connectivity_scope = logic_config.ConnectivityScope(adv.connectivity_scope)
-        self.connectivity_tolerance_meters = float(adv.connectivity_tolerance_meters)
+        self.connectivity_scope = logic_config.ConnectivityScope(conn.connectivity_scope)
+        self.connectivity_tolerance_meters = float(conn.connectivity_tolerance_meters)
         self.line_connectivity_mode = logic_config.LineConnectivityMode(
-            adv.line_connectivity_mode
+            conn.line_connectivity_mode
         )
 
         if self.connect_to_features is None and self.fill_gaps_on_self is False:
@@ -1025,25 +1034,21 @@ class FillLineGaps:
                 "Invalid config: fill_gaps_on_self cannot be False when connect_to_features is None."
             )
 
-        # ----------------------------
-        # Source line direction
-        # ----------------------------
-        self.lines_are_directed: bool = bool(adv.lines_are_directed)
+        self.lines_are_directed: bool = bool(ang.lines_are_directed)
+        self.dangle_pair_apply_connector_diff: bool = bool(
+            ang.dangle_pair_apply_connector_diff
+        )
 
-        # ----------------------------
-        # Angle config
-        # ----------------------------
         self.angle_block_threshold_degrees = (
             None
-            if adv.angle_block_threshold_degrees is None
-            else float(adv.angle_block_threshold_degrees)
+            if ang.angle_block_threshold_degrees is None
+            else float(ang.angle_block_threshold_degrees)
         )
         self.angle_extra_dangle_threshold_degrees = (
             None
-            if adv.angle_extra_dangle_threshold_degrees is None
-            else float(adv.angle_extra_dangle_threshold_degrees)
+            if ang.angle_extra_dangle_threshold_degrees is None
+            else float(ang.angle_extra_dangle_threshold_degrees)
         )
-        self.best_fit_weights = adv.best_fit_weights
 
         if self.lines_are_directed and self.best_fit_weights.angle == 0.0:
             raise ValueError(
@@ -1051,38 +1056,27 @@ class FillLineGaps:
                 "directional scoring has no effect when angle weight is zero."
             )
 
-        self.angle_local_half_window_m = float(
-            getattr(adv, "angle_local_half_window_m", 2.0)
-        )
+        self.angle_local_half_window_m = float(ang.angle_local_half_window_m)
 
-        # Raw config map (may be keyed by path or dataset_key(path))
         self._connect_to_features_angle_mode_raw = (
-            adv.connect_to_features_angle_mode or {}
+            ang.connect_to_features_angle_mode or {}
         )
 
-        # Filled during _build_external_target_layers_once:
-        # dataset_key(output_layer) -> AngleTargetMode
         self._angle_mode_by_external_ds_key: dict[str, logic_config.AngleTargetMode] = (
             {}
         )
 
-        # ----------------------------
-        # Z / elevation layer
-        # ----------------------------
         self.raster_paths: tuple[str, ...] = (
-            tuple(adv.raster_paths) if adv.raster_paths else ()
+            tuple(z.raster_paths) if z.raster_paths else ()
         )
         self.z_drop_threshold: Optional[float] = (
-            None if adv.z_drop_threshold is None else float(adv.z_drop_threshold)
+            None if z.z_drop_threshold is None else float(z.z_drop_threshold)
         )
         self._raster_handles: list[geometry_tools.RasterHandle] = []
 
-        self.reject_crossing_connectors: bool = bool(adv.reject_crossing_connectors)
-        self.crossing_check_spatial_reference = adv.crossing_check_spatial_reference
-        self.barrier_layers: list[str] | None = adv.barrier_layers or None
-        self.dangle_pair_apply_connector_diff: bool = bool(
-            adv.dangle_pair_apply_connector_diff
-        )
+        self.reject_crossing_connectors: bool = bool(cross.reject_crossing_connectors)
+        self.crossing_check_spatial_reference = cross.crossing_check_spatial_reference
+        self.barrier_layers: list[str] | None = cross.barrier_layers or None
 
         # Local angle cache (dataset_key, oid, rx, ry) -> Optional[float]
         self._local_angle_cache: dict[tuple[str, int, int, int], Optional[float]] = {}

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -834,6 +834,11 @@ class _CandidateContext:
     target_dangle_oid: Optional[DangleOid]
     near_fc_key: DatasetKey
     near_fid: int  # polymorphic: DangleOid / ParentId / external FID
+    # Segment-level identity preserved for the connector-crossing cache so
+    # multiple candidates from segments of one parent stay distinguishable
+    # (with segmentation off, these mirror near_fc_key / near_fid).
+    near_fc_key_raw: DatasetKey
+    near_fid_raw: int
     # Geometry
     dangle_x: float
     dangle_y: float
@@ -2700,7 +2705,7 @@ class FillLineGaps:
             from_x, from_y = xy
 
             for cand in candidates:
-                key = (dangle_oid, cand.near_fc_key, cand.near_fid)
+                key = (dangle_oid, cand.near_fc_key_raw, cand.near_fid_raw)
 
                 trimmed = self._build_trimmed_connector(
                     from_x=from_x,
@@ -2763,7 +2768,7 @@ class FillLineGaps:
                 continue
             from_x, from_y = xy
             for cand in candidates:
-                key = (dangle_oid, cand.near_fc_key, cand.near_fid)
+                key = (dangle_oid, cand.near_fc_key_raw, cand.near_fid_raw)
                 trimmed = self._build_trimmed_connector(
                     from_x=from_x,
                     from_y=from_y,
@@ -4350,7 +4355,7 @@ class FillLineGaps:
                 _parent_id = parent_id_by_dangle[_dangle_oid]
                 _remaining: list[NearCandidate] = []
                 for _cand in legal_rows_by_dangle[_dangle_oid]:
-                    _cand_key = (_dangle_oid, _cand.near_fc_key, _cand.near_fid)
+                    _cand_key = (_dangle_oid, _cand.near_fc_key_raw, _cand.near_fid_raw)
                     if _cand_key in reject_keys:
                         if collect_diags:
                             _step1a_illegal.append(
@@ -5110,6 +5115,8 @@ class FillLineGaps:
                 target_dangle_oid=target_dangle_oid,
                 near_fc_key=ds_key,
                 near_fid=near_fid,
+                near_fc_key_raw=str(chosen.near_fc_key_raw),
+                near_fid_raw=int(chosen.near_fid_raw),
                 dangle_x=float(d_x),
                 dangle_y=float(d_y),
                 near_x=chosen.near_x,
@@ -5332,8 +5339,8 @@ class FillLineGaps:
             for prop in global_winners:
                 _key = (
                     int(prop.ctx.dangle_oid),
-                    str(prop.ctx.near_fc_key),
-                    int(prop.ctx.near_fid),
+                    str(prop.ctx.near_fc_key_raw),
+                    int(prop.ctx.near_fid_raw),
                 )
                 _trimmed = trimmed_connector_cache.get(_key)
                 if _trimmed is not None:
@@ -5365,7 +5372,7 @@ class FillLineGaps:
                 rank_counter += 1
                 d_oid = int(prop.ctx.dangle_oid)
                 kruskal_rank_by_dangle_oid[d_oid] = rank_counter
-                _key = (d_oid, str(prop.ctx.near_fc_key), int(prop.ctx.near_fid))
+                _key = (d_oid, str(prop.ctx.near_fc_key_raw), int(prop.ctx.near_fid_raw))
                 accepted_keys.add(_key)
                 accepted_connector_raw.append(
                     AcceptedConnectorRaw(
@@ -5382,8 +5389,8 @@ class FillLineGaps:
                 return False
             key = (
                 int(prop.ctx.dangle_oid),
-                str(prop.ctx.near_fc_key),
-                int(prop.ctx.near_fid),
+                str(prop.ctx.near_fc_key_raw),
+                int(prop.ctx.near_fid_raw),
             )
             if trimmed_connector_cache.get(key) is None:
                 return False

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1928,6 +1928,42 @@ class FillLineGaps:
 
         return oid_to_key
 
+    @staticmethod
+    def _find_crossing_pairs(
+        in_fc: str,
+        against_fcs: list[str],
+    ) -> dict[int, set[int]]:
+        """Return {in_oid: {against_oid, ...}} for pairs where in_fc line crosses against_fcs line.
+
+        Uses INTERSECT as a broad spatial pre-filter, then confirms each candidate
+        with spatial_relationship="CROSSES" — exact, no false positives from
+        XY-tolerance snapping.  Self-pairs are excluded when against_fcs contains in_fc.
+        """
+        pairs: dict[int, set[int]] = {}
+        _in_lyr = arcpy.management.MakeFeatureLayer(in_fc, "__crossing_filter_lyr")[0]
+        for i, _against_fc in enumerate(against_fcs):
+            arcpy.management.SelectLayerByLocation(
+                in_layer=_in_lyr,
+                overlap_type="INTERSECT",
+                select_features=_against_fc,
+                selection_type="NEW_SELECTION" if i == 0 else "ADD_TO_SELECTION",
+            )
+        with arcpy.da.SearchCursor(_in_lyr, ["OID@", "SHAPE@"]) as _cur:
+            for _in_oid, _in_geom in _cur:
+                for _against_fc in against_fcs:
+                    with arcpy.da.SearchCursor(
+                        _against_fc,
+                        ["OID@"],
+                        spatial_filter=_in_geom,
+                        spatial_relationship="CROSSES",
+                    ) as _inner:
+                        for (_against_oid,) in _inner:
+                            if _against_fc == in_fc and _against_oid == _in_oid:
+                                continue
+                            pairs.setdefault(_in_oid, set()).add(_against_oid)
+        arcpy.management.Delete(_in_lyr)
+        return pairs
+
     def _find_crossing_conflict_keys(
         self,
         *,
@@ -1941,8 +1977,8 @@ class FillLineGaps:
         Pre-filter: identify candidates whose trimmed connector crosses an existing feature.
 
         Writes trimmed candidate connectors to a temp in-memory FC and uses
-        GenerateNearTable against check_feature_layers as the source of truth for
-        crossing conflicts.  Only legal candidates (already filtered by all other
+        a spatial CROSSES relationship check against check_feature_layers as the
+        source of truth for crossing conflicts.  Only legal candidates (already filtered by all other
         legality checks) are considered, so the temp FC is as small as possible.
 
         Returns:
@@ -1985,7 +2021,6 @@ class FillLineGaps:
             return set(), trimmed_cache
 
         _cands_fc = "memory/crossing_check_trimmed_cands"
-        _near_table = "memory/crossing_check_near"
 
         oid_to_key = self._write_trimmed_cands_fc(
             cands_with_keys=cands_with_keys,
@@ -1993,30 +2028,14 @@ class FillLineGaps:
             spatial_reference=spatial_reference,
         )
 
-        if arcpy.Exists(_near_table):
-            arcpy.management.Delete(_near_table)
-        arcpy.analysis.GenerateNearTable(
-            in_features=_cands_fc,
-            near_features=check_feature_layers,
-            out_table=_near_table,
-            search_radius=self._connectivity_tolerance_linear_unit(),
-            location="NO_LOCATION",
-            angle="NO_ANGLE",
-            closest="ALL",
-            closest_count=0,
-            method="PLANAR",
-        )
+        crossing_pairs = self._find_crossing_pairs(_cands_fc, check_feature_layers)
 
         conflict_keys: set[tuple[int, str, int]] = set()
-        with arcpy.da.SearchCursor(_near_table, ["IN_FID", "NEAR_DIST"]) as cur:
-            for in_fid, near_dist in cur:
-                if near_dist != 0.0:
-                    continue
-                key = oid_to_key.get(int(in_fid))
-                if key is not None:
-                    conflict_keys.add(key)
+        for in_oid in crossing_pairs:
+            key = oid_to_key.get(in_oid)
+            if key is not None:
+                conflict_keys.add(key)
 
-        arcpy.management.Delete(_near_table)
         arcpy.management.Delete(_cands_fc)
 
         return conflict_keys, trimmed_cache
@@ -4134,9 +4153,9 @@ class FillLineGaps:
             of an already-accepted candidate's trimmed connector
             (reason: crosses_accepted_connector).
 
-        Crossing uses a single pre-loop GenerateNearTable of all candidate trimmed
-        connectors against themselves to build a conflict lookup.  During the loop,
-        _crossing_blocked consults that lookup instead of running live geometry
+        Crossing uses a single pre-loop CROSSES relationship check of all candidate
+        trimmed connectors against themselves to build a conflict lookup.  During the
+        loop, _crossing_blocked consults that lookup instead of running live geometry
         checks.
 
         Note on deferred displacement inaccuracy:
@@ -4176,38 +4195,21 @@ class FillLineGaps:
 
             if _kruskal_cands:
                 _kruskal_fc = "memory/crossing_check_kruskal_cands"
-                _kruskal_near = "memory/crossing_check_kruskal_near"
                 _kruskal_oid_to_key = self._write_trimmed_cands_fc(
                     cands_with_keys=_kruskal_cands,
                     fc_path=_kruskal_fc,
                     spatial_reference=crossing_spatial_reference,
                 )
-                if arcpy.Exists(_kruskal_near):
-                    arcpy.management.Delete(_kruskal_near)
-                arcpy.analysis.GenerateNearTable(
-                    in_features=_kruskal_fc,
-                    near_features=[_kruskal_fc],
-                    out_table=_kruskal_near,
-                    search_radius=self._connectivity_tolerance_linear_unit(),
-                    location="NO_LOCATION",
-                    angle="NO_ANGLE",
-                    closest="ALL",
-                    closest_count=0,
-                    method="PLANAR",
-                )
-                with arcpy.da.SearchCursor(
-                    _kruskal_near, ["IN_FID", "NEAR_FID", "NEAR_DIST"]
-                ) as _cur:
-                    for _in_fid, _near_fid, _near_dist in _cur:
-                        if int(_in_fid) == int(_near_fid):
-                            continue
-                        if _near_dist != 0.0:
-                            continue
-                        _key_in = _kruskal_oid_to_key.get(int(_in_fid))
-                        _key_near = _kruskal_oid_to_key.get(int(_near_fid))
-                        if _key_in is not None and _key_near is not None:
+                for _oid_in, _against_oids in self._find_crossing_pairs(
+                    _kruskal_fc, [_kruskal_fc]
+                ).items():
+                    _key_in = _kruskal_oid_to_key.get(_oid_in)
+                    if _key_in is None:
+                        continue
+                    for _oid_near in _against_oids:
+                        _key_near = _kruskal_oid_to_key.get(_oid_near)
+                        if _key_near is not None:
                             conflict_lookup.setdefault(_key_in, set()).add(_key_near)
-                arcpy.management.Delete(_kruskal_near)
                 arcpy.management.Delete(_kruskal_fc)
 
         def _accept(prop: Any, gap_source: Any) -> None:
@@ -4355,8 +4357,9 @@ class FillLineGaps:
         """Re-check resnap captures against accepted connector geometries.
 
         Called after _resnap_connections resolves final geometry for deferred
-        connectors.  Uses GenerateNearTable (trimmed resnap connectors vs trimmed
-        accepted connectors) as the source of truth for crossing conflicts, then
+        connectors.  Uses a spatial CROSSES relationship check (trimmed resnap
+        connectors vs trimmed accepted connectors) as the source of truth for
+        crossing conflicts, then
         applies rank-based conflict resolution:
 
           - If the resnap capture has a worse (higher) rank than the best-ranked
@@ -4411,7 +4414,6 @@ class FillLineGaps:
 
         _resnap_fc = "memory/resnap_crossing_trimmed"
         _accepted_fc = "memory/resnap_crossing_accepted"
-        _near_table = "memory/resnap_crossing_near"
 
         oid_to_parent_id = self._write_trimmed_cands_fc(
             cands_with_keys=resnap_cands,
@@ -4424,34 +4426,19 @@ class FillLineGaps:
             spatial_reference=spatial_reference,
         )
 
-        if arcpy.Exists(_near_table):
-            arcpy.management.Delete(_near_table)
-        arcpy.analysis.GenerateNearTable(
-            in_features=_resnap_fc,
-            near_features=[_accepted_fc],
-            out_table=_near_table,
-            search_radius=self._connectivity_tolerance_linear_unit(),
-            location="NO_LOCATION",
-            angle="NO_ANGLE",
-            closest="ALL",
-            closest_count=0,
-            method="PLANAR",
-        )
-
         # {parent_id: set of conflicting accepted dangle_oids}
         conflicts_by_parent: dict[int, set[int]] = {}
-        with arcpy.da.SearchCursor(
-            _near_table, ["IN_FID", "NEAR_FID", "NEAR_DIST"]
-        ) as cur:
-            for in_fid, near_fid, near_dist in cur:
-                if near_dist != 0.0:
-                    continue
-                parent_id = oid_to_parent_id.get(int(in_fid))
-                acc_doid = oid_to_accepted_doid.get(int(near_fid))
-                if parent_id is not None and acc_doid is not None:
+        for rsnp_oid, acc_oids in self._find_crossing_pairs(
+            _resnap_fc, [_accepted_fc]
+        ).items():
+            parent_id = oid_to_parent_id.get(rsnp_oid)
+            if parent_id is None:
+                continue
+            for acc_oid in acc_oids:
+                acc_doid = oid_to_accepted_doid.get(acc_oid)
+                if acc_doid is not None:
                     conflicts_by_parent.setdefault(parent_id, set()).add(int(acc_doid))
 
-        arcpy.management.Delete(_near_table)
         arcpy.management.Delete(_resnap_fc)
         arcpy.management.Delete(_accepted_fc)
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1363,6 +1363,26 @@ class FillLineGaps:
         self._local_angle_cache[key] = angle
         return angle
 
+    def _line_measure_at_xy(self, polyline, x: float, y: float) -> Optional[float]:
+        """
+        Returns the percentage measure [0, 1] of the nearest point to (x, y) on polyline.
+        Returns None if the query fails or the result is unavailable.
+        """
+        if polyline is None:
+            return None
+        try:
+            sr = getattr(polyline, "spatialReference", None)
+            pt = arcpy.PointGeometry(arcpy.Point(float(x), float(y)), sr)
+            try:
+                q = polyline.queryPointAndDistance(pt, use_percentage=True)
+            except TypeError:
+                q = polyline.queryPointAndDistance(pt, True)
+            if q and len(q) >= 2 and q[1] is not None:
+                return float(q[1])
+        except Exception:
+            pass
+        return None
+
     # ----------------------------
     # Target staging
     # ----------------------------
@@ -2138,6 +2158,27 @@ class FillLineGaps:
         if ds_key == dangles_fc_key:
             _diff = self._directional_diff
             angle_max_deg = 180.0
+
+            # Normalize both angles to a digitization-independent convention so
+            # that directional diffs are 0 for a perfect collinear gap fill
+            # regardless of which end of each line the dangle sits on.
+            #
+            # src_angle_deg -> "exit direction from source dangle toward the gap"
+            #   Forward tangent points away from the line when the dangle is at
+            #   the end (m >= 0.5); it points INTO the line when at the start
+            #   (m < 0.5), so we reverse it.
+            src_poly_for_norm = polyline_by_parent.get(int(src_parent_id))
+            if src_poly_for_norm is not None and src_angle_deg is not None:
+                src_m = self._line_measure_at_xy(src_poly_for_norm, dangle_x, dangle_y)
+                if src_m is not None and src_m < 0.5:
+                    src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
+
+            # target_angle -> "entry direction into target interior from its dangle"
+            #   Forward tangent equals the entry direction when the dangle is at
+            #   the start (m < 0.5); it must be reversed when at the end (m >= 0.5).
+            tgt_m = self._line_measure_at_xy(tgt_poly, float(tx), float(ty))
+            if tgt_m is not None and tgt_m >= 0.5:
+                target_angle = (float(target_angle) + 180.0) % 360.0
         else:
             _diff = self._orientation_diff
             angle_max_deg = 90.0

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -940,6 +940,9 @@ class FillLineGaps:
         self.increased_tolerance_edge_case_distance_meters = int(
             adv.increased_tolerance_edge_case_distance_meters
         )
+        self.require_mutual_dangle_preference_for_bonus = bool(
+            adv.require_mutual_dangle_preference_for_bonus
+        )
         self.edit_method = logic_config.EditMethod(adv.edit_method)
 
         self.connectivity_scope = logic_config.ConnectivityScope(adv.connectivity_scope)
@@ -1252,6 +1255,29 @@ class FillLineGaps:
                 return int(cand["near_fid"])
         return None
 
+    def _mutual_dangle_preference(
+        self,
+        *,
+        dangle_oid: int,
+        other_dangle_oid: int,
+        dangle_parent: dict[int, int],
+        best_line_parent_by_dangle: dict[int, int],
+    ) -> bool:
+        """
+        True when source and target dangles mutually prefer each other's parent line:
+        - source's best line target is the other dangle's parent
+        - other dangle's best line target is the source's parent
+        """
+        src_parent = dangle_parent.get(int(dangle_oid))
+        other_parent = dangle_parent.get(int(other_dangle_oid))
+        if src_parent is None or other_parent is None:
+            return False
+        src_best = best_line_parent_by_dangle.get(int(dangle_oid))
+        other_best = best_line_parent_by_dangle.get(int(other_dangle_oid))
+        if src_best is None or other_best is None:
+            return False
+        return int(src_best) == int(other_parent) and int(other_best) == int(src_parent)
+
     def _edge_case_bonus_applies(
         self,
         *,
@@ -1262,13 +1288,17 @@ class FillLineGaps:
         best_line_parent_by_dangle: dict[int, int],
     ) -> bool:
         """
-        Edge-case bonus applies only for dangle targets when:
+        Determines whether the edge-case distance bonus applies for a candidate.
 
-        - source dangle's best legal line target is the target dangle's parent line
-        - target dangle's best legal line target is the source dangle's parent line
+        The bonus is only possible when the TARGET is a true dangle — i.e. an unconnected
+        endpoint of an input line. For all other target types (self-lines, external features)
+        the bonus is never applied; those targets benefit only from the expanded search
+        tolerance, not from the effective-distance reduction.
 
-        This is the explicit implementation of:
-        "if both dangles want each other's parent line, prioritize the dangle".
+        For dangle targets the condition is mutual preference: both dangles must prefer
+        each other's parent line (see _mutual_dangle_preference).
+
+        Requires increased_tolerance_edge_case_distance_meters > 0.
         """
         extra = max(0, int(self.increased_tolerance_edge_case_distance_meters))
         if extra <= 0:
@@ -1277,24 +1307,15 @@ class FillLineGaps:
         if str(cand["near_fc_key"]) != str(dangles_fc_key):
             return False
 
-        src_parent = dangle_parent.get(int(dangle_oid))
-        if src_parent is None:
-            return False
+        if not self.require_mutual_dangle_preference_for_bonus:
+            return True
 
-        other_dangle_oid = int(cand["near_fid"])
-        other_parent = dangle_parent.get(int(other_dangle_oid))
-        if other_parent is None:
-            return False
-
-        src_best_line_parent = best_line_parent_by_dangle.get(int(dangle_oid))
-        other_best_line_parent = best_line_parent_by_dangle.get(int(other_dangle_oid))
-
-        if src_best_line_parent is None or other_best_line_parent is None:
-            return False
-
-        return int(src_best_line_parent) == int(other_parent) and int(
-            other_best_line_parent
-        ) == int(src_parent)
+        return self._mutual_dangle_preference(
+            dangle_oid=dangle_oid,
+            other_dangle_oid=int(cand["near_fid"]),
+            dangle_parent=dangle_parent,
+            best_line_parent_by_dangle=best_line_parent_by_dangle,
+        )
 
     def _candidate_score_details(
         self,
@@ -2102,6 +2123,7 @@ class FillLineGaps:
         dangle_parent: dict[int, int],
         dangles_fc_key: str,
         lines_fc_key: str,
+        line_like_ds_keys: set[str],
         parent_id: int,
         cand: dict,
         base_tol: float,
@@ -2113,7 +2135,6 @@ class FillLineGaps:
         dist = float(cand["near_dist"])
 
         if ds_key == dangles_fc_key:
-            # IMPORTANT: use dangle_candidate_tol, not expanded tolerance by default
             if dist > float(dangle_candidate_tol):
                 return False
 
@@ -2121,7 +2142,6 @@ class FillLineGaps:
             if other_parent is None:
                 return False
 
-            # Same-network restriction (value-neutral topology)
             if topology is not None and self._same_network(
                 a_parent=int(parent_id),
                 b_parent=int(other_parent),
@@ -2129,7 +2149,7 @@ class FillLineGaps:
             ):
                 return False
 
-            # Dangle->dangle still illegal-checks against the other parent line id
+            # Dangle->dangle illegal-checks against the other parent line id
             if self._is_illegal(
                 illegal=illegal,
                 parent_id=parent_id,
@@ -2140,14 +2160,15 @@ class FillLineGaps:
 
             return True
 
-        # non-dangle always uses base_tol
-        if dist > float(base_tol):
+        # Line-like targets (self-lines and connect_to_features polylines) use the
+        # expanded tolerance so true-dangle connections beyond base_tol are reachable.
+        effective_tol = dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
+        if dist > float(effective_tol):
             return False
 
         if ds_key == lines_fc_key and int(oid) == int(parent_id):
             return False
 
-        # Same-network restriction for line targets (oid is in ORIGINAL_ID space in your grouped rows)
         if (
             ds_key == lines_fc_key
             and topology is not None
@@ -2176,6 +2197,7 @@ class FillLineGaps:
         dangle_parent: dict[int, int],
         dangles_fc_key: str,
         lines_fc_key: str,
+        line_like_ds_keys: set[str],
         parent_id: int,
         cand: dict,
         base_tol: float,
@@ -2206,7 +2228,8 @@ class FillLineGaps:
                 return "illegal_target"
             return "illegal_target"
 
-        if dist > float(base_tol):
+        effective_tol = dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
+        if dist > float(effective_tol):
             return "beyond_distance_tolerance"
         if topology is not None and ds_key == lines_fc_key and self._same_network(
             a_parent=int(parent_id), b_parent=int(oid), topology=topology
@@ -2542,6 +2565,7 @@ class FillLineGaps:
                 dangle_parent=dangle_parent,
                 dangles_fc_key=dangles_fc_key,
                 lines_fc_key=lines_fc_key,
+                line_like_ds_keys=set(),  # no expanded tolerance in this context
                 parent_id=parent_id,
                 cand=cand,
                 base_tol=base_tol,
@@ -2778,47 +2802,12 @@ class FillLineGaps:
         collect_diags = self.candidate_connections_output is not None
 
         # ----------------------------
-        # Dangle filtering: collect legal candidates per dangle
-        # ----------------------------
-        legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
-            self._filter_legal_candidates(
-                grouped=grouped,
-                dangle_parent=dangle_parent,
-                illegal=illegal,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
-                base_tol=base_tol,
-                dangle_tol=dangle_tol,
-                topology=topology,
-                collect_diags=collect_diags,
-            )
-        )
-
-        if not legal_rows_by_dangle:
-            return {}, {}, self._assemble_diagnostics(
-                collect_diags=collect_diags,
-                step1a_illegal=_step1a_illegal,
-                step1b_illegal=[],
-                step1b_scored=[],
-                connection_loser_oids=set(),
-                kruskal_rejected_oids=set(),
-                accepted_dangle_oids=set(),
-                gap_source_by_dangle={},
-                dangle_norm_z_by_dangle={},
-                connection_norm_z_by_dangle={},
-                global_norm_z_by_dangle={},
-                dangle_xy=dangle_xy,
-                dangle_parent=dangle_parent,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
-            )
-
-        # ----------------------------
         # Angle caches
         # ----------------------------
         polyline_by_parent = self._build_polyline_by_parent_id()
 
-        # External polyline caches keyed by dataset_key(layer)
+        # External polyline caches and line-type map, keyed by dataset_key(layer).
+        # Built before candidate filtering so line_like_ds_keys is available.
         polyline_by_external: dict[str, dict[int, Any]] = {}
         is_external_line_like: dict[str, bool] = {}
 
@@ -2845,6 +2834,53 @@ class FillLineGaps:
                 polyline_by_external[ds_key] = self._build_polyline_by_oid(lyr)
             else:
                 is_external_line_like[ds_key] = False
+
+        # ds_keys for line-like targets that receive the expanded tolerance.
+        # Self-lines are included only when fill_gaps_on_self is active (otherwise no
+        # candidates with lines_key appear in the near table anyway).
+        line_like_external_ds_keys: set[str] = {
+            ds_key for ds_key, is_line in is_external_line_like.items() if is_line
+        }
+        line_like_ds_keys: set[str] = line_like_external_ds_keys.copy()
+        if self.fill_gaps_on_self:
+            line_like_ds_keys.add(lines_key)
+
+        # ----------------------------
+        # Dangle filtering: collect legal candidates per dangle
+        # ----------------------------
+        legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
+            self._filter_legal_candidates(
+                grouped=grouped,
+                dangle_parent=dangle_parent,
+                illegal=illegal,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+                line_like_ds_keys=line_like_ds_keys,
+                base_tol=base_tol,
+                dangle_tol=dangle_tol,
+                topology=topology,
+                collect_diags=collect_diags,
+            )
+        )
+
+        if not legal_rows_by_dangle:
+            return {}, {}, self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                step1a_illegal=_step1a_illegal,
+                step1b_illegal=[],
+                step1b_scored=[],
+                connection_loser_oids=set(),
+                kruskal_rejected_oids=set(),
+                accepted_dangle_oids=set(),
+                gap_source_by_dangle={},
+                dangle_norm_z_by_dangle={},
+                connection_norm_z_by_dangle={},
+                global_norm_z_by_dangle={},
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+            )
 
         # ----------------------------
         # Best line parent per dangle (angle-aware)
@@ -2895,7 +2931,6 @@ class FillLineGaps:
                 if assess.blocks:
                     continue
 
-                # Line targets do not use edge-case bonus.
                 raw_dist = float(cand["near_dist"])
                 _tol = float(self.gap_tolerance_meters) or 1.0
                 eff = self._compute_best_fit_score(
@@ -2920,6 +2955,8 @@ class FillLineGaps:
                 dangle_xy=dangle_xy,
                 dangles_key=dangles_key,
                 lines_key=lines_key,
+                line_like_ds_keys=line_like_ds_keys,
+                line_like_external_ds_keys=line_like_external_ds_keys,
                 base_tol=base_tol,
                 polyline_by_parent=polyline_by_parent,
                 polyline_by_external=polyline_by_external,
@@ -3081,6 +3118,7 @@ class FillLineGaps:
         illegal: _IllegalTargets,
         dangles_key: str,
         lines_key: str,
+        line_like_ds_keys: set[str],
         base_tol: float,
         dangle_tol: float,
         topology: TopologyModel,
@@ -3119,6 +3157,7 @@ class FillLineGaps:
                     dangle_parent=dangle_parent,
                     dangles_fc_key=dangles_key,
                     lines_fc_key=lines_key,
+                    line_like_ds_keys=line_like_ds_keys,
                     parent_id=parent_id,
                     cand=cand,
                     base_tol=base_tol,
@@ -3133,6 +3172,7 @@ class FillLineGaps:
                         dangle_parent=dangle_parent,
                         dangles_fc_key=dangles_key,
                         lines_fc_key=lines_key,
+                        line_like_ds_keys=line_like_ds_keys,
                         parent_id=parent_id,
                         cand=cand,
                         base_tol=base_tol,
@@ -3157,6 +3197,8 @@ class FillLineGaps:
         dangle_xy: dict[int, tuple[float, float]],
         dangles_key: str,
         lines_key: str,
+        line_like_ds_keys: set[str],
+        line_like_external_ds_keys: set[str],
         base_tol: float,
         polyline_by_parent: dict[int, Any],
         polyline_by_external: dict[str, dict[int, Any]],
@@ -3275,12 +3317,15 @@ class FillLineGaps:
                         )
                     continue
 
-                # 2) Expanded dangle tolerance gating (angle_extra_dangle_threshold_degrees)
+                # 2) Expanded tolerance gating (angle_extra_dangle_threshold_degrees)
+                # Applies to dangle targets and line-like targets that are only in range
+                # because of the expanded tolerance — angle must permit extra-dangle behavior.
                 is_dangle_target = str(cand["near_fc_key"]) == str(dangles_key)
+                is_line_like_target = str(cand["near_fc_key"]) in line_like_ds_keys
                 dist = float(cand["near_dist"])
 
                 if (
-                    is_dangle_target
+                    (is_dangle_target or is_line_like_target)
                     and dist > float(base_tol)
                     and not bool(assess.allow_extra_dangle)
                 ):
@@ -3313,7 +3358,8 @@ class FillLineGaps:
                             )
                         continue
 
-                # 4) Edge-case bonus eligibility is angle-controlled (and conservative when angle missing)
+                # 4) Edge-case bonus eligibility is angle-controlled (and conservative when
+                # angle missing). Only dangle targets can receive the bonus.
                 bonus_allowed = True
                 if is_dangle_target:
                     # conservative policy: if angle is unavailable => no expanded behavior, no bonus
@@ -4299,7 +4345,7 @@ class FillLineGaps:
                     d.raw_distance,
                     d.best_fit_score,
                     d.best_fit_rank,
-                    int(d.bonus_applied) if d.bonus_applied is not None else None,
+                    int(bool(d.bonus_applied)),
                     a.angle_metric_deg if a is not None else None,
                     a.src_connector_diff if a is not None else None,
                     a.connector_target_diff if a is not None else None,

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -718,7 +718,7 @@ class Proposal:
     chosen: dict  # the chosen candidate row dict
 
     raw_distance: float
-    effective_distance: float
+    best_fit_score: float
     bonus_applied: bool
 
     # (effective_dist, bonus_rank, raw_dist, src_parent, dangle_oid, near_fc_key, near_fid)
@@ -737,7 +737,6 @@ class AngleAssessment:
     blocks: bool
     allow_extra_dangle: bool  # expanded dangle tol + edge-case bonus
     angle_metric_deg: Optional[float]
-    angle_penalty_m: float
 
     # Diagnostics (optional)
     src_connector_diff: Optional[float] = None
@@ -806,11 +805,7 @@ class FillLineGaps:
             if adv.angle_extra_dangle_threshold_degrees is None
             else float(adv.angle_extra_dangle_threshold_degrees)
         )
-        self.angle_penalty_max_meters = (
-            None
-            if adv.angle_penalty_max_meters is None
-            else float(adv.angle_penalty_max_meters)
-        )
+        self.best_fit_weights = adv.best_fit_weights
 
         w = float(getattr(adv, "line_alignment_weight", 0.6))
         self.line_alignment_weight = max(0.0, min(1.0, w))
@@ -1872,7 +1867,6 @@ class FillLineGaps:
                 blocks=False,
                 allow_extra_dangle=bool(allow_extra),
                 angle_metric_deg=None,
-                angle_penalty_m=0.0,
             )
 
         src_connector_diff = self._orientation_diff(
@@ -1897,16 +1891,11 @@ class FillLineGaps:
                         self.angle_extra_dangle_threshold_degrees
                     )
 
-            penalty = 0.0
-            if self.angle_penalty_max_meters is not None:
-                penalty = (metric / 90.0) * float(self.angle_penalty_max_meters)
-
             return AngleAssessment(
                 available=True,
                 blocks=bool(blocks),
                 allow_extra_dangle=bool(allow_extra),
                 angle_metric_deg=float(metric),
-                angle_penalty_m=float(penalty),
                 src_connector_diff=float(src_connector_diff),
             )
 
@@ -1966,7 +1955,6 @@ class FillLineGaps:
                 blocks=False,
                 allow_extra_dangle=bool(allow_extra),
                 angle_metric_deg=None,
-                angle_penalty_m=0.0,
                 src_connector_diff=float(src_connector_diff),
             )
 
@@ -1999,16 +1987,11 @@ class FillLineGaps:
             else:
                 allow_extra = metric <= float(self.angle_extra_dangle_threshold_degrees)
 
-        penalty = 0.0
-        if self.angle_penalty_max_meters is not None:
-            penalty = (metric / 90.0) * float(self.angle_penalty_max_meters)
-
         return AngleAssessment(
             available=True,
             blocks=bool(blocks),
             allow_extra_dangle=bool(allow_extra),
             angle_metric_deg=float(metric),
-            angle_penalty_m=float(penalty),
             src_connector_diff=float(src_connector_diff),
             connector_target_diff=float(connector_target_diff),
             src_target_diff=float(src_target_diff),
@@ -2413,9 +2396,14 @@ class FillLineGaps:
                 if assess.blocks:
                     continue
 
-                # Line targets do not use edge-case bonus. Score is raw + angle penalty.
+                # Line targets do not use edge-case bonus.
                 raw_dist = float(cand["near_dist"])
-                eff = raw_dist + float(assess.angle_penalty_m)
+                _tol = float(self.gap_tolerance_meters) or 1.0
+                _norm_d = raw_dist / _tol
+                _norm_a = (float(assess.angle_metric_deg) / 90.0
+                           if assess.angle_metric_deg is not None else 0.0)
+                eff = (float(self.best_fit_weights.distance) * _norm_d
+                       + float(self.best_fit_weights.angle) * _norm_a)
 
                 # Deterministic tie-break:
                 score = (float(eff), float(raw_dist), self._candidate_sort_key(cand))
@@ -2516,9 +2504,14 @@ class FillLineGaps:
                     )
                 )
 
-                # 4) Distance-equivalent angle penalty integrates into scoring
-                effective_for_scoring = float(effective_distance) + float(
-                    assess.angle_penalty_m
+                # 4) Normalized weighted composite score
+                _tol = float(self.gap_tolerance_meters) or 1.0
+                _norm_d = float(effective_distance) / _tol
+                _norm_a = (float(assess.angle_metric_deg) / 90.0
+                           if assess.angle_metric_deg is not None else 0.0)
+                effective_for_scoring = (
+                    float(self.best_fit_weights.distance) * _norm_d
+                    + float(self.best_fit_weights.angle) * _norm_a
                 )
 
                 # Keep score tuple shape stable; only replace the first element
@@ -2602,7 +2595,7 @@ class FillLineGaps:
                 tgt_node=tgt_node,
                 chosen=chosen,
                 raw_distance=float(raw_distance),
-                effective_distance=float(effective_distance_for_scoring),
+                best_fit_score=float(effective_distance_for_scoring),
                 bonus_applied=bool(bonus_applied),
                 score=score,
                 pair_key=pair_key,
@@ -2759,6 +2752,7 @@ class FillLineGaps:
                 gap_source=str(gap_source),
                 bonus_applied=prop.bonus_applied,
                 assess=assess_by_dangle.get(int(prop.dangle_oid)),
+                best_fit_score=prop.best_fit_score,
             )
 
             tmp.setdefault(int(prop.src_parent_id), []).append((prop.score, entry))
@@ -2784,6 +2778,7 @@ class FillLineGaps:
         gap_source: str,
         bonus_applied: bool = False,
         assess: "Optional[AngleAssessment]" = None,
+        best_fit_score: Optional[float] = None,
     ) -> dict:
         edit_op = self._resolve_edit_op(gap_source=str(gap_source))
         entry: dict = {
@@ -2808,7 +2803,7 @@ class FillLineGaps:
                 entry["meta_connector_transition_diff"] = assess.connector_transition_diff
                 entry["meta_line_match_diff"] = assess.line_match_diff
                 entry["meta_angle_metric_deg"] = assess.angle_metric_deg
-                entry["meta_angle_penalty_m"] = assess.angle_penalty_m
+                entry["meta_best_fit_score"] = best_fit_score
         return entry
 
     def _apply_pair_symmetric_skip(self, decided_by_parent: dict[int, dict]) -> None:
@@ -2990,7 +2985,7 @@ class FillLineGaps:
             "connector_transition_diff",
             "line_match_diff",
             "angle_metric_deg",
-            "angle_penalty_m",
+            "best_fit_score",
         ]
         for fname in meta_double_fields:
             if fname not in existing:
@@ -3027,7 +3022,7 @@ class FillLineGaps:
                 meta.get("meta_connector_transition_diff"),
                 meta.get("meta_line_match_diff"),
                 meta.get("meta_angle_metric_deg"),
-                meta.get("meta_angle_penalty_m"),
+                meta.get("meta_best_fit_score"),
                 meta.get("meta_bonus_applied"),
             ])
         return tuple(row)
@@ -3098,7 +3093,7 @@ class FillLineGaps:
                             "meta_connector_transition_diff",
                             "meta_line_match_diff",
                             "meta_angle_metric_deg",
-                            "meta_angle_penalty_m",
+                            "meta_best_fit_score",
                             "meta_bonus_applied",
                         )} if any(k in info for k in (
                             "meta_src_connector_diff",
@@ -3130,7 +3125,7 @@ class FillLineGaps:
                 "connector_transition_diff",
                 "line_match_diff",
                 "angle_metric_deg",
-                "angle_penalty_m",
+                "best_fit_score",
                 "bonus_applied",
             ]
             with arcpy.da.InsertCursor(

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -776,6 +776,7 @@ class FillLineGaps:
         adv = line_gap_config.advanced_config
         self.fill_gaps_on_self = bool(adv.fill_gaps_on_self)
         self.line_changes_output = adv.line_changes_output
+        self.write_output_metadata = bool(adv.write_output_metadata)
         self.increased_tolerance_edge_case_distance_meters = int(
             adv.increased_tolerance_edge_case_distance_meters
         )
@@ -2428,6 +2429,7 @@ class FillLineGaps:
         # Step 1B: choose exactly ONE proposal per dangle using angle-aware scoring
         # ----------------------------
         proposals_by_dangle: dict[int, Proposal] = {}
+        assess_by_dangle: dict[int, AngleAssessment] = {}
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             dangle_oid = int(dangle_oid)
@@ -2458,6 +2460,7 @@ class FillLineGaps:
                     float,  # raw_distance
                     float,  # effective_distance_for_scoring
                     bool,  # bonus_applied
+                    "AngleAssessment",  # assess for winning candidate metadata
                 ]
             ] = []
 
@@ -2536,6 +2539,7 @@ class FillLineGaps:
                         float(raw_distance),
                         float(effective_for_scoring),
                         bool(bonus_applied),
+                        assess,
                     )
                 )
 
@@ -2548,6 +2552,7 @@ class FillLineGaps:
                 raw_distance,
                 effective_distance_for_scoring,
                 bonus_applied,
+                chosen_assess,
             ) = min(
                 scored_candidates,
                 key=lambda item: item[0],
@@ -2604,6 +2609,7 @@ class FillLineGaps:
                 target_parent_id=target_parent_id,
                 target_dangle_oid=target_dangle_oid,
             )
+            assess_by_dangle[dangle_oid] = chosen_assess
 
         if not proposals_by_dangle:
             return {}, {}
@@ -2751,6 +2757,8 @@ class FillLineGaps:
                 dangle_y=float(d_y),
                 chosen=prop.chosen,
                 gap_source=str(gap_source),
+                bonus_applied=prop.bonus_applied,
+                assess=assess_by_dangle.get(int(prop.dangle_oid)),
             )
 
             tmp.setdefault(int(prop.src_parent_id), []).append((prop.score, entry))
@@ -2774,9 +2782,11 @@ class FillLineGaps:
         dangle_y: float,
         chosen: dict,
         gap_source: str,
+        bonus_applied: bool = False,
+        assess: "Optional[AngleAssessment]" = None,
     ) -> dict:
         edit_op = self._resolve_edit_op(gap_source=str(gap_source))
-        return {
+        entry: dict = {
             "processed": False,
             "skip": False,
             "gap_source": str(gap_source),
@@ -2789,6 +2799,17 @@ class FillLineGaps:
             "chosen_near_fc_key": str(chosen["near_fc_key"]),
             "chosen_near_fid": int(chosen["near_fid"]),
         }
+        if self.write_output_metadata:
+            entry["meta_bonus_applied"] = int(bonus_applied)
+            if assess is not None:
+                entry["meta_src_connector_diff"] = assess.src_connector_diff
+                entry["meta_connector_target_diff"] = assess.connector_target_diff
+                entry["meta_src_target_diff"] = assess.src_target_diff
+                entry["meta_connector_transition_diff"] = assess.connector_transition_diff
+                entry["meta_line_match_diff"] = assess.line_match_diff
+                entry["meta_angle_metric_deg"] = assess.angle_metric_deg
+                entry["meta_angle_penalty_m"] = assess.angle_penalty_m
+        return entry
 
     def _apply_pair_symmetric_skip(self, decided_by_parent: dict[int, dict]) -> None:
         """
@@ -2939,7 +2960,7 @@ class FillLineGaps:
     # ----------------------------
 
     def _setup_line_changes_output(self) -> None:
-        if self.line_changes_output is None:
+        if self.line_changes_output is None or not self.write_output_metadata:
             return
 
         file_utilities.create_feature_class(
@@ -2962,6 +2983,22 @@ class FillLineGaps:
                 self.line_changes_output, self.FIELD_GAP_SOURCE, "TEXT", field_length=20
             )
 
+        meta_double_fields = [
+            "src_connector_diff",
+            "connector_target_diff",
+            "src_target_diff",
+            "connector_transition_diff",
+            "line_match_diff",
+            "angle_metric_deg",
+            "angle_penalty_m",
+        ]
+        for fname in meta_double_fields:
+            if fname not in existing:
+                arcpy.management.AddField(self.line_changes_output, fname, "DOUBLE")
+
+        if "bonus_applied" not in existing:
+            arcpy.management.AddField(self.line_changes_output, "bonus_applied", "SHORT")
+
     def _build_change_row(
         self,
         original_id: int,
@@ -2971,6 +3008,7 @@ class FillLineGaps:
         near_y: float,
         spatial_reference,
         gap_source: str,
+        meta: Optional[dict] = None,
     ):
         dist = ((dangle_x - near_x) ** 2 + (dangle_y - near_y) ** 2) ** 0.5
         if dist == 0.0:
@@ -2980,7 +3018,19 @@ class FillLineGaps:
             [arcpy.Point(dangle_x, dangle_y), arcpy.Point(near_x, near_y)]
         )
         geom = arcpy.Polyline(arr, spatial_reference)
-        return (geom, int(original_id), float(dist), str(gap_source))
+        row = [geom, int(original_id), float(dist), str(gap_source)]
+        if meta is not None:
+            row.extend([
+                meta.get("meta_src_connector_diff"),
+                meta.get("meta_connector_target_diff"),
+                meta.get("meta_src_target_diff"),
+                meta.get("meta_connector_transition_diff"),
+                meta.get("meta_line_match_diff"),
+                meta.get("meta_angle_metric_deg"),
+                meta.get("meta_angle_penalty_m"),
+                meta.get("meta_bonus_applied"),
+            ])
+        return tuple(row)
 
     def _apply_plan(self, plan) -> None:
         if not plan:
@@ -3040,7 +3090,21 @@ class FillLineGaps:
 
                     info["processed"] = True
 
-                    if self.line_changes_output is not None:
+                    if self.line_changes_output is not None and self.write_output_metadata:
+                        meta = {k: info.get(k) for k in (
+                            "meta_src_connector_diff",
+                            "meta_connector_target_diff",
+                            "meta_src_target_diff",
+                            "meta_connector_transition_diff",
+                            "meta_line_match_diff",
+                            "meta_angle_metric_deg",
+                            "meta_angle_penalty_m",
+                            "meta_bonus_applied",
+                        )} if any(k in info for k in (
+                            "meta_src_connector_diff",
+                            "meta_angle_metric_deg",
+                            "meta_bonus_applied",
+                        )) else None
                         row = self._build_change_row(
                             original_id=pid,
                             dangle_x=float(info["dangle_x"]),
@@ -3051,13 +3115,24 @@ class FillLineGaps:
                             gap_source=str(
                                 info.get("gap_source", self.GAP_SOURCE_DEFAULT)
                             ),
+                            meta=meta,
                         )
                         if row is not None:
                             change_rows.append(row)
 
                 cur.updateRow((original_id, current_shape))
 
-        if self.line_changes_output is not None and change_rows:
+        if self.line_changes_output is not None and self.write_output_metadata and change_rows:
+            meta_fields = [
+                "src_connector_diff",
+                "connector_target_diff",
+                "src_target_diff",
+                "connector_transition_diff",
+                "line_match_diff",
+                "angle_metric_deg",
+                "angle_penalty_m",
+                "bonus_applied",
+            ]
             with arcpy.da.InsertCursor(
                 self.line_changes_output,
                 [
@@ -3065,9 +3140,12 @@ class FillLineGaps:
                     self.ORIGINAL_ID,
                     self.FIELD_GAP_DIST_M,
                     self.FIELD_GAP_SOURCE,
-                ],
+                ] + meta_fields,
             ) as icur:
                 for row in change_rows:
+                    if len(row) == 4:
+                        # Deferred / polygon rows — no metadata; pad with None
+                        row = row + (None,) * len(meta_fields)
                     icur.insertRow(row)
 
     def _write_output(self) -> None:
@@ -3096,7 +3174,7 @@ class FillLineGaps:
         self._filter_true_dangles()
         dangles_for_plan = self.filtered_dangles
 
-        if self.line_changes_output is not None:
+        if self.line_changes_output is not None and self.write_output_metadata:
             if arcpy.Exists(self.line_changes_output):
                 arcpy.management.Delete(self.line_changes_output)
             self._setup_line_changes_output()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1087,6 +1087,9 @@ class FillLineGaps:
         self.reject_crossing_connectors: bool = bool(adv.reject_crossing_connectors)
         self.crossing_check_spatial_reference = adv.crossing_check_spatial_reference
         self.barrier_layers: list[str] | None = adv.barrier_layers or None
+        self.dangle_pair_apply_connector_diff: bool = bool(
+            adv.dangle_pair_apply_connector_diff
+        )
 
         if (
             self.source_direction_mode
@@ -2847,7 +2850,11 @@ class FillLineGaps:
                 )
                 _tgt_is_start = self._xy_is_at_line_start(tgt_poly, _snap_x, _snap_y)
                 if _src_is_end and _tgt_is_start:
-                    metric = float(src_target_diff)
+                    metric = (
+                        max(float(src_target_diff), float(src_connector_diff))
+                        if self.dangle_pair_apply_connector_diff and _is_dangle_pair
+                        else float(src_target_diff)
+                    )
                 else:
                     metric = 180.0
             elif _is_directional:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -126,6 +126,7 @@ class TopologyBuilder:
         if len(key) <= max_len:
             return key
         import hashlib
+
         return key[:16] + hashlib.md5(key.encode()).hexdigest()[:8]
 
     def build(
@@ -313,7 +314,9 @@ class TopologyBuilder:
     def _build_parent_adjacency_endpoints(
         self, restrict_to_parent_ids: Optional[set[int]]
     ) -> dict[int, set[int]]:
-        endpoints_fc = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_line_endpoints")
+        endpoints_fc = self.wfm.build_file_path(
+            file_name=f"{self.file_name_prefix}topo_line_endpoints"
+        )
         arcpy.management.FeatureVerticesToPoints(
             self.lines_fc, endpoints_fc, "BOTH_ENDS"
         )
@@ -329,7 +332,9 @@ class TopologyBuilder:
                 endpoints_lyr, "NEW_SELECTION", where
             )
 
-        near_table = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_endpoints_near_lines")
+        near_table = self.wfm.build_file_path(
+            file_name=f"{self.file_name_prefix}topo_endpoints_near_lines"
+        )
         arcpy.analysis.GenerateNearTable(
             in_features=endpoints_lyr,
             near_features=[self.lines_fc],
@@ -392,7 +397,9 @@ class TopologyBuilder:
             )
             arcpy.management.SelectLayerByAttribute(lines_lyr, "NEW_SELECTION", where)
 
-        near_table = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_lines_near_lines")
+        near_table = self.wfm.build_file_path(
+            file_name=f"{self.file_name_prefix}topo_lines_near_lines"
+        )
         arcpy.analysis.GenerateNearTable(
             in_features=lines_lyr,
             near_features=[self.lines_fc],
@@ -630,7 +637,9 @@ class TopologyBuilder:
         """
         Adds undirected optional↔optional edges to union-find for TRANSITIVE.
         """
-        table = self.wfm.build_file_path(file_name=f"{self.file_name_prefix}topo_optopt_{self._short_key(ds_in)}_to_{self._short_key(ds_near)}")
+        table = self.wfm.build_file_path(
+            file_name=f"{self.file_name_prefix}topo_optopt_{self._short_key(ds_in)}_to_{self._short_key(ds_near)}"
+        )
         arcpy.analysis.GenerateNearTable(
             in_features=in_layer,
             near_features=[near_layer],
@@ -721,58 +730,69 @@ class TopologyBuilder:
 @dataclass(frozen=True)
 class _CandidateContext:
     """Fixed metadata for a dangle winner; carried unchanged across scope promotions."""
+
     # Topology routing
-    dangle_oid:        int
-    src_parent_id:     int
-    src_node:          "EntityKey"
-    tgt_node:          "EntityKey"
-    pair_key:          "tuple[EntityKey, EntityKey]"
-    target_parent_id:  Optional[int]
+    dangle_oid: int
+    src_parent_id: int
+    src_node: "EntityKey"
+    tgt_node: "EntityKey"
+    pair_key: "tuple[EntityKey, EntityKey]"
+    target_parent_id: Optional[int]
     target_dangle_oid: Optional[int]
-    near_fc_key:       str
-    near_fid:          int
+    near_fc_key: str
+    near_fid: int
     # Geometry
-    dangle_x:          float
-    dangle_y:          float
-    near_x:            float
-    near_y:            float
-    raw_distance:      float
-    bonus_applied:     bool
+    dangle_x: float
+    dangle_y: float
+    near_x: float
+    near_y: float
+    raw_distance: float
+    bonus_applied: bool
     # Scoring inputs (fixed; needed for diagnostics and score recomputation)
-    start_z:           Optional[float]   # Z at source dangle endpoint
-    end_z:             Optional[float]   # Z at target near-point
-    norm_dist:         float             # raw_distance / gap_tolerance_meters
-    assess:            Optional["AngleAssessment"]
+    start_z: Optional[float]  # Z at source dangle endpoint
+    end_z: Optional[float]  # Z at target near-point
+    norm_dist: float  # raw_distance / gap_tolerance_meters
+    assess: Optional["AngleAssessment"]
 
 
 @dataclass(frozen=True)
 class _ProposalScore:
     """Readable replacement for the opaque score tuple."""
-    composite:  float            # weighted best-fit score (primary sort key)
-    bonus_rank: int              # 0 = bonus applied, 1 = no bonus
-    norm_dist:  float            # effective distance component [0, 1]
+
+    composite: float  # weighted best-fit score (primary sort key)
+    bonus_rank: int  # 0 = bonus applied, 1 = no bonus
+    norm_dist: float  # effective distance component [0, 1]
     norm_angle: Optional[float]  # angle component [0, 1]; None if unavailable
-    norm_z:     Optional[float]  # Z component at current scope; None if unavailable
+    norm_z: Optional[float]  # Z component at current scope; None if unavailable
 
 
 @dataclass(frozen=True)
 class _DangleProposal:
     """Step-1B winner; Z normalized within its dangle's candidate set."""
-    ctx:   "_CandidateContext"
-    score: "_ProposalScore"      # score.norm_z = dangle_norm_z
+
+    ctx: "_CandidateContext"
+    score: "_ProposalScore"  # score.norm_z = dangle_norm_z
 
     def sort_key(self) -> tuple:
         c = self.ctx
-        return (self.score.composite, self.score.bonus_rank,
-                c.raw_distance, c.src_parent_id, c.dangle_oid, c.near_fc_key, c.near_fid)
+        return (
+            self.score.composite,
+            self.score.bonus_rank,
+            c.raw_distance,
+            c.src_parent_id,
+            c.dangle_oid,
+            c.near_fc_key,
+            c.near_fid,
+        )
 
 
 @dataclass(frozen=True)
 class _ConnectionProposal:
     """Stage-A candidate; Z normalized within its pair_key group."""
-    ctx:           "_CandidateContext"
-    dangle_norm_z: Optional[float]   # carried from _DangleProposal.score.norm_z
-    score:         "_ProposalScore"  # score.norm_z = connection_norm_z
+
+    ctx: "_CandidateContext"
+    dangle_norm_z: Optional[float]  # carried from _DangleProposal.score.norm_z
+    score: "_ProposalScore"  # score.norm_z = connection_norm_z
 
     @classmethod
     def from_dangle(
@@ -782,29 +802,48 @@ class _ConnectionProposal:
 
     def sort_key(self) -> tuple:
         c = self.ctx
-        return (self.score.composite, self.score.bonus_rank,
-                c.raw_distance, c.src_parent_id, c.dangle_oid, c.near_fc_key, c.near_fid)
+        return (
+            self.score.composite,
+            self.score.bonus_rank,
+            c.raw_distance,
+            c.src_parent_id,
+            c.dangle_oid,
+            c.near_fc_key,
+            c.near_fid,
+        )
 
 
 @dataclass(frozen=True)
 class _GlobalProposal:
     """Stage-B candidate; Z normalized across all Stage-A winners."""
-    ctx:            "_CandidateContext"
-    dangle_norm_z:  Optional[float]
+
+    ctx: "_CandidateContext"
+    dangle_norm_z: Optional[float]
     connection_norm_z: Optional[float]
-    score:          "_ProposalScore"  # score.norm_z = global_norm_z
+    score: "_ProposalScore"  # score.norm_z = global_norm_z
 
     @classmethod
     def from_network(
         cls, n: "_ConnectionProposal", score: "_ProposalScore"
     ) -> "_GlobalProposal":
-        return cls(ctx=n.ctx, dangle_norm_z=n.dangle_norm_z,
-                   connection_norm_z=n.score.norm_z, score=score)
+        return cls(
+            ctx=n.ctx,
+            dangle_norm_z=n.dangle_norm_z,
+            connection_norm_z=n.score.norm_z,
+            score=score,
+        )
 
     def sort_key(self) -> tuple:
         c = self.ctx
-        return (self.score.composite, self.score.bonus_rank,
-                c.raw_distance, c.src_parent_id, c.dangle_oid, c.near_fc_key, c.near_fid)
+        return (
+            self.score.composite,
+            self.score.bonus_rank,
+            c.raw_distance,
+            c.src_parent_id,
+            c.dangle_oid,
+            c.near_fc_key,
+            c.near_fid,
+        )
 
 
 @dataclass(frozen=True)
@@ -819,7 +858,7 @@ class _ResnappedCapture:
 
     parent_id: int
     dangle_oid: int
-    forced_target_parent: int   # target_parent_id of the accepted connection
+    forced_target_parent: int  # target_parent_id of the accepted connection
     proposal: "_GlobalProposal"
     gap_source: str
 
@@ -877,35 +916,63 @@ class CandidateDiagnostic:
     near_x: float
     near_y: float
     raw_distance: float
-    candidate_status: str           # see class docstring
-    status_reason: Optional[str]    # see class docstring; None only for rare edge cases
+    candidate_status: str  # see class docstring
+    status_reason: Optional[str]  # see class docstring; None only for rare edge cases
     best_fit_score: Optional[float]
-    best_fit_rank: Optional[int]    # 1 = local dangle winner; higher = lower-ranked legal
+    best_fit_rank: Optional[int]  # 1 = local dangle winner; higher = lower-ranked legal
     bonus_applied: Optional[bool]
     assess: Optional[AngleAssessment]
     target_parent_id: Optional[int]
-    final_gap_source: Optional[str] # gap_source value for applied_to_output rows; None otherwise
-    start_z:         Optional[float] = None  # Z at the dangle point (candidate start); None when no rasters
-    end_z:           Optional[float] = None  # Z at the near point (candidate end); None when no rasters
-    dangle_norm_z:   Optional[float] = None  # Z normalized within dangle candidate set; None for illegals
-    connection_norm_z:  Optional[float] = None  # Z normalized within pair_key group; None for illegals/deferred
-    global_norm_z:   Optional[float] = None  # Z normalized across all Stage-A winners; None unless Stage-B reached
+    final_gap_source: Optional[
+        str
+    ]  # gap_source value for applied_to_output rows; None otherwise
+    start_z: Optional[float] = (
+        None  # Z at the dangle point (candidate start); None when no rasters
+    )
+    end_z: Optional[float] = (
+        None  # Z at the near point (candidate end); None when no rasters
+    )
+    dangle_norm_z: Optional[float] = (
+        None  # Z normalized within dangle candidate set; None for illegals
+    )
+    connection_norm_z: Optional[float] = (
+        None  # Z normalized within pair_key group; None for illegals/deferred
+    )
+    global_norm_z: Optional[float] = (
+        None  # Z normalized across all Stage-A winners; None unless Stage-B reached
+    )
 
 
 # ---------------------------------------------------------------------------
 # Pipeline type aliases
 # ---------------------------------------------------------------------------
-_DangleXYsByParent:    TypeAlias = dict[int, list[tuple[float, float]]]
-_IllegalTargets:       TypeAlias = dict[int, dict[str, set[int]]]
-_CandRow:              TypeAlias = dict[str, Any]
-_Grouped:              TypeAlias = dict[int, list[_CandRow]]
-_NormZByDangle:        TypeAlias = dict[int, Optional[float]]
+_DangleXYsByParent: TypeAlias = dict[int, list[tuple[float, float]]]
+_IllegalTargets: TypeAlias = dict[int, dict[str, set[int]]]
+_CandRow: TypeAlias = dict[str, Any]
+_Grouped: TypeAlias = dict[int, list[_CandRow]]
+_NormZByDangle: TypeAlias = dict[int, Optional[float]]
 _ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, str]
-_GlobalWithSource:     TypeAlias = tuple[_GlobalProposal, str]
+_GlobalWithSource: TypeAlias = tuple[_GlobalProposal, str]
 # Diagnostic collection tuples (produced in _select_dangle_proposals, consumed in _assemble_diagnostics)
-_Step1AIllegalEntry:   TypeAlias = tuple[int, int, _CandRow, str]
-_Step1BIllegalEntry:   TypeAlias = tuple[int, int, _CandRow, AngleAssessment, str, Optional[float], Optional[float]]
-_Step1BScoredEntry:    TypeAlias = tuple[int, int, _CandRow, AngleAssessment, float, float, bool, bool, tuple[float, int, float], Optional[float], Optional[float], Optional[float]]
+_Step1AIllegalEntry: TypeAlias = tuple[int, int, _CandRow, str]
+_Step1BIllegalEntry: TypeAlias = tuple[
+    int, int, _CandRow, AngleAssessment, str, Optional[float], Optional[float]
+]
+_Step1BScoredEntry: TypeAlias = tuple[
+    int,
+    int,
+    _CandRow,
+    AngleAssessment,
+    float,
+    float,
+    bool,
+    bool,
+    tuple[float, int, float],
+    Optional[float],
+    Optional[float],
+    Optional[float],
+]
+
 
 class FillLineGaps:
     ORIGINAL_ID = "line_gap_original_id"
@@ -1015,8 +1082,12 @@ class FillLineGaps:
         )
         self._raster_handles: list[geometry_tools.RasterHandle] = []
 
+        self.reject_crossing_connectors: bool = bool(adv.reject_crossing_connectors)
+        self.crossing_check_spatial_reference = adv.crossing_check_spatial_reference
+
         if (
-            self.source_direction_mode == logic_config.SourceDirectionMode.RASTER_DERIVED
+            self.source_direction_mode
+            == logic_config.SourceDirectionMode.RASTER_DERIVED
             and not self.raster_paths
         ):
             raise ValueError(
@@ -1783,6 +1854,199 @@ class FillLineGaps:
         return start_oids
 
     # ----------------------------
+    # Connector crossing check helpers
+    # ----------------------------
+
+    def _build_trimmed_connector(
+        self,
+        *,
+        from_x: float,
+        from_y: float,
+        to_x: float,
+        to_y: float,
+        trim_distance: float,
+        spatial_reference: Any,
+    ) -> Any:
+        """
+        Returns a connector polyline with trim_distance removed from each endpoint.
+
+        Returns None if the connector is too short to survive trimming (i.e.
+        2 * trim_distance >= full length).  The returned geometry is a temporary
+        check artifact only; it is never written to output.
+        """
+        full = arcpy.Polyline(
+            arcpy.Array([arcpy.Point(from_x, from_y), arcpy.Point(to_x, to_y)]),
+            spatial_reference,
+        )
+        length = float(full.length)
+        if length <= 2.0 * trim_distance:
+            return None
+        start_pt = full.positionAlongLine(trim_distance)
+        end_pt = full.positionAlongLine(length - trim_distance)
+        return arcpy.Polyline(
+            arcpy.Array([start_pt.firstPoint, end_pt.firstPoint]),
+            spatial_reference,
+        )
+
+    @staticmethod
+    def _connector_intersects_any(
+        trimmed_connector: Any,
+        geom_with_extents: list[tuple[Any, Any]],
+    ) -> bool:
+        """
+        Returns True if trimmed_connector intersects any geometry in the list.
+
+        Caller must pre-trim the connector so that legitimate endpoint touches
+        are excluded before calling this method.
+
+        Each element of geom_with_extents is (geometry, geometry.extent).
+        The extent is used as a cheap bounding-box pre-filter so that the
+        expensive .disjoint() call is only made when envelopes actually overlap.
+        """
+        conn_ext = trimmed_connector.extent
+        cx_min = conn_ext.XMin
+        cx_max = conn_ext.XMax
+        cy_min = conn_ext.YMin
+        cy_max = conn_ext.YMax
+        for geom, ext in geom_with_extents:
+            if cx_max < ext.XMin or cx_min > ext.XMax:
+                continue
+            if cy_max < ext.YMin or cy_min > ext.YMax:
+                continue
+            if not trimmed_connector.disjoint(geom):
+                return True
+        return False
+
+    def _collect_spatially_selected_geometries(
+        self,
+        *,
+        trimmed_geoms: list[Any],
+        check_feature_layers: list[str],
+        spatial_reference: Any,
+    ) -> list[tuple[Any, Any]]:
+        """
+        Writes trimmed_geoms to a temporary in-memory FC, then for each layer in
+        check_feature_layers runs SelectLayerByLocation (INTERSECT) to collect only
+        those features that intersect at least one trimmed connector.
+
+        Returns a list of (geometry, extent) pairs ready for _connector_intersects_any.
+        The temporary FC and feature layers are deleted before returning.
+        """
+        _temp_fc = "memory/crossing_check_trimmed_cands"
+        if arcpy.Exists(_temp_fc):
+            arcpy.management.Delete(_temp_fc)
+        arcpy.management.CreateFeatureclass(
+            "memory", "crossing_check_trimmed_cands", "POLYLINE",
+            spatial_reference=spatial_reference,
+        )
+        with arcpy.da.InsertCursor(_temp_fc, ["SHAPE@"]) as ins:
+            for geom in trimmed_geoms:
+                ins.insertRow((geom,))
+
+        result: list[tuple[Any, Any]] = []
+        try:
+            for check_lyr in check_feature_layers:
+                _temp_lyr = "crossing_check_sel_lyr"
+                arcpy.management.MakeFeatureLayer(check_lyr, _temp_lyr)
+                try:
+                    arcpy.management.SelectLayerByLocation(
+                        _temp_lyr,
+                        "INTERSECT",
+                        _temp_fc,
+                        selection_type="NEW_SELECTION",
+                    )
+                    with arcpy.da.SearchCursor(_temp_lyr, ["SHAPE@"]) as cur:
+                        for (geom,) in cur:
+                            if geom is not None:
+                                result.append((geom, geom.extent))
+                finally:
+                    arcpy.management.Delete(_temp_lyr)
+        finally:
+            arcpy.management.Delete(_temp_fc)
+
+        return result
+
+    def _find_crossing_conflict_keys(
+        self,
+        *,
+        grouped: "_Grouped",
+        dangle_xy: dict[int, tuple[float, float]],
+        check_feature_layers: list[str],
+        trim_distance: float,
+        spatial_reference: Any,
+    ) -> tuple[set[tuple[int, str, int]], dict[tuple[int, str, int], Any]]:
+        """
+        Pre-filter: identify candidates whose connector crosses an existing feature.
+
+        Step 1 – builds trimmed connector geometries for all candidates and
+                 populates trimmed_cache.
+        Step 2 – delegates to _collect_spatially_selected_geometries to reduce
+                 each check layer to only those features that intersect at least
+                 one trimmed candidate (single arcpy spatial-index batch call per
+                 layer instead of O(candidates × features) Python geometry calls).
+        Step 3 – per-candidate intersection check against the reduced set.
+
+        Returns:
+          crossing_conflict_keys
+            (dangle_oid, near_fc_key, near_fid) tuples whose trimmed connector
+            intersects at least one check geometry.
+          trimmed_cache
+            Trimmed connector polyline for every candidate key (None when the
+            connector is too short to trim).  Cached here so Kruskal's crossing
+            check can reuse the geometries without re-trimming.
+        """
+        # --- Step 1: build trimmed cache ---
+        trimmed_cache: dict[tuple[int, str, int], Any] = {}
+        trimmed_geoms: list[Any] = []
+
+        for dangle_oid, candidates in grouped.items():
+            dangle_oid = int(dangle_oid)
+            xy = dangle_xy.get(dangle_oid)
+            if xy is None:
+                continue
+            from_x, from_y = xy
+
+            for cand in candidates:
+                near_fc_key = str(cand["near_fc_key"])
+                near_fid = int(cand["near_fid"])
+                key = (dangle_oid, near_fc_key, near_fid)
+
+                trimmed = self._build_trimmed_connector(
+                    from_x=from_x,
+                    from_y=from_y,
+                    to_x=float(cand["near_x"]),
+                    to_y=float(cand["near_y"]),
+                    trim_distance=trim_distance,
+                    spatial_reference=spatial_reference,
+                )
+                trimmed_cache[key] = trimmed
+                if trimmed is not None:
+                    trimmed_geoms.append(trimmed)
+
+        if not trimmed_geoms or not check_feature_layers:
+            return set(), trimmed_cache
+
+        # --- Step 2: spatially-select check features ---
+        check_geoms_with_extents = self._collect_spatially_selected_geometries(
+            trimmed_geoms=trimmed_geoms,
+            check_feature_layers=check_feature_layers,
+            spatial_reference=spatial_reference,
+        )
+
+        if not check_geoms_with_extents:
+            return set(), trimmed_cache
+
+        # --- Step 3: per-candidate intersection check against the reduced set ---
+        conflict_keys: set[tuple[int, str, int]] = set()
+        for key, trimmed in trimmed_cache.items():
+            if trimmed is None:
+                continue
+            if self._connector_intersects_any(trimmed, check_geoms_with_extents):
+                conflict_keys.add(key)
+
+        return conflict_keys, trimmed_cache
+
+    # ----------------------------
     # Illegal targets detection
     # ----------------------------
 
@@ -2193,7 +2457,9 @@ class FillLineGaps:
 
         # Line-like targets (self-lines and connect_to_features polylines) use the
         # expanded tolerance so true-dangle connections beyond base_tol are reachable.
-        effective_tol = dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
+        effective_tol = (
+            dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
+        )
         if dist > float(effective_tol):
             return False
 
@@ -2259,11 +2525,17 @@ class FillLineGaps:
                 return "illegal_target"
             return "illegal_target"
 
-        effective_tol = dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
+        effective_tol = (
+            dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
+        )
         if dist > float(effective_tol):
             return "beyond_distance_tolerance"
-        if topology is not None and ds_key == lines_fc_key and self._same_network(
-            a_parent=int(parent_id), b_parent=int(oid), topology=topology
+        if (
+            topology is not None
+            and ds_key == lines_fc_key
+            and self._same_network(
+                a_parent=int(parent_id), b_parent=int(oid), topology=topology
+            )
         ):
             return "same_network"
         if self._is_illegal(
@@ -2455,7 +2727,8 @@ class FillLineGaps:
 
             src_poly_for_norm = polyline_by_parent.get(int(src_parent_id))
             _is_directional = (
-                self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
+                self.source_direction_mode
+                != logic_config.SourceDirectionMode.UNDIRECTED
             )
             _endpoint_snap = _is_dangle_pair or _is_dangle_parent_line
             # In directional mode: always use raw forward direction (no flip).
@@ -2475,7 +2748,10 @@ class FillLineGaps:
             # direction of the target line at the snap point. The source exits toward the gap;
             # the target should flow in the same direction for a good match — flipping would
             # collapse the score to 0° for both dangles regardless of their relative orientation.
-            if self.source_direction_mode == logic_config.SourceDirectionMode.UNDIRECTED:
+            if (
+                self.source_direction_mode
+                == logic_config.SourceDirectionMode.UNDIRECTED
+            ):
                 _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
                 _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
                 if not self._xy_is_at_line_start(tgt_poly, _tgt_snap_x, _tgt_snap_y):
@@ -2514,7 +2790,9 @@ class FillLineGaps:
                 _snap_y = float(ty) if _is_dangle_pair else float(near_y)
                 _src_is_end = (
                     src_poly_for_norm is not None
-                    and not self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y)
+                    and not self._xy_is_at_line_start(
+                        src_poly_for_norm, dangle_x, dangle_y
+                    )
                 )
                 _tgt_is_start = self._xy_is_at_line_start(tgt_poly, _snap_x, _snap_y)
                 if _src_is_end and _tgt_is_start:
@@ -2766,7 +3044,13 @@ class FillLineGaps:
 
     def _build_plan(
         self, *, dangles_fc: str, target_layers: list[str]
-    ) -> tuple[dict[int, list[dict]], list[_ResnappedCapture], list[CandidateDiagnostic]]:
+    ) -> tuple[
+        dict[int, list[dict]],
+        list["_ResnappedCapture"],
+        list["CandidateDiagnostic"],
+        list[Any],   # accepted_connector_geoms  (for resnap crossing re-check)
+        dict[int, int],  # kruskal_rank_by_dangle_oid (for resnap crossing re-check)
+    ]:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
@@ -2828,7 +3112,7 @@ class FillLineGaps:
         )
 
         if not grouped:
-            return {}, {}, []
+            return {}, [], [], [], {}
 
         collect_diags = self.candidate_connections_output is not None
 
@@ -2876,6 +3160,37 @@ class FillLineGaps:
         if self.fill_gaps_on_self:
             line_like_ds_keys.add(lines_key)
 
+        # ----------------------------
+        # Crossing conflict pre-filter (Step 1a)
+        # Build trimmed connector geometries for all candidates and flag any
+        # that cross an existing feature (self-lines + connect_to_features).
+        # The trimmed connector cache is reused in _run_kruskal.
+        # ----------------------------
+        crossing_conflict_keys: set[tuple[int, str, int]] = set()
+        trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
+
+        if self.reject_crossing_connectors:
+            _crossing_sr = arcpy.SpatialReference(
+                self.crossing_check_spatial_reference
+            )
+            # lines_copy provides self-line geometries (source of polyline_by_parent).
+            # External layers whose ds_key is in polyline_by_external are polyline
+            # features that were loaded as angle caches; pass their layer paths so
+            # _find_crossing_conflict_keys can run SelectLayerByLocation on them.
+            _check_layers: list[str] = [self.lines_copy]
+            for _lyr in target_layers:
+                if self._dataset_key(_lyr) in polyline_by_external:
+                    _check_layers.append(_lyr)
+            crossing_conflict_keys, trimmed_connector_cache = (
+                self._find_crossing_conflict_keys(
+                    grouped=grouped,
+                    dangle_xy=dangle_xy,
+                    check_feature_layers=_check_layers,
+                    trim_distance=float(self.connectivity_tolerance_meters),
+                    spatial_reference=_crossing_sr,
+                )
+            )
+
         # In directed mode, source dangles at a line's start node are invalid sources.
         # polyline_by_parent is already built above; dangle_xy was built at the top.
         directed_start_dangles = self._directed_start_dangle_oids(
@@ -2900,26 +3215,34 @@ class FillLineGaps:
                 topology=topology,
                 collect_diags=collect_diags,
                 directed_source_illegal_oids=directed_start_dangles,
+                crossing_conflict_keys=crossing_conflict_keys,
             )
         )
 
         if not legal_rows_by_dangle:
-            return {}, {}, self._assemble_diagnostics(
-                collect_diags=collect_diags,
-                step1a_illegal=_step1a_illegal,
-                step1b_illegal=[],
-                step1b_scored=[],
-                connection_loser_oids=set(),
-                kruskal_rejected_oids=set(),
-                accepted_dangle_oids=set(),
-                gap_source_by_dangle={},
-                dangle_norm_z_by_dangle={},
-                connection_norm_z_by_dangle={},
-                global_norm_z_by_dangle={},
-                dangle_xy=dangle_xy,
-                dangle_parent=dangle_parent,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
+            return (
+                {},
+                [],
+                self._assemble_diagnostics(
+                    collect_diags=collect_diags,
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=[],
+                    step1b_scored=[],
+                    connection_loser_oids=set(),
+                    kruskal_rejected_oids=set(),
+                    kruskal_crossing_rejected_oids=set(),
+                    accepted_dangle_oids=set(),
+                    gap_source_by_dangle={},
+                    dangle_norm_z_by_dangle={},
+                    connection_norm_z_by_dangle={},
+                    global_norm_z_by_dangle={},
+                    dangle_xy=dangle_xy,
+                    dangle_parent=dangle_parent,
+                    dangles_key=dangles_key,
+                    lines_key=lines_key,
+                ),
+                [],
+                {},
             )
 
         # ----------------------------
@@ -3009,22 +3332,29 @@ class FillLineGaps:
         )
 
         if not _dangle_proposals:
-            return {}, [], self._assemble_diagnostics(
-                collect_diags=collect_diags,
-                step1a_illegal=_step1a_illegal,
-                step1b_illegal=_step1b_illegal,
-                step1b_scored=_step1b_scored,
-                connection_loser_oids=set(),
-                kruskal_rejected_oids=set(),
-                accepted_dangle_oids=set(),
-                gap_source_by_dangle={},
-                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                connection_norm_z_by_dangle={},
-                global_norm_z_by_dangle={},
-                dangle_xy=dangle_xy,
-                dangle_parent=dangle_parent,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
+            return (
+                {},
+                [],
+                self._assemble_diagnostics(
+                    collect_diags=collect_diags,
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    connection_loser_oids=set(),
+                    kruskal_rejected_oids=set(),
+                    kruskal_crossing_rejected_oids=set(),
+                    accepted_dangle_oids=set(),
+                    gap_source_by_dangle={},
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                    connection_norm_z_by_dangle={},
+                    global_norm_z_by_dangle={},
+                    dangle_xy=dangle_xy,
+                    dangle_parent=dangle_parent,
+                    dangles_key=dangles_key,
+                    lines_key=lines_key,
+                ),
+                [],
+                {},
             )
 
         # ----------------------------
@@ -3034,22 +3364,29 @@ class FillLineGaps:
         # ----------------------------
         active: list[_DangleProposal] = list(_dangle_proposals.values())
         if not active:
-            return {}, [], self._assemble_diagnostics(
-                collect_diags=collect_diags,
-                step1a_illegal=_step1a_illegal,
-                step1b_illegal=_step1b_illegal,
-                step1b_scored=_step1b_scored,
-                connection_loser_oids=set(),
-                kruskal_rejected_oids=set(),
-                accepted_dangle_oids=set(),
-                gap_source_by_dangle={},
-                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                connection_norm_z_by_dangle={},
-                global_norm_z_by_dangle={},
-                dangle_xy=dangle_xy,
-                dangle_parent=dangle_parent,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
+            return (
+                {},
+                [],
+                self._assemble_diagnostics(
+                    collect_diags=collect_diags,
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    connection_loser_oids=set(),
+                    kruskal_rejected_oids=set(),
+                    kruskal_crossing_rejected_oids=set(),
+                    accepted_dangle_oids=set(),
+                    gap_source_by_dangle={},
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                    connection_norm_z_by_dangle={},
+                    global_norm_z_by_dangle={},
+                    dangle_xy=dangle_xy,
+                    dangle_parent=dangle_parent,
+                    dangles_key=dangles_key,
+                    lines_key=lines_key,
+                ),
+                [],
+                {},
             )
         active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
 
@@ -3095,31 +3432,50 @@ class FillLineGaps:
         # ----------------------------
         # Global selection: Kruskal cycle prevention across accepted connections
         # ----------------------------
-        _global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle = (
-            self._run_kruskal(
-                global_winners=_global_winners,
-                topology=topology,
-                collect_diags=collect_diags,
-            )
+        (
+            _global_proposals,
+            accepted_dangle_oids,
+            kruskal_rejected_oids,
+            kruskal_crossing_rejected_oids,
+            gap_source_by_dangle,
+            accepted_connector_geoms,
+            kruskal_rank_by_dangle_oid,
+        ) = self._run_kruskal(
+            global_winners=_global_winners,
+            topology=topology,
+            collect_diags=collect_diags,
+            trimmed_connector_cache=trimmed_connector_cache,
+            crossing_spatial_reference=(
+                arcpy.SpatialReference(self.crossing_check_spatial_reference)
+                if self.reject_crossing_connectors
+                else None
+            ),
         )
 
         if not _global_proposals:
-            return {}, [], self._assemble_diagnostics(
-                collect_diags=collect_diags,
-                step1a_illegal=_step1a_illegal,
-                step1b_illegal=_step1b_illegal,
-                step1b_scored=_step1b_scored,
-                connection_loser_oids=connection_loser_oids,
-                kruskal_rejected_oids=kruskal_rejected_oids,
-                accepted_dangle_oids=accepted_dangle_oids,
-                gap_source_by_dangle=gap_source_by_dangle,
-                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-                global_norm_z_by_dangle=global_norm_z_by_dangle,
-                dangle_xy=dangle_xy,
-                dangle_parent=dangle_parent,
-                dangles_key=dangles_key,
-                lines_key=lines_key,
+            return (
+                {},
+                [],
+                self._assemble_diagnostics(
+                    collect_diags=collect_diags,
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    connection_loser_oids=connection_loser_oids,
+                    kruskal_rejected_oids=kruskal_rejected_oids,
+                    kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
+                    accepted_dangle_oids=accepted_dangle_oids,
+                    gap_source_by_dangle=gap_source_by_dangle,
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                    connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+                    global_norm_z_by_dangle=global_norm_z_by_dangle,
+                    dangle_xy=dangle_xy,
+                    dangle_parent=dangle_parent,
+                    dangles_key=dangles_key,
+                    lines_key=lines_key,
+                ),
+                [],
+                {},
             )
 
         # ----------------------------
@@ -3132,22 +3488,29 @@ class FillLineGaps:
         # ----------------------------
         plan_by_parent = self._assemble_plan_entries(_global_proposals)
 
-        return plan_by_parent, resnap_captures, self._assemble_diagnostics(
-            collect_diags=collect_diags,
-            step1a_illegal=_step1a_illegal,
-            step1b_illegal=_step1b_illegal,
-            step1b_scored=_step1b_scored,
-            connection_loser_oids=connection_loser_oids,
-            kruskal_rejected_oids=kruskal_rejected_oids,
-            accepted_dangle_oids=accepted_dangle_oids,
-            gap_source_by_dangle=gap_source_by_dangle,
-            dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-            connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-            global_norm_z_by_dangle=global_norm_z_by_dangle,
-            dangle_xy=dangle_xy,
-            dangle_parent=dangle_parent,
-            dangles_key=dangles_key,
-            lines_key=lines_key,
+        return (
+            plan_by_parent,
+            resnap_captures,
+            self._assemble_diagnostics(
+                collect_diags=collect_diags,
+                step1a_illegal=_step1a_illegal,
+                step1b_illegal=_step1b_illegal,
+                step1b_scored=_step1b_scored,
+                connection_loser_oids=connection_loser_oids,
+                kruskal_rejected_oids=kruskal_rejected_oids,
+                kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
+                accepted_dangle_oids=accepted_dangle_oids,
+                gap_source_by_dangle=gap_source_by_dangle,
+                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+                global_norm_z_by_dangle=global_norm_z_by_dangle,
+                dangle_xy=dangle_xy,
+                dangle_parent=dangle_parent,
+                dangles_key=dangles_key,
+                lines_key=lines_key,
+            ),
+            accepted_connector_geoms,
+            kruskal_rank_by_dangle_oid,
         )
 
     def _filter_legal_candidates(
@@ -3164,6 +3527,7 @@ class FillLineGaps:
         topology: TopologyModel,
         collect_diags: bool,
         directed_source_illegal_oids: set[int],
+        crossing_conflict_keys: set[tuple[int, str, int]],
     ) -> tuple[_Grouped, dict[int, int], list[_Step1AIllegalEntry]]:
         """Dangle filtering: collect legal candidates per dangle.
 
@@ -3187,10 +3551,9 @@ class FillLineGaps:
             if dangle_oid in directed_source_illegal_oids:
                 if collect_diags:
                     for cand in candidates:
-                        if (
-                            str(cand["near_fc_key"]) == str(lines_key)
-                            and int(cand["near_fid"]) == int(parent_id)
-                        ):
+                        if str(cand["near_fc_key"]) == str(lines_key) and int(
+                            cand["near_fid"]
+                        ) == int(parent_id):
                             continue
                         _step1a_illegal.append(
                             (dangle_oid, parent_id, cand, "directed_start_node")
@@ -3202,10 +3565,18 @@ class FillLineGaps:
             legal_rows: list[dict] = []
             for cand in rows:
                 # Self-parent candidates are excluded from the plan and from diagnostics.
-                if (
-                    str(cand["near_fc_key"]) == str(lines_key)
-                    and int(cand["near_fid"]) == int(parent_id)
-                ):
+                if str(cand["near_fc_key"]) == str(lines_key) and int(
+                    cand["near_fid"]
+                ) == int(parent_id):
+                    continue
+
+                # Candidate whose connector crosses an existing feature is illegal.
+                cand_key = (dangle_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))
+                if cand_key in crossing_conflict_keys:
+                    if collect_diags:
+                        _step1a_illegal.append(
+                            (dangle_oid, parent_id, cand, "crosses_existing_feature")
+                        )
                     continue
 
                 is_legal = self._candidate_is_legal(
@@ -3328,7 +3699,9 @@ class FillLineGaps:
                     end_z_by_cand_index[_i] = _ez
 
                 if float(self.best_fit_weights.z) > 0.0:
-                    _valid_z = [z for z in end_z_by_cand_index.values() if z is not None]
+                    _valid_z = [
+                        z for z in end_z_by_cand_index.values() if z is not None
+                    ]
                     if _valid_z:
                         z_score_min = min(_valid_z)
                         z_score_max = max(_valid_z)
@@ -3368,8 +3741,15 @@ class FillLineGaps:
                 if assess.blocks:
                     if collect_diags:
                         _step1b_illegal.append(
-                            (dangle_oid, parent_id, cand, assess, "blocked_by_angle",
-                             start_z, _cand_end_z)
+                            (
+                                dangle_oid,
+                                parent_id,
+                                cand,
+                                assess,
+                                "blocked_by_angle",
+                                start_z,
+                                _cand_end_z,
+                            )
                         )
                     continue
 
@@ -3388,9 +3768,15 @@ class FillLineGaps:
                     # Candidate is only legal due to expanded tolerance; angle disallows it
                     if collect_diags:
                         _step1b_illegal.append(
-                            (dangle_oid, parent_id, cand, assess,
-                             "expanded_dangle_angle_disallowed",
-                             start_z, _cand_end_z)
+                            (
+                                dangle_oid,
+                                parent_id,
+                                cand,
+                                assess,
+                                "expanded_dangle_angle_disallowed",
+                                start_z,
+                                _cand_end_z,
+                            )
                         )
                     continue
 
@@ -3405,12 +3791,21 @@ class FillLineGaps:
                             float(cand["near_y"]),
                         )
                     )
-                    if _end_z_gate is not None and (_end_z_gate - start_z) > self.z_drop_threshold:
+                    if (
+                        _end_z_gate is not None
+                        and (_end_z_gate - start_z) > self.z_drop_threshold
+                    ):
                         if collect_diags:
                             _step1b_illegal.append(
-                                (dangle_oid, parent_id, cand, assess,
-                                 "blocked_by_z_drop",
-                                 start_z, _cand_end_z)
+                                (
+                                    dangle_oid,
+                                    parent_id,
+                                    cand,
+                                    assess,
+                                    "blocked_by_z_drop",
+                                    start_z,
+                                    _cand_end_z,
+                                )
                             )
                         continue
 
@@ -3447,7 +3842,7 @@ class FillLineGaps:
                         if z_score_max > z_score_min:
                             _norm_z = (_ez - z_score_min) / (z_score_max - z_score_min)
                         else:
-                            _norm_z = None   # flat range: Z cannot discriminate
+                            _norm_z = None  # flat range: Z cannot discriminate
 
                 effective_for_scoring = self._compute_best_fit_score(
                     norm_dist=_eff_norm_dist,
@@ -3478,7 +3873,7 @@ class FillLineGaps:
                         bool(bonus_applied),
                         assess,
                         _norm_z,
-                        end_z_by_cand_index.get(_cand_idx),   # per-candidate end_z
+                        end_z_by_cand_index.get(_cand_idx),  # per-candidate end_z
                     )
                 )
 
@@ -3502,21 +3897,36 @@ class FillLineGaps:
 
             if collect_diags:
                 for sc_tuple in scored_candidates:
-                    sc_score, sc_cand, sc_raw, sc_best_fit, sc_bonus, sc_assess, sc_norm_z, sc_end_z = sc_tuple
-                    _step1b_scored.append((
-                        dangle_oid,
-                        parent_id,
+                    (
+                        sc_score,
                         sc_cand,
+                        sc_raw,
+                        sc_best_fit,
+                        sc_bonus,
                         sc_assess,
-                        float(sc_raw),
-                        float(sc_best_fit),
-                        bool(sc_bonus),
-                        sc_tuple is winner_item,
-                        (sc_score.composite, sc_score.bonus_rank, sc_raw),  # for per-dangle rank
-                        sc_norm_z,               # dangle_norm_z for this candidate
-                        start_z,                 # fixed per dangle
-                        sc_end_z,                # per-candidate end_z
-                    ))
+                        sc_norm_z,
+                        sc_end_z,
+                    ) = sc_tuple
+                    _step1b_scored.append(
+                        (
+                            dangle_oid,
+                            parent_id,
+                            sc_cand,
+                            sc_assess,
+                            float(sc_raw),
+                            float(sc_best_fit),
+                            bool(sc_bonus),
+                            sc_tuple is winner_item,
+                            (
+                                sc_score.composite,
+                                sc_score.bonus_rank,
+                                sc_raw,
+                            ),  # for per-dangle rank
+                            sc_norm_z,  # dangle_norm_z for this candidate
+                            start_z,  # fixed per dangle
+                            sc_end_z,  # per-candidate end_z
+                        )
+                    )
 
             # ----------------------------
             # _DangleProposal construction
@@ -3578,10 +3988,17 @@ class FillLineGaps:
                 assess=chosen_assess,
             )
 
-            _dangle_proposals[dangle_oid] = _DangleProposal(ctx=ctx, score=winner_dangle_score)
+            _dangle_proposals[dangle_oid] = _DangleProposal(
+                ctx=ctx, score=winner_dangle_score
+            )
             dangle_norm_z_by_dangle[dangle_oid] = winner_norm_z
 
-        return _dangle_proposals, dangle_norm_z_by_dangle, _step1b_illegal, _step1b_scored
+        return (
+            _dangle_proposals,
+            dangle_norm_z_by_dangle,
+            _step1b_illegal,
+            _step1b_scored,
+        )
 
     def _run_connection_normalization(
         self,
@@ -3661,7 +4078,9 @@ class FillLineGaps:
 
         connection_loser_oids: set[int] = set()
         if collect_diags:
-            _stage_a_winner_oids = {int(prop.ctx.dangle_oid) for prop, _ in _connection_proposals}
+            _stage_a_winner_oids = {
+                int(prop.ctx.dangle_oid) for prop, _ in _connection_proposals
+            }
             connection_loser_oids.update(
                 int(p.ctx.dangle_oid)
                 for p in connection_proposals_by_dangle.values()
@@ -3706,14 +4125,94 @@ class FillLineGaps:
         global_winners: list[_GlobalWithSource],
         topology: TopologyModel,
         collect_diags: bool,
-    ) -> tuple[list[_GlobalWithSource], set[int], set[int], dict[int, str]]:
+        trimmed_connector_cache: dict[tuple[int, str, int], Any],
+        crossing_spatial_reference: Any,  # arcpy.SpatialReference | None
+    ) -> tuple[
+        list[_GlobalWithSource],
+        set[int],         # accepted_dangle_oids
+        set[int],         # kruskal_rejected_oids (cycle-based)
+        set[int],         # kruskal_crossing_rejected_oids
+        dict[int, str],   # gap_source_by_dangle
+        list[Any],        # accepted_connector_geoms (original untrimmed, for resnap re-check)
+        dict[int, int],   # kruskal_rank_by_dangle_oid
+    ]:
         """Global selection: Kruskal cycle prevention across accepted connections.
 
-        Returns (_global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle).
+        Candidates are processed in score order (best first).  Two rejection
+        reasons exist:
+          - Cycle rejection: UF finds src_node and tgt_node already in the same
+            component (reason: lost_kruskal_selection).
+          - Crossing rejection (when reject_crossing_connectors is True): the
+            candidate's trimmed connector intersects the original geometry of an
+            already-accepted connector (reason: crosses_accepted_connector).
+
+        Crossing check uses trimmed_connector_cache (built in _find_crossing_conflict_keys)
+        to avoid re-trimming.  Accepted connector geometries are stored in
+        original (untrimmed) form because the accepted connectors' full bodies
+        are real output geometry; any intersection of the new trimmed candidate
+        with that body — including endpoints — is a genuine crossing conflict.
+
+        Note on deferred displacement inaccuracy:
+            When a deferred connector's (resnap capture's) final geometry causes
+            a previously accepted connector to be displaced during the resnap
+            re-check (see _recheck_resnap_crossings), the Union-Find state built
+            here becomes stale.  Two consequences follow: (1) components merged
+            by the displaced connector become disconnected in output, and (2)
+            candidates rejected here as cycle-forming may in hindsight have been
+            valid.  Both are accepted inaccuracies — the scenario is rare enough
+            that a full mock-Kruskal + mock-deferred pass to eliminate it is not
+            justified.
+
+        Returns (proposals, accepted_dangle_oids, kruskal_rejected_oids,
+                 kruskal_crossing_rejected_oids, gap_source_by_dangle,
+                 accepted_connector_geoms, kruskal_rank_by_dangle_oid).
         """
+        reject_crossing = crossing_spatial_reference is not None
         scope = topology.scope
         _global_proposals: list[_GlobalWithSource] = []
+        kruskal_crossing_rejected_oids: set[int] = set()
+        # Stores (geometry, extent) pairs so _connector_intersects_any can apply
+        # the bounding-box pre-filter without re-fetching extents each call.
+        accepted_connector_geoms: list[tuple[Any, Any]] = []
+        accepted_connector_dangle_oids: list[int] = []
+        kruskal_rank_by_dangle_oid: dict[int, int] = {}
+        rank_counter = 0
 
+        def _accept(prop: Any, gap_source: Any) -> None:
+            nonlocal rank_counter
+            _global_proposals.append((prop, gap_source))
+            if reject_crossing:
+                rank_counter += 1
+                d_oid = int(prop.ctx.dangle_oid)
+                kruskal_rank_by_dangle_oid[d_oid] = rank_counter
+                accepted_connector_dangle_oids.append(d_oid)
+                geom = arcpy.Polyline(
+                    arcpy.Array(
+                        [
+                            arcpy.Point(
+                                float(prop.ctx.dangle_x), float(prop.ctx.dangle_y)
+                            ),
+                            arcpy.Point(
+                                float(prop.ctx.near_x), float(prop.ctx.near_y)
+                            ),
+                        ]
+                    ),
+                    crossing_spatial_reference,
+                )
+                accepted_connector_geoms.append((geom, geom.extent))
+
+        def _crossing_blocked(prop: Any) -> bool:
+            if not reject_crossing:
+                return False
+            key = (
+                int(prop.ctx.dangle_oid),
+                str(prop.ctx.near_fc_key),
+                int(prop.ctx.near_fid),
+            )
+            trimmed = trimmed_connector_cache.get(key)
+            if trimmed is None:
+                return False
+            return self._connector_intersects_any(trimmed, accepted_connector_geoms)
         if scope in (
             logic_config.ConnectivityScope.INPUT_LINES,
             logic_config.ConnectivityScope.ONE_DEGREE,
@@ -3728,17 +4227,33 @@ class FillLineGaps:
                     self.connect_to_features or [], self.external_target_layers
                 )
             }
-            for (ds_key, oid), cid in (topology.connectivity_id_by_optional or {}).items():
+            for (ds_key, oid), cid in (
+                topology.connectivity_id_by_optional or {}
+            ).items():
                 cand_ds_key = topo_to_cand_ds_key.get(ds_key, ds_key)
-                uf.union(("component", int(cid)), ("optional_candidate", str(cand_ds_key), int(oid)))
-            for prop, gap_source in sorted(global_winners, key=lambda t: t[0].sort_key()):
+                uf.union(
+                    ("component", int(cid)),
+                    ("optional_candidate", str(cand_ds_key), int(oid)),
+                )
+            for prop, gap_source in sorted(
+                global_winners, key=lambda t: t[0].sort_key()
+            ):
                 if uf.find(prop.ctx.src_node) == uf.find(prop.ctx.tgt_node):
                     continue
+                if _crossing_blocked(prop):
+                    kruskal_crossing_rejected_oids.add(int(prop.ctx.dangle_oid))
+                    continue
                 uf.union(prop.ctx.src_node, prop.ctx.tgt_node)
-                _global_proposals.append((prop, gap_source))
+                _accept(prop, gap_source)
         else:
-            # NONE / DIRECT_CONNECTION: only connection selection (already globally normalized)
-            _global_proposals = list(global_winners)
+            # NONE / DIRECT_CONNECTION: no cycle check, crossing check only.
+            for prop, gap_source in sorted(
+                global_winners, key=lambda t: t[0].sort_key()
+            ):
+                if _crossing_blocked(prop):
+                    kruskal_crossing_rejected_oids.add(int(prop.ctx.dangle_oid))
+                    continue
+                _accept(prop, gap_source)
 
         accepted_dangle_oids: set[int] = set()
         kruskal_rejected_oids: set[int] = set()
@@ -3750,12 +4265,21 @@ class FillLineGaps:
                 int(prop.ctx.dangle_oid)
                 for prop, _ in global_winners
                 if int(prop.ctx.dangle_oid) not in _accepted_oids
+                and int(prop.ctx.dangle_oid) not in kruskal_crossing_rejected_oids
             )
             gap_source_by_dangle.update(
                 {int(prop.ctx.dangle_oid): str(gs) for prop, gs in _global_proposals}
             )
 
-        return _global_proposals, accepted_dangle_oids, kruskal_rejected_oids, gap_source_by_dangle
+        return (
+            _global_proposals,
+            accepted_dangle_oids,
+            kruskal_rejected_oids,
+            kruskal_crossing_rejected_oids,
+            gap_source_by_dangle,
+            accepted_connector_geoms,
+            kruskal_rank_by_dangle_oid,
+        )
 
     def _identify_resnap_captures(
         self,
@@ -3780,14 +4304,108 @@ class FillLineGaps:
             tp = prop.ctx.target_parent_id
             if tp is None or int(tp) not in snap_source_parents:
                 continue
-            resnap_captures.append(_ResnappedCapture(
-                parent_id=int(prop.ctx.src_parent_id),
-                dangle_oid=int(prop.ctx.dangle_oid),
-                forced_target_parent=int(tp),
-                proposal=prop,
-                gap_source=str(gap_source),
-            ))
+            resnap_captures.append(
+                _ResnappedCapture(
+                    parent_id=int(prop.ctx.src_parent_id),
+                    dangle_oid=int(prop.ctx.dangle_oid),
+                    forced_target_parent=int(tp),
+                    proposal=prop,
+                    gap_source=str(gap_source),
+                )
+            )
         return resnap_captures
+
+    def _recheck_resnap_crossings(
+        self,
+        *,
+        resnap_plan: dict[int, dict],
+        accepted_connector_geoms: list[Any],
+        kruskal_rank_by_dangle_oid: dict[int, int],
+        trim_distance: float,
+        spatial_reference: Any,
+    ) -> tuple[dict[int, dict], set[int], set[int]]:
+        """Re-check resnap captures against accepted connector geometries.
+
+        Called after _resnap_connections resolves final geometry for deferred
+        connectors.  Uses rank-based conflict resolution:
+
+          - If the resnap capture has a worse (higher) rank than the best-ranked
+            conflicting accepted connector → the resnap capture loses; its plan
+            entry is marked skip=True so the corrected geometry is not applied.
+          - If the resnap capture has a better (lower) rank → it wins; the
+            conflicting connector(s) are flagged as displaced.  Their geometry
+            is already applied to the feature class and is not reverted, so the
+            displacement is recorded in diagnostics only.
+
+        Returns (resnap_plan, resnap_crossing_rejected_oids,
+                 resnap_crossing_displaced_oids).
+        """
+        if not accepted_connector_geoms:
+            return resnap_plan, set(), set()
+
+        # Build reverse lookup: index in accepted_connector_geoms → dangle_oid
+        # (populated alongside accepted_connector_geoms in _run_kruskal)
+        # We recover this from kruskal_rank_by_dangle_oid: rank = index + 1.
+        rank_to_dangle_oid: dict[int, int] = {
+            rank: d_oid for d_oid, rank in kruskal_rank_by_dangle_oid.items()
+        }
+
+        resnap_crossing_rejected_oids: set[int] = set()
+        resnap_crossing_displaced_oids: set[int] = set()
+
+        for parent_id, entry in resnap_plan.items():
+            if entry.get("skip", False):
+                continue
+
+            dangle_oid = int(entry["dangle_oid"])
+            trimmed = self._build_trimmed_connector(
+                from_x=float(entry["dangle_x"]),
+                from_y=float(entry["dangle_y"]),
+                to_x=float(entry["near_x"]),
+                to_y=float(entry["near_y"]),
+                trim_distance=trim_distance,
+                spatial_reference=spatial_reference,
+            )
+            if trimmed is None:
+                continue
+
+            # Find indices of conflicting accepted connectors (extent pre-filter).
+            trimmed_ext = trimmed.extent
+            conflict_indices = [
+                i
+                for i, (geom, ext) in enumerate(accepted_connector_geoms)
+                if not (
+                    trimmed_ext.XMax < ext.XMin or trimmed_ext.XMin > ext.XMax
+                    or trimmed_ext.YMax < ext.YMin or trimmed_ext.YMin > ext.YMax
+                )
+                and not trimmed.disjoint(geom)
+            ]
+            if not conflict_indices:
+                continue
+
+            # Rank of the resnap capture; default to +inf if somehow absent.
+            resnap_rank = kruskal_rank_by_dangle_oid.get(dangle_oid, float("inf"))
+
+            # Best (lowest) rank among conflicting accepted connectors.
+            best_conflict_rank = min(
+                kruskal_rank_by_dangle_oid.get(
+                    rank_to_dangle_oid.get(i + 1, -1), float("inf")
+                )
+                for i in conflict_indices
+            )
+
+            if resnap_rank <= best_conflict_rank:
+                # Resnap capture wins: displace the conflicting accepted connectors.
+                for i in conflict_indices:
+                    conflict_d_oid = rank_to_dangle_oid.get(i + 1)
+                    if conflict_d_oid is not None:
+                        resnap_crossing_displaced_oids.add(conflict_d_oid)
+            else:
+                # Resnap capture loses: skip the corrected-geometry application.
+                entry["skip"] = True
+                resnap_crossing_rejected_oids.add(dangle_oid)
+
+        return resnap_plan, resnap_crossing_rejected_oids, resnap_crossing_displaced_oids
 
     def _assemble_plan_entries(
         self,
@@ -3814,7 +4432,9 @@ class FillLineGaps:
                 best_fit_score=prop.score.composite,
             )
 
-            tmp.setdefault(int(prop.ctx.src_parent_id), []).append((prop.sort_key(), entry))
+            tmp.setdefault(int(prop.ctx.src_parent_id), []).append(
+                (prop.sort_key(), entry)
+            )
 
         plan_by_parent: dict[int, list[dict]] = {}
         for pid, items in tmp.items():
@@ -3835,6 +4455,7 @@ class FillLineGaps:
         step1b_scored: list[_Step1BScoredEntry],
         connection_loser_oids: set[int],
         kruskal_rejected_oids: set[int],
+        kruskal_crossing_rejected_oids: set[int],
         accepted_dangle_oids: set[int],
         gap_source_by_dangle: dict[int, str],
         dangle_norm_z_by_dangle: _NormZByDangle,
@@ -3869,64 +4490,68 @@ class FillLineGaps:
             if xy is None:
                 continue
             _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
-            result.append(CandidateDiagnostic(
-                parent_id=p_id,
-                dangle_oid=d_oid,
-                dangle_x=float(xy[0]),
-                dangle_y=float(xy[1]),
-                near_fc_key=str(cand["near_fc_key"]),
-                near_fid=int(cand["near_fid"]),
-                near_x=float(cand["near_x"]),
-                near_y=float(cand["near_y"]),
-                raw_distance=float(cand["near_dist"]),
-                candidate_status="illegal",
-                status_reason=reason,
-                best_fit_score=None,
-                best_fit_rank=None,
-                bonus_applied=None,
-                assess=None,
-                target_parent_id=self._resolve_target_parent_id(
-                    cand, dangle_parent, dangles_key, lines_key
-                ),
-                final_gap_source=None,
-                start_z=_sz,
-                end_z=_ez,
-                dangle_norm_z=None,
-                connection_norm_z=None,
-                global_norm_z=None,
-            ))
+            result.append(
+                CandidateDiagnostic(
+                    parent_id=p_id,
+                    dangle_oid=d_oid,
+                    dangle_x=float(xy[0]),
+                    dangle_y=float(xy[1]),
+                    near_fc_key=str(cand["near_fc_key"]),
+                    near_fid=int(cand["near_fid"]),
+                    near_x=float(cand["near_x"]),
+                    near_y=float(cand["near_y"]),
+                    raw_distance=float(cand["near_dist"]),
+                    candidate_status="illegal",
+                    status_reason=reason,
+                    best_fit_score=None,
+                    best_fit_rank=None,
+                    bonus_applied=None,
+                    assess=None,
+                    target_parent_id=self._resolve_target_parent_id(
+                        cand, dangle_parent, dangles_key, lines_key
+                    ),
+                    final_gap_source=None,
+                    start_z=_sz,
+                    end_z=_ez,
+                    dangle_norm_z=None,
+                    connection_norm_z=None,
+                    global_norm_z=None,
+                )
+            )
 
         # Step-1B angle-blocked illegals: z values carried in tuple
         for d_oid, p_id, cand, assess, reason, _sz, _ez in step1b_illegal:
             xy = dangle_xy.get(int(d_oid))
             if xy is None:
                 continue
-            result.append(CandidateDiagnostic(
-                parent_id=p_id,
-                dangle_oid=d_oid,
-                dangle_x=float(xy[0]),
-                dangle_y=float(xy[1]),
-                near_fc_key=str(cand["near_fc_key"]),
-                near_fid=int(cand["near_fid"]),
-                near_x=float(cand["near_x"]),
-                near_y=float(cand["near_y"]),
-                raw_distance=float(cand["near_dist"]),
-                candidate_status="illegal",
-                status_reason=reason,
-                best_fit_score=None,
-                best_fit_rank=None,
-                bonus_applied=None,
-                assess=assess,
-                target_parent_id=self._resolve_target_parent_id(
-                    cand, dangle_parent, dangles_key, lines_key
-                ),
-                final_gap_source=None,
-                start_z=_sz,
-                end_z=_ez,
-                dangle_norm_z=None,
-                connection_norm_z=None,
-                global_norm_z=None,
-            ))
+            result.append(
+                CandidateDiagnostic(
+                    parent_id=p_id,
+                    dangle_oid=d_oid,
+                    dangle_x=float(xy[0]),
+                    dangle_y=float(xy[1]),
+                    near_fc_key=str(cand["near_fc_key"]),
+                    near_fid=int(cand["near_fid"]),
+                    near_x=float(cand["near_x"]),
+                    near_y=float(cand["near_y"]),
+                    raw_distance=float(cand["near_dist"]),
+                    candidate_status="illegal",
+                    status_reason=reason,
+                    best_fit_score=None,
+                    best_fit_rank=None,
+                    bonus_applied=None,
+                    assess=assess,
+                    target_parent_id=self._resolve_target_parent_id(
+                        cand, dangle_parent, dangles_key, lines_key
+                    ),
+                    final_gap_source=None,
+                    start_z=_sz,
+                    end_z=_ez,
+                    dangle_norm_z=None,
+                    connection_norm_z=None,
+                    global_norm_z=None,
+                )
+            )
 
         # Compute per-dangle rank for scored candidates (1 = local winner)
         scored_by_dangle: dict[int, list[_Step1BScoredEntry]] = {}
@@ -3934,21 +4559,33 @@ class FillLineGaps:
             scored_by_dangle.setdefault(int(entry[0]), []).append(entry)
         rank_map: dict[tuple[int, str, int], int] = {}
         for d_oid, entries in scored_by_dangle.items():
-            for rank, entry in enumerate(
-                sorted(entries, key=lambda e: e[8]), start=1
-            ):
+            for rank, entry in enumerate(sorted(entries, key=lambda e: e[8]), start=1):
                 cand = entry[2]
-                rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = rank
+                rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = (
+                    rank
+                )
 
         # Step-1B scored candidates; z values carried in tuple
         for (
-            d_oid, p_id, cand, assess, raw_dist, best_fit, bonus,
-            is_local_winner, _score, sc_norm_z, sc_start_z, sc_end_z,
+            d_oid,
+            p_id,
+            cand,
+            assess,
+            raw_dist,
+            best_fit,
+            bonus,
+            is_local_winner,
+            _score,
+            sc_norm_z,
+            sc_start_z,
+            sc_end_z,
         ) in step1b_scored:
             xy = dangle_xy.get(int(d_oid))
             if xy is None:
                 continue
-            rank = rank_map.get((d_oid, str(cand["near_fc_key"]), int(cand["near_fid"])))
+            rank = rank_map.get(
+                (d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))
+            )
 
             if not is_local_winner:
                 status = "legal_not_selected"
@@ -3968,6 +4605,12 @@ class FillLineGaps:
                 final_gs = None
                 conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
                 glob_nz = global_norm_z_by_dangle.get(int(d_oid))
+            elif int(d_oid) in kruskal_crossing_rejected_oids:
+                status = "selected_for_dangle"
+                reason = "crosses_accepted_connector"
+                final_gs = None
+                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
+                glob_nz = global_norm_z_by_dangle.get(int(d_oid))
             elif int(d_oid) in accepted_dangle_oids:
                 status = "applied_to_output"
                 reason = "applied_main"
@@ -3983,32 +4626,34 @@ class FillLineGaps:
                 conn_nz = None
                 glob_nz = None
 
-            result.append(CandidateDiagnostic(
-                parent_id=p_id,
-                dangle_oid=d_oid,
-                dangle_x=float(xy[0]),
-                dangle_y=float(xy[1]),
-                near_fc_key=str(cand["near_fc_key"]),
-                near_fid=int(cand["near_fid"]),
-                near_x=float(cand["near_x"]),
-                near_y=float(cand["near_y"]),
-                raw_distance=float(raw_dist),
-                candidate_status=status,
-                status_reason=reason,
-                best_fit_score=float(best_fit),
-                best_fit_rank=rank,
-                bonus_applied=bool(bonus),
-                assess=assess,
-                target_parent_id=self._resolve_target_parent_id(
-                    cand, dangle_parent, dangles_key, lines_key
-                ),
-                final_gap_source=final_gs,
-                start_z=sc_start_z,
-                end_z=sc_end_z,
-                dangle_norm_z=sc_norm_z,
-                connection_norm_z=conn_nz,
-                global_norm_z=glob_nz,
-            ))
+            result.append(
+                CandidateDiagnostic(
+                    parent_id=p_id,
+                    dangle_oid=d_oid,
+                    dangle_x=float(xy[0]),
+                    dangle_y=float(xy[1]),
+                    near_fc_key=str(cand["near_fc_key"]),
+                    near_fid=int(cand["near_fid"]),
+                    near_x=float(cand["near_x"]),
+                    near_y=float(cand["near_y"]),
+                    raw_distance=float(raw_dist),
+                    candidate_status=status,
+                    status_reason=reason,
+                    best_fit_score=float(best_fit),
+                    best_fit_rank=rank,
+                    bonus_applied=bool(bonus),
+                    assess=assess,
+                    target_parent_id=self._resolve_target_parent_id(
+                        cand, dangle_parent, dangles_key, lines_key
+                    ),
+                    final_gap_source=final_gs,
+                    start_z=sc_start_z,
+                    end_z=sc_end_z,
+                    dangle_norm_z=sc_norm_z,
+                    connection_norm_z=conn_nz,
+                    global_norm_z=glob_nz,
+                )
+            )
         return result
 
     def _make_plan_entry(
@@ -4106,7 +4751,9 @@ class FillLineGaps:
             f" IN ({','.join(map(str, sorted(forced_target_parents)))})"
         )
         v_prev_by_parent: dict[int, tuple[float, float]] = {}
-        with arcpy.da.SearchCursor(self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"], where_l) as cur:
+        with arcpy.da.SearchCursor(
+            self.lines_copy, [self.ORIGINAL_ID, "SHAPE@"], where_l
+        ) as cur:
             for pid, shape in cur:
                 part = shape.getPart(0)
                 pts = [pt for pt in part if pt is not None]
@@ -4117,8 +4764,12 @@ class FillLineGaps:
                     continue
                 # Determine which end was the dangle by proximity to the original
                 # dangle position (dangle end has moved; non-dangle end is unchanged).
-                d_first = (pts[0].X - orig_v_end[0]) ** 2 + (pts[0].Y - orig_v_end[1]) ** 2
-                d_last = (pts[-1].X - orig_v_end[0]) ** 2 + (pts[-1].Y - orig_v_end[1]) ** 2
+                d_first = (pts[0].X - orig_v_end[0]) ** 2 + (
+                    pts[0].Y - orig_v_end[1]
+                ) ** 2
+                d_last = (pts[-1].X - orig_v_end[0]) ** 2 + (
+                    pts[-1].Y - orig_v_end[1]
+                ) ** 2
                 if d_first <= d_last:
                     v_prev_by_parent[int(pid)] = (pts[1].X, pts[1].Y)
                 else:
@@ -4148,7 +4799,9 @@ class FillLineGaps:
 
         # --- 3. GenerateNearTable against updated target-line geometry ---
         dangle_oids = sorted({int(cap.dangle_oid) for cap in filtered})
-        forced_parents_filtered = sorted({int(cap.forced_target_parent) for cap in filtered})
+        forced_parents_filtered = sorted(
+            {int(cap.forced_target_parent) for cap in filtered}
+        )
 
         dangles_oid_field = arcpy.Describe(dangles_fc).OIDFieldName
         where_d = (
@@ -4167,11 +4820,15 @@ class FillLineGaps:
 
         lines_oid_field = arcpy.Describe(resnap_lines_lyr).OIDFieldName
         near_oid_to_parent: dict[int, int] = {}
-        with arcpy.da.SearchCursor(resnap_lines_lyr, [lines_oid_field, self.ORIGINAL_ID]) as cur:
+        with arcpy.da.SearchCursor(
+            resnap_lines_lyr, [lines_oid_field, self.ORIGINAL_ID]
+        ) as cur:
             for oid, pid in cur:
                 near_oid_to_parent[int(oid)] = int(pid)
 
-        search_radius = 2 * self.connectivity_tolerance_meters + self.gap_tolerance_meters
+        search_radius = (
+            2 * self.connectivity_tolerance_meters + self.gap_tolerance_meters
+        )
         resnap_table = self.wfm.build_file_path(file_name="resnap_near_table")
         arcpy.analysis.GenerateNearTable(
             in_features=resnap_dangles_lyr,
@@ -4186,7 +4843,13 @@ class FillLineGaps:
         )
 
         best_xy: dict[tuple[int, int], tuple[float, float, float]] = {}
-        fields = [self.F_IN_FID, self.F_NEAR_FID, self.F_NEAR_DIST, self.F_NEAR_X, self.F_NEAR_Y]
+        fields = [
+            self.F_IN_FID,
+            self.F_NEAR_FID,
+            self.F_NEAR_DIST,
+            self.F_NEAR_X,
+            self.F_NEAR_Y,
+        ]
         with arcpy.da.SearchCursor(resnap_table, fields) as cur:
             for in_fid, near_fid, near_dist, near_x, near_y in cur:
                 if near_fid is None or near_dist is None:
@@ -4387,35 +5050,40 @@ class FillLineGaps:
         with arcpy.da.InsertCursor(fc_path, fields) as cur:
             for d in diagnostics:
                 arr = arcpy.Array(
-                    [arcpy.Point(d.dangle_x, d.dangle_y), arcpy.Point(d.near_x, d.near_y)]
+                    [
+                        arcpy.Point(d.dangle_x, d.dangle_y),
+                        arcpy.Point(d.near_x, d.near_y),
+                    ]
                 )
                 geom = arcpy.Polyline(arr, spatial_reference)
                 a = d.assess
-                cur.insertRow((
-                    geom,
-                    d.parent_id,
-                    d.dangle_oid,
-                    d.near_fc_key,
-                    d.near_fid,
-                    d.target_parent_id,
-                    d.raw_distance,
-                    d.best_fit_score,
-                    d.best_fit_rank,
-                    int(bool(d.bonus_applied)),
-                    a.angle_metric_deg if a is not None else None,
-                    a.src_connector_diff if a is not None else None,
-                    a.connector_target_diff if a is not None else None,
-                    a.src_target_diff if a is not None else None,
-                    a.connector_transition_diff if a is not None else None,
-                    d.final_gap_source,
-                    d.candidate_status,
-                    d.status_reason,
-                    d.start_z,
-                    d.end_z,
-                    d.dangle_norm_z,
-                    d.connection_norm_z,
-                    d.global_norm_z,
-                ))
+                cur.insertRow(
+                    (
+                        geom,
+                        d.parent_id,
+                        d.dangle_oid,
+                        d.near_fc_key,
+                        d.near_fid,
+                        d.target_parent_id,
+                        d.raw_distance,
+                        d.best_fit_score,
+                        d.best_fit_rank,
+                        int(bool(d.bonus_applied)),
+                        a.angle_metric_deg if a is not None else None,
+                        a.src_connector_diff if a is not None else None,
+                        a.connector_target_diff if a is not None else None,
+                        a.src_target_diff if a is not None else None,
+                        a.connector_transition_diff if a is not None else None,
+                        d.final_gap_source,
+                        d.candidate_status,
+                        d.status_reason,
+                        d.start_z,
+                        d.end_z,
+                        d.dangle_norm_z,
+                        d.connection_norm_z,
+                        d.global_norm_z,
+                    )
+                )
 
     def _apply_plan(self, plan) -> None:
         if not plan:
@@ -4568,14 +5236,20 @@ class FillLineGaps:
         self._build_raster_handles()
         self._add_original_id_field()
 
-        if self.source_direction_mode == logic_config.SourceDirectionMode.RASTER_DERIVED:
+        if (
+            self.source_direction_mode
+            == logic_config.SourceDirectionMode.RASTER_DERIVED
+        ):
             self._orient_feature_class_by_raster(self.lines_copy)
 
         self._create_dangles()
 
         self._build_external_target_layers_once()
 
-        if self.source_direction_mode == logic_config.SourceDirectionMode.RASTER_DERIVED:
+        if (
+            self.source_direction_mode
+            == logic_config.SourceDirectionMode.RASTER_DERIVED
+        ):
             for ext_layer in self.external_target_layers:
                 if self._is_polyline_fc(ext_layer):
                     self._orient_feature_class_by_raster(ext_layer)
@@ -4587,15 +5261,14 @@ class FillLineGaps:
         dangles_for_plan = self.filtered_dangles
 
         if self.line_changes_output is not None and self.write_output_metadata:
-            if arcpy.Exists(self.line_changes_output):
-                arcpy.management.Delete(self.line_changes_output)
+            file_utilities.delete_feature(input_feature=self.line_changes_output)
             self._setup_line_changes_output()
 
         if self.candidate_connections_output is not None:
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
-        plan, resnap_captures, diagnostics = self._build_plan(
-            dangles_fc=dangles_for_plan, target_layers=targets
+        plan, resnap_captures, diagnostics, accepted_connector_geoms, kruskal_rank_by_dangle_oid = (
+            self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
         )
 
         # Capture snap-source dangle endpoints before _apply_plan moves them.
@@ -4614,20 +5287,42 @@ class FillLineGaps:
                 dangles_fc=dangles_for_plan,
                 snap_source_dangle_xy=snap_source_dangle_xy,
             )
+
+            if self.reject_crossing_connectors and resnap_plan and accepted_connector_geoms:
+                resnap_plan, resnap_crossing_rejected_oids, resnap_crossing_displaced_oids = (
+                    self._recheck_resnap_crossings(
+                        resnap_plan=resnap_plan,
+                        accepted_connector_geoms=accepted_connector_geoms,
+                        kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
+                        trim_distance=float(self.connectivity_tolerance_meters),
+                        spatial_reference=arcpy.SpatialReference(
+                            self.crossing_check_spatial_reference
+                        ),
+                    )
+                )
+            else:
+                resnap_crossing_rejected_oids: set[int] = set()
+                resnap_crossing_displaced_oids: set[int] = set()
+
             self._apply_plan(resnap_plan)
 
-            if self.candidate_connections_output is not None and diagnostics and resnap_plan:
+            if self.candidate_connections_output is not None and diagnostics:
                 resnapped_dangle_oids = {
                     int(v["dangle_oid"])
                     for v in resnap_plan.values()
                     if isinstance(v, dict) and "dangle_oid" in v
+                    and not v.get("skip", False)
                 }
                 for diag in diagnostics:
-                    if (
-                        diag.candidate_status == "applied_to_output"
-                        and int(diag.dangle_oid) in resnapped_dangle_oids
-                    ):
-                        diag.status_reason = "applied_resnapped"
+                    d_oid = int(diag.dangle_oid)
+                    if diag.candidate_status == "applied_to_output":
+                        if d_oid in resnap_crossing_displaced_oids:
+                            diag.status_reason = "resnap_crossing_displaced"
+                        elif d_oid in resnapped_dangle_oids:
+                            diag.status_reason = "applied_resnapped"
+                    elif diag.candidate_status == "selected_for_dangle":
+                        if d_oid in resnap_crossing_rejected_oids:
+                            diag.status_reason = "resnap_crossing_rejected"
 
         if self.candidate_connections_output is not None and diagnostics:
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -954,6 +954,14 @@ class FillLineGaps:
             )
 
         # ----------------------------
+        # Source direction mode
+        # ----------------------------
+        self.source_direction_mode = logic_config.SourceDirectionMode(
+            adv.source_direction_mode
+        )
+        self.min_z_drop_meters: float = float(adv.min_z_drop_meters)
+
+        # ----------------------------
         # Angle config
         # ----------------------------
         self.angle_block_threshold_degrees = (
@@ -967,6 +975,16 @@ class FillLineGaps:
             else float(adv.angle_extra_dangle_threshold_degrees)
         )
         self.best_fit_weights = adv.best_fit_weights
+
+        if (
+            self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
+            and self.best_fit_weights.angle == 0.0
+        ):
+            raise ValueError(
+                f"source_direction_mode={self.source_direction_mode.value!r} requires "
+                f"best_fit_weights.angle > 0.0 — directional scoring has no effect when "
+                f"angle weight is zero."
+            )
 
         self.angle_local_half_window_m = float(
             getattr(adv, "angle_local_half_window_m", 2.0)
@@ -993,6 +1011,14 @@ class FillLineGaps:
             None if adv.z_drop_threshold is None else float(adv.z_drop_threshold)
         )
         self._raster_handles: list[geometry_tools.RasterHandle] = []
+
+        if (
+            self.source_direction_mode == logic_config.SourceDirectionMode.RASTER_DERIVED
+            and not self.raster_paths
+        ):
+            raise ValueError(
+                "source_direction_mode='raster_derived' requires raster_paths to be set."
+            )
 
         # Local angle cache (dataset_key, oid, rx, ry) -> Optional[float]
         self._local_angle_cache: dict[tuple[str, int, int, int], Optional[float]] = {}
@@ -1485,6 +1511,37 @@ class FillLineGaps:
                 )
 
         self._raster_handles = handles
+
+    # ----------------------------
+    # Source direction orientation
+    # ----------------------------
+
+    def _z_orient_mode_for_scope(self) -> logic_config.LineZOrientMode:
+        """Derive LineZOrientMode from connectivity_scope.
+        Point-to-point scopes (NONE, DIRECT_CONNECTION) use INDIVIDUAL orientation;
+        network-aware scopes use NETWORK orientation.
+        """
+        individual_scopes = (
+            ConnectivityScope.NONE,
+            ConnectivityScope.DIRECT_CONNECTION,
+        )
+        if self.connectivity_scope in individual_scopes:
+            return logic_config.LineZOrientMode.INDIVIDUAL
+        return logic_config.LineZOrientMode.NETWORK
+
+    def _orient_feature_class_by_raster(self, feature_class: str) -> None:
+        """Run LineZOrientTool on *feature_class* in-place using the shared raster
+        config. Called for lines_copy and any external line-like working copies when
+        source_direction_mode == RASTER_DERIVED.
+        """
+        orient_config = logic_config.LineZOrientConfig(
+            input_lines=feature_class,
+            raster_paths=self.raster_paths,
+            orientation_mode=self._z_orient_mode_for_scope(),
+            min_z_drop_meters=self.min_z_drop_meters,
+            connectivity_tolerance_meters=self.connectivity_tolerance_meters,
+        )
+        geometry_tools.LineZOrientTool(config=orient_config).run()
 
     def _local_angle_cache_key(
         self, *, dataset_key: str, oid: int, x: float, y: float
@@ -2309,11 +2366,11 @@ class FillLineGaps:
                 src_connector_diff=float(src_connector_diff),
             )
 
-        # Dangle-pair targets use directional comparison so anti-parallel lines
-        # are not collapsed to zero diff. A line candidate to the parent of a
-        # known target-dangle candidate represents the same connection opportunity
-        # and must be scored with identical directional semantics to prevent it
-        # from getting an unfair undirected scoring advantage.
+        # Dangle-pair detection is retained for:
+        # (1) edge-case distance bonus eligibility
+        # (2) diagnostic labeling
+        # (3) using the precise dangle XY as the target snap point for angle normalisation.
+        # It no longer solely drives the switch to directional semantics.
         _is_dangle_pair = ds_key == dangles_fc_key
         _is_dangle_parent_line = False
         if ds_key == lines_fc_key and dangle_xys_by_parent is not None:
@@ -2322,7 +2379,16 @@ class FillLineGaps:
                 abs(dx - near_x) < _tol and abs(dy - near_y) < _tol
                 for dx, dy in dangle_xys_by_parent.get(int(near_fid), [])
             )
-        _use_directional = _is_dangle_pair or _is_dangle_parent_line
+
+        # Use directional diff (0–180°, src_target_diff as metric) when:
+        # - source lines are known/assumed to be oriented (PRE_ORIENTED or RASTER_DERIVED), or
+        # - comparing dangle-pair / dangle-parent-line targets in UNDIRECTED mode, to avoid
+        #   collapsing anti-parallel lines to zero diff.
+        _use_directional = (
+            self.source_direction_mode != logic_config.SourceDirectionMode.UNDIRECTED
+            or _is_dangle_pair
+            or _is_dangle_parent_line
+        )
 
         if _use_directional:
             _diff = self._directional_diff
@@ -2342,17 +2408,19 @@ class FillLineGaps:
                 if src_m is not None and src_m < 0.5:
                     src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
 
-            # target_angle -> "entry direction into target interior from its dangle"
-            #   Forward tangent equals the entry direction when the dangle is at
-            #   the start (m < 0.5); it must be reversed when at the end (m >= 0.5).
-            # For a true dangle candidate the snap point is the target dangle XY;
-            # for a line candidate that shares the same parent, the snap point is
-            # the GenerateNearTable hit on the line (near_x, near_y).
-            _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
-            _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
-            tgt_m = self._line_measure_at_xy(tgt_poly, _tgt_snap_x, _tgt_snap_y)
-            if tgt_m is not None and tgt_m >= 0.5:
-                target_angle = (float(target_angle) + 180.0) % 360.0
+            # In UNDIRECTED mode (_use_directional triggered by dangle-pair / dangle-parent-line):
+            # normalise target_angle to "entry direction into target interior" so that both
+            # dangles in a pair score symmetrically (0° for a good collinear fill).
+            # In PRE_ORIENTED / RASTER_DERIVED mode: leave target_angle as the raw flow
+            # direction of the target line at the snap point. The source exits toward the gap;
+            # the target should flow in the same direction for a good match — flipping would
+            # collapse the score to 0° for both dangles regardless of their relative orientation.
+            if self.source_direction_mode == logic_config.SourceDirectionMode.UNDIRECTED:
+                _tgt_snap_x = float(tx) if _is_dangle_pair else float(near_x)
+                _tgt_snap_y = float(ty) if _is_dangle_pair else float(near_y)
+                tgt_m = self._line_measure_at_xy(tgt_poly, _tgt_snap_x, _tgt_snap_y)
+                if tgt_m is not None and tgt_m >= 0.5:
+                    target_angle = (float(target_angle) + 180.0) % 360.0
         else:
             _diff = self._orientation_diff
             angle_max_deg = 90.0
@@ -2360,7 +2428,7 @@ class FillLineGaps:
         connector_target_diff = _diff(float(connector_angle), float(target_angle))
         src_target_diff = _diff(float(src_angle_deg), float(target_angle))
         # connector_transition_diff mixes src→connector and connector→target.
-        # For directional cases, use directional src→connector to stay consistent.
+        # Use directional src→connector when in directional mode to stay consistent.
         _src_conn_for_transition = (
             self._directional_diff(float(src_angle_deg), float(connector_angle))
             if _use_directional
@@ -4363,9 +4431,19 @@ class FillLineGaps:
         self._copy_input_lines()
         self._build_raster_handles()
         self._add_original_id_field()
+
+        if self.source_direction_mode == logic_config.SourceDirectionMode.RASTER_DERIVED:
+            self._orient_feature_class_by_raster(self.lines_copy)
+
         self._create_dangles()
 
         self._build_external_target_layers_once()
+
+        if self.source_direction_mode == logic_config.SourceDirectionMode.RASTER_DERIVED:
+            for ext_layer in self.external_target_layers:
+                if self._is_polyline_fc(ext_layer):
+                    self._orient_feature_class_by_raster(ext_layer)
+
         targets = self._select_targets_within_tolerance_of_dangles()
 
         # Keep only dangles that have any candidate within base tolerance

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -4,7 +4,7 @@ from enum import Enum
 import math
 import os
 
-from typing import Optional, Callable, Iterable, Any, TypeAlias
+from typing import Optional, Callable, Iterable, Any, TypeAlias, NamedTuple
 
 import arcpy
 
@@ -881,30 +881,53 @@ class AngleAssessment:
     connector_transition_diff: Optional[float] = None
 
 
+@dataclass(frozen=True, slots=True)
+class ScopeRecord:
+    """
+    Status snapshot at one pipeline scope for a candidate connection.
+
+    status: the outcome at this scope (scope-specific vocabulary; see CandidateDiagnostic).
+    reason: optional detail string; None when status is self-explanatory (e.g. "scored",
+        "accepted").
+    norm_z: Z value normalized within this scope's candidate comparison set; None when Z
+        is inactive or the scope was not reached.
+    """
+
+    status: str
+    reason: Optional[str] = None
+    norm_z: Optional[float] = None
+
+
 @dataclass
 class CandidateDiagnostic:
     """
     Diagnostic record for one candidate connection evaluated during the main planning phase.
 
     One record exists per (dangle, target) pair, excluding the self parent line target.
-    The dataclass is mutable so that resnap outcomes can be patched by run()
-    after _resnap_connections resolves.
+    The dataclass is mutable so that resnap outcomes can update deferred_scope and
+    final_status after _resnap_connections resolves.
 
-    candidate_status values:
-        "illegal"             — failed legality or angle blocking; could not be selected
-        "legal_not_selected"  — passed legality but lost to a better scored candidate
-                               within the same dangle
-        "selected_for_dangle" — was the local best candidate for its dangle but did not
-                               survive later pipeline stages to become applied output
-        "applied_to_output"   — truly survived the full pipeline and was applied to geometry
+    Per-scope fields record the outcome at each pipeline stage independently. None means
+    the candidate did not reach that scope. final_status repeats the last non-None scope.
 
-    status_reason values per status:
-        illegal:              beyond_distance_tolerance | same_network | illegal_target |
-                              blocked_by_angle | expanded_dangle_angle_disallowed |
-                              blocked_by_z_drop
-        legal_not_selected:   outscored_within_dangle
-        selected_for_dangle:  lost_connection_selection | lost_kruskal_selection
-        applied_to_output:    applied_main | applied_resnapped
+    Candidate scope status values (candidate_scope.status):
+        Illegal: beyond_distance_tolerance | same_network | illegal_target |
+                 crosses_existing_feature | crosses_barrier_layer | directed_start_node |
+                 blocked_by_angle | expanded_dangle_angle_disallowed | blocked_by_z_drop
+        Passed:  scored
+
+    Network scope status values (network_scope.status):
+        outscored_within_dangle | lost_connection_selection | passed
+
+    Kruskal scope status values (kruskal_scope.status):
+        lost_kruskal_selection | crosses_accepted_connector | accepted
+
+    Deferred scope status values (deferred_scope.status):
+        applied_resnapped | resnap_crossing_rejected | resnap_crossing_displaced |
+        referenced_as_winner
+
+    final_status repeats the last non-None scope. For accepted non-resnapped candidates
+    deferred_scope is None and final_status repeats kruskal_scope.
     """
 
     parent_id: int
@@ -916,31 +939,21 @@ class CandidateDiagnostic:
     near_x: float
     near_y: float
     raw_distance: float
-    candidate_status: str  # see class docstring
-    status_reason: Optional[str]  # see class docstring; None only for rare edge cases
+    candidate_scope: ScopeRecord
+    network_scope: Optional[ScopeRecord]
+    kruskal_scope: Optional[ScopeRecord]
+    deferred_scope: Optional[ScopeRecord]
+    final_status: ScopeRecord
     best_fit_score: Optional[float]
-    best_fit_rank: Optional[int]  # 1 = local dangle winner; higher = lower-ranked legal
+    best_fit_rank: Optional[int]
     bonus_applied: Optional[bool]
+    norm_dist: Optional[float]
+    norm_angle: Optional[float]
     assess: Optional[AngleAssessment]
     target_parent_id: Optional[int]
-    final_gap_source: Optional[
-        str
-    ]  # gap_source value for applied_to_output rows; None otherwise
-    start_z: Optional[float] = (
-        None  # Z at the dangle point (candidate start); None when no rasters
-    )
-    end_z: Optional[float] = (
-        None  # Z at the near point (candidate end); None when no rasters
-    )
-    dangle_norm_z: Optional[float] = (
-        None  # Z normalized within dangle candidate set; None for illegals
-    )
-    connection_norm_z: Optional[float] = (
-        None  # Z normalized within pair_key group; None for illegals/deferred
-    )
-    global_norm_z: Optional[float] = (
-        None  # Z normalized across all Stage-A winners; None unless Stage-B reached
-    )
+    final_gap_source: Optional[str]
+    start_z: Optional[float] = None
+    end_z: Optional[float] = None
 
 
 # ---------------------------------------------------------------------------
@@ -955,25 +968,63 @@ _ConnectionWithSource: TypeAlias = tuple[_ConnectionProposal, str]
 _GlobalWithSource: TypeAlias = tuple[_GlobalProposal, str]
 # (dangle_oid, dangle_x, dangle_y, near_x, near_y)
 _AcceptedConnectorRaw: TypeAlias = tuple[int, float, float, float, float]
-# Diagnostic collection tuples (produced in _select_dangle_proposals, consumed in _assemble_diagnostics)
-_Step1AIllegalEntry: TypeAlias = tuple[int, int, _CandRow, str]
-_Step1BIllegalEntry: TypeAlias = tuple[
-    int, int, _CandRow, AngleAssessment, str, Optional[float], Optional[float]
-]
-_Step1BScoredEntry: TypeAlias = tuple[
-    int,
-    int,
-    _CandRow,
-    AngleAssessment,
-    float,
-    float,
-    bool,
-    bool,
-    tuple[float, int, float],
-    Optional[float],
-    Optional[float],
-    Optional[float],
-]
+
+
+class _CandidateIllegalA(NamedTuple):
+    """Candidate rejected at Step 1A (distance/network/legality gate) before angle assessment."""
+
+    dangle_oid: int
+    parent_id: int
+    cand: _CandRow
+    reason: str
+
+
+class _CandidateIllegalB(NamedTuple):
+    """Candidate rejected at Step 1B (angle/Z gate) after angle assessment."""
+
+    dangle_oid: int
+    parent_id: int
+    cand: _CandRow
+    assess: AngleAssessment
+    reason: str
+    start_z: Optional[float]
+    end_z: Optional[float]
+
+
+class _CandidateScored(NamedTuple):
+    """Candidate that survived all legality gates and received a composite score."""
+
+    dangle_oid: int
+    parent_id: int
+    cand: _CandRow
+    assess: AngleAssessment
+    raw_distance: float
+    best_fit: float
+    bonus: bool
+    is_local_winner: bool
+    score_tuple: tuple[float, int, float]
+    norm_dist: float
+    norm_angle: Optional[float]
+    dangle_norm_z: Optional[float]
+    start_z: Optional[float]
+    end_z: Optional[float]
+
+
+@dataclass
+class _DiagnosticsState:
+    """All pipeline state collected during _build_plan for diagnostic assembly."""
+
+    step1a_illegal: list[_CandidateIllegalA]
+    step1b_illegal: list[_CandidateIllegalB]
+    step1b_scored: list[_CandidateScored]
+    connection_loser_oids: set[int]
+    kruskal_rejected_oids: set[int]
+    kruskal_crossing_rejected_oids: set[int]
+    accepted_dangle_oids: set[int]
+    gap_source_by_dangle: dict[int, str]
+    dangle_norm_z_by_dangle: _NormZByDangle
+    connection_norm_z_by_dangle: _NormZByDangle
+    global_norm_z_by_dangle: _NormZByDangle
 
 
 class FillLineGaps:
@@ -3224,12 +3275,7 @@ class FillLineGaps:
                         if _cand_key in _barrier_keys:
                             if collect_diags:
                                 _step1a_illegal.append(
-                                    (
-                                        _dangle_oid,
-                                        _parent_id,
-                                        _cand,
-                                        "crosses_barrier_layer",
-                                    )
+                                    _CandidateIllegalA(_dangle_oid, _parent_id, _cand, "crosses_barrier_layer")
                                 )
                         else:
                             _remaining.append(_cand)
@@ -3269,12 +3315,7 @@ class FillLineGaps:
                         if _cand_key in crossing_conflict_keys:
                             if collect_diags:
                                 _step1a_illegal.append(
-                                    (
-                                        _dangle_oid,
-                                        _parent_id,
-                                        _cand,
-                                        "crosses_existing_feature",
-                                    )
+                                    _CandidateIllegalA(_dangle_oid, _parent_id, _cand, "crosses_existing_feature")
                                 )
                         else:
                             _remaining.append(_cand)
@@ -3290,17 +3331,19 @@ class FillLineGaps:
                 [],
                 self._assemble_diagnostics(
                     collect_diags=collect_diags,
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=[],
-                    step1b_scored=[],
-                    connection_loser_oids=set(),
-                    kruskal_rejected_oids=set(),
-                    kruskal_crossing_rejected_oids=set(),
-                    accepted_dangle_oids=set(),
-                    gap_source_by_dangle={},
-                    dangle_norm_z_by_dangle={},
-                    connection_norm_z_by_dangle={},
-                    global_norm_z_by_dangle={},
+                    state=_DiagnosticsState(
+                        step1a_illegal=_step1a_illegal,
+                        step1b_illegal=[],
+                        step1b_scored=[],
+                        connection_loser_oids=set(),
+                        kruskal_rejected_oids=set(),
+                        kruskal_crossing_rejected_oids=set(),
+                        accepted_dangle_oids=set(),
+                        gap_source_by_dangle={},
+                        dangle_norm_z_by_dangle={},
+                        connection_norm_z_by_dangle={},
+                        global_norm_z_by_dangle={},
+                    ),
                     dangle_xy=dangle_xy,
                     dangle_parent=dangle_parent,
                     dangles_key=dangles_key,
@@ -3402,17 +3445,19 @@ class FillLineGaps:
                 [],
                 self._assemble_diagnostics(
                     collect_diags=collect_diags,
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    connection_loser_oids=set(),
-                    kruskal_rejected_oids=set(),
-                    kruskal_crossing_rejected_oids=set(),
-                    accepted_dangle_oids=set(),
-                    gap_source_by_dangle={},
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                    connection_norm_z_by_dangle={},
-                    global_norm_z_by_dangle={},
+                    state=_DiagnosticsState(
+                        step1a_illegal=_step1a_illegal,
+                        step1b_illegal=_step1b_illegal,
+                        step1b_scored=_step1b_scored,
+                        connection_loser_oids=set(),
+                        kruskal_rejected_oids=set(),
+                        kruskal_crossing_rejected_oids=set(),
+                        accepted_dangle_oids=set(),
+                        gap_source_by_dangle={},
+                        dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                        connection_norm_z_by_dangle={},
+                        global_norm_z_by_dangle={},
+                    ),
                     dangle_xy=dangle_xy,
                     dangle_parent=dangle_parent,
                     dangles_key=dangles_key,
@@ -3434,17 +3479,19 @@ class FillLineGaps:
                 [],
                 self._assemble_diagnostics(
                     collect_diags=collect_diags,
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    connection_loser_oids=set(),
-                    kruskal_rejected_oids=set(),
-                    kruskal_crossing_rejected_oids=set(),
-                    accepted_dangle_oids=set(),
-                    gap_source_by_dangle={},
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                    connection_norm_z_by_dangle={},
-                    global_norm_z_by_dangle={},
+                    state=_DiagnosticsState(
+                        step1a_illegal=_step1a_illegal,
+                        step1b_illegal=_step1b_illegal,
+                        step1b_scored=_step1b_scored,
+                        connection_loser_oids=set(),
+                        kruskal_rejected_oids=set(),
+                        kruskal_crossing_rejected_oids=set(),
+                        accepted_dangle_oids=set(),
+                        gap_source_by_dangle={},
+                        dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                        connection_norm_z_by_dangle={},
+                        global_norm_z_by_dangle={},
+                    ),
                     dangle_xy=dangle_xy,
                     dangle_parent=dangle_parent,
                     dangles_key=dangles_key,
@@ -3523,17 +3570,19 @@ class FillLineGaps:
                 [],
                 self._assemble_diagnostics(
                     collect_diags=collect_diags,
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    connection_loser_oids=connection_loser_oids,
-                    kruskal_rejected_oids=kruskal_rejected_oids,
-                    kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
-                    accepted_dangle_oids=accepted_dangle_oids,
-                    gap_source_by_dangle=gap_source_by_dangle,
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                    connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-                    global_norm_z_by_dangle=global_norm_z_by_dangle,
+                    state=_DiagnosticsState(
+                        step1a_illegal=_step1a_illegal,
+                        step1b_illegal=_step1b_illegal,
+                        step1b_scored=_step1b_scored,
+                        connection_loser_oids=connection_loser_oids,
+                        kruskal_rejected_oids=kruskal_rejected_oids,
+                        kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
+                        accepted_dangle_oids=accepted_dangle_oids,
+                        gap_source_by_dangle=gap_source_by_dangle,
+                        dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                        connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+                        global_norm_z_by_dangle=global_norm_z_by_dangle,
+                    ),
                     dangle_xy=dangle_xy,
                     dangle_parent=dangle_parent,
                     dangles_key=dangles_key,
@@ -3558,17 +3607,19 @@ class FillLineGaps:
             resnap_captures,
             self._assemble_diagnostics(
                 collect_diags=collect_diags,
-                step1a_illegal=_step1a_illegal,
-                step1b_illegal=_step1b_illegal,
-                step1b_scored=_step1b_scored,
-                connection_loser_oids=connection_loser_oids,
-                kruskal_rejected_oids=kruskal_rejected_oids,
-                kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
-                accepted_dangle_oids=accepted_dangle_oids,
-                gap_source_by_dangle=gap_source_by_dangle,
-                dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-                global_norm_z_by_dangle=global_norm_z_by_dangle,
+                state=_DiagnosticsState(
+                    step1a_illegal=_step1a_illegal,
+                    step1b_illegal=_step1b_illegal,
+                    step1b_scored=_step1b_scored,
+                    connection_loser_oids=connection_loser_oids,
+                    kruskal_rejected_oids=kruskal_rejected_oids,
+                    kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
+                    accepted_dangle_oids=accepted_dangle_oids,
+                    gap_source_by_dangle=gap_source_by_dangle,
+                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
+                    connection_norm_z_by_dangle=connection_norm_z_by_dangle,
+                    global_norm_z_by_dangle=global_norm_z_by_dangle,
+                ),
                 dangle_xy=dangle_xy,
                 dangle_parent=dangle_parent,
                 dangles_key=dangles_key,
@@ -3592,14 +3643,14 @@ class FillLineGaps:
         topology: TopologyModel,
         collect_diags: bool,
         directed_source_illegal_oids: set[int],
-    ) -> tuple[_Grouped, dict[int, int], list[_Step1AIllegalEntry]]:
+    ) -> tuple[_Grouped, dict[int, int], list[_CandidateIllegalA]]:
         """Dangle filtering: collect legal candidates per dangle.
 
         Returns (legal_rows_by_dangle, parent_id_by_dangle, step1a_illegal).
         """
         legal_rows_by_dangle: dict[int, list[dict]] = {}
         parent_id_by_dangle: dict[int, int] = {}
-        _step1a_illegal: list[_Step1AIllegalEntry] = []
+        _step1a_illegal: list[_CandidateIllegalA] = []
 
         for dangle_oid in sorted(grouped.keys()):
             candidates = grouped[dangle_oid]
@@ -3620,7 +3671,7 @@ class FillLineGaps:
                         ) == int(parent_id):
                             continue
                         _step1a_illegal.append(
-                            (dangle_oid, parent_id, cand, "directed_start_node")
+                            _CandidateIllegalA(dangle_oid, parent_id, cand, "directed_start_node")
                         )
                 continue
 
@@ -3661,7 +3712,7 @@ class FillLineGaps:
                         dangle_candidate_tol=dangle_tol,
                         topology=topology,
                     )
-                    _step1a_illegal.append((dangle_oid, parent_id, cand, reason))
+                    _step1a_illegal.append(_CandidateIllegalA(dangle_oid, parent_id, cand, reason))
 
             if not legal_rows:
                 continue
@@ -3692,8 +3743,8 @@ class FillLineGaps:
     ) -> tuple[
         dict[int, _DangleProposal],
         _NormZByDangle,
-        list[_Step1BIllegalEntry],
-        list[_Step1BScoredEntry],
+        list[_CandidateIllegalB],
+        list[_CandidateScored],
     ]:
         """Dangle selection: choose one proposal per dangle using angle-aware scoring.
 
@@ -3701,8 +3752,8 @@ class FillLineGaps:
         """
         _dangle_proposals: dict[int, _DangleProposal] = {}
         dangle_norm_z_by_dangle: dict[int, Optional[float]] = {}
-        _step1b_illegal: list[_Step1BIllegalEntry] = []
-        _step1b_scored: list[_Step1BScoredEntry] = []
+        _step1b_illegal: list[_CandidateIllegalB] = []
+        _step1b_scored: list[_CandidateScored] = []
 
         for dangle_oid in sorted(legal_rows_by_dangle.keys()):
             dangle_oid = int(dangle_oid)
@@ -3796,15 +3847,7 @@ class FillLineGaps:
                 if assess.blocks:
                     if collect_diags:
                         _step1b_illegal.append(
-                            (
-                                dangle_oid,
-                                parent_id,
-                                cand,
-                                assess,
-                                "blocked_by_angle",
-                                start_z,
-                                _cand_end_z,
-                            )
+                            _CandidateIllegalB(dangle_oid, parent_id, cand, assess, "blocked_by_angle", start_z, _cand_end_z)
                         )
                     continue
 
@@ -3820,18 +3863,9 @@ class FillLineGaps:
                     and dist > float(base_tol)
                     and not bool(assess.allow_extra_dangle)
                 ):
-                    # Candidate is only legal due to expanded tolerance; angle disallows it
                     if collect_diags:
                         _step1b_illegal.append(
-                            (
-                                dangle_oid,
-                                parent_id,
-                                cand,
-                                assess,
-                                "expanded_dangle_angle_disallowed",
-                                start_z,
-                                _cand_end_z,
-                            )
+                            _CandidateIllegalB(dangle_oid, parent_id, cand, assess, "expanded_dangle_angle_disallowed", start_z, _cand_end_z)
                         )
                     continue
 
@@ -3852,15 +3886,7 @@ class FillLineGaps:
                     ):
                         if collect_diags:
                             _step1b_illegal.append(
-                                (
-                                    dangle_oid,
-                                    parent_id,
-                                    cand,
-                                    assess,
-                                    "blocked_by_z_drop",
-                                    start_z,
-                                    _cand_end_z,
-                                )
+                                _CandidateIllegalB(dangle_oid, parent_id, cand, assess, "blocked_by_z_drop", start_z, _cand_end_z)
                             )
                         continue
 
@@ -3928,6 +3954,8 @@ class FillLineGaps:
                         bool(bonus_applied),
                         assess,
                         _norm_z,
+                        _eff_norm_dist,
+                        _norm_angle,
                         end_z_by_cand_index.get(_cand_idx),  # per-candidate end_z
                     )
                 )
@@ -3947,6 +3975,8 @@ class FillLineGaps:
                 bonus_applied,
                 chosen_assess,
                 winner_norm_z,
+                _winner_norm_dist,
+                _winner_norm_angle,
                 winner_end_z,
             ) = winner_item
 
@@ -3960,26 +3990,26 @@ class FillLineGaps:
                         sc_bonus,
                         sc_assess,
                         sc_norm_z,
+                        sc_norm_dist,
+                        sc_norm_angle,
                         sc_end_z,
                     ) = sc_tuple
                     _step1b_scored.append(
-                        (
-                            dangle_oid,
-                            parent_id,
-                            sc_cand,
-                            sc_assess,
-                            float(sc_raw),
-                            float(sc_best_fit),
-                            bool(sc_bonus),
-                            sc_tuple is winner_item,
-                            (
-                                sc_score.composite,
-                                sc_score.bonus_rank,
-                                sc_raw,
-                            ),  # for per-dangle rank
-                            sc_norm_z,  # dangle_norm_z for this candidate
-                            start_z,  # fixed per dangle
-                            sc_end_z,  # per-candidate end_z
+                        _CandidateScored(
+                            dangle_oid=dangle_oid,
+                            parent_id=parent_id,
+                            cand=sc_cand,
+                            assess=sc_assess,
+                            raw_distance=float(sc_raw),
+                            best_fit=float(sc_best_fit),
+                            bonus=bool(sc_bonus),
+                            is_local_winner=sc_tuple is winner_item,
+                            score_tuple=(sc_score.composite, sc_score.bonus_rank, sc_raw),
+                            norm_dist=float(sc_norm_dist),
+                            norm_angle=sc_norm_angle,
+                            dangle_norm_z=sc_norm_z,
+                            start_z=start_z,
+                            end_z=sc_end_z,
                         )
                     )
 
@@ -4404,28 +4434,29 @@ class FillLineGaps:
         kruskal_rank_by_dangle_oid: dict[int, int],
         trim_distance: float,
         spatial_reference: Any,
-    ) -> tuple[dict[int, dict], set[int], set[int]]:
+    ) -> tuple[dict[int, dict], set[int], set[int], set[int]]:
         """Re-check resnap captures against accepted connector geometries.
 
         Called after _resnap_connections resolves final geometry for deferred
         connectors.  Uses a spatial CROSSES relationship check (trimmed resnap
         connectors vs trimmed accepted connectors) as the source of truth for
-        crossing conflicts, then
-        applies rank-based conflict resolution:
+        crossing conflicts, then applies rank-based conflict resolution:
 
           - If the resnap capture has a worse (higher) rank than the best-ranked
-            conflicting accepted connector → the resnap capture loses; its plan
+            conflicting accepted connector -> the resnap capture loses; its plan
             entry is marked skip=True so the corrected geometry is not applied.
-          - If the resnap capture has a better (lower) rank → it wins; the
-            conflicting connector(s) are flagged as displaced.  Their geometry
-            is already applied to the feature class and is not reverted, so the
+          - If the resnap capture has a better (lower) rank -> it wins; the
+            conflicting connector(s) are flagged as displaced. Their geometry is
+            already applied to the feature class and is not reverted, so the
             displacement is recorded in diagnostics only.
 
         Returns (resnap_plan, resnap_crossing_rejected_oids,
-                 resnap_crossing_displaced_oids).
+                 resnap_crossing_displaced_oids, resnap_crossing_winner_oids).
+        resnap_crossing_winner_oids contains dangle_oids of accepted connectors that
+        won a conflict against a resnap capture (i.e. the resnap capture deferred to them).
         """
         if not accepted_connector_raw:
-            return resnap_plan, set(), set()
+            return resnap_plan, set(), set(), set()
 
         # Build trimmed resnap connectors: key = parent_id (unique per resnap entry).
         resnap_cands: list[tuple[Any, Any]] = []
@@ -4444,7 +4475,7 @@ class FillLineGaps:
                 resnap_cands.append((parent_id, trimmed))
 
         if not resnap_cands:
-            return resnap_plan, set(), set()
+            return resnap_plan, set(), set(), set()
 
         # Build trimmed accepted connectors: key = dangle_oid.
         accepted_cands: list[tuple[Any, Any]] = []
@@ -4461,7 +4492,7 @@ class FillLineGaps:
                 accepted_cands.append((acc_doid, trimmed))
 
         if not accepted_cands:
-            return resnap_plan, set(), set()
+            return resnap_plan, set(), set(), set()
 
         _resnap_fc = "memory/resnap_crossing_trimmed"
         _accepted_fc = "memory/resnap_crossing_accepted"
@@ -4495,6 +4526,7 @@ class FillLineGaps:
 
         resnap_crossing_rejected_oids: set[int] = set()
         resnap_crossing_displaced_oids: set[int] = set()
+        resnap_crossing_winner_oids: set[int] = set()
 
         for parent_id, entry in resnap_plan.items():
             if entry.get("skip", False):
@@ -4514,6 +4546,7 @@ class FillLineGaps:
             if resnap_rank <= best_conflict_rank:
                 # Resnap capture wins: displace the conflicting accepted connectors.
                 resnap_crossing_displaced_oids.update(conflicting_doids)
+                resnap_crossing_winner_oids.add(dangle_oid)
             else:
                 # Resnap capture loses: skip the corrected-geometry application.
                 entry["skip"] = True
@@ -4523,6 +4556,7 @@ class FillLineGaps:
             resnap_plan,
             resnap_crossing_rejected_oids,
             resnap_crossing_displaced_oids,
+            resnap_crossing_winner_oids,
         )
 
     def _assemble_plan_entries(
@@ -4564,21 +4598,37 @@ class FillLineGaps:
 
         return plan_by_parent
 
+    def _make_base_diag_fields(
+        self,
+        cand: _CandRow,
+        dangle_oid: int,
+        parent_id: int,
+        xy: tuple[float, float],
+        dangle_parent: dict[int, int],
+        dangles_key: str,
+        lines_key: str,
+    ) -> dict:
+        """Return the identity fields shared by all three diagnostic assembly branches."""
+        return dict(
+            parent_id=parent_id,
+            dangle_oid=dangle_oid,
+            dangle_x=float(xy[0]),
+            dangle_y=float(xy[1]),
+            near_fc_key=str(cand["near_fc_key"]),
+            near_fid=int(cand["near_fid"]),
+            near_x=float(cand["near_x"]),
+            near_y=float(cand["near_y"]),
+            raw_distance=float(cand["near_dist"]),
+            target_parent_id=self._resolve_target_parent_id(
+                cand, dangle_parent, dangles_key, lines_key
+            ),
+        )
+
     def _assemble_diagnostics(
         self,
         *,
         collect_diags: bool,
-        step1a_illegal: list[_Step1AIllegalEntry],
-        step1b_illegal: list[_Step1BIllegalEntry],
-        step1b_scored: list[_Step1BScoredEntry],
-        connection_loser_oids: set[int],
-        kruskal_rejected_oids: set[int],
-        kruskal_crossing_rejected_oids: set[int],
-        accepted_dangle_oids: set[int],
-        gap_source_by_dangle: dict[int, str],
-        dangle_norm_z_by_dangle: _NormZByDangle,
-        connection_norm_z_by_dangle: _NormZByDangle,
-        global_norm_z_by_dangle: _NormZByDangle,
+        state: _DiagnosticsState,
         dangle_xy: dict[int, tuple[float, float]],
         dangle_parent: dict[int, int],
         dangles_key: str,
@@ -4603,173 +4653,149 @@ class FillLineGaps:
             return sz, ez
 
         # Step-1A illegals: angle never computed; z values looked up here
-        for d_oid, p_id, cand, reason in step1a_illegal:
-            xy = dangle_xy.get(int(d_oid))
+        for entry in state.step1a_illegal:
+            xy = dangle_xy.get(int(entry.dangle_oid))
             if xy is None:
                 continue
-            _sz, _ez = _z_pair(xy, cand["near_x"], cand["near_y"])
+            _sz, _ez = _z_pair(xy, entry.cand["near_x"], entry.cand["near_y"])
+            cand_scope = ScopeRecord(status=entry.reason)
             result.append(
                 CandidateDiagnostic(
-                    parent_id=p_id,
-                    dangle_oid=d_oid,
-                    dangle_x=float(xy[0]),
-                    dangle_y=float(xy[1]),
-                    near_fc_key=str(cand["near_fc_key"]),
-                    near_fid=int(cand["near_fid"]),
-                    near_x=float(cand["near_x"]),
-                    near_y=float(cand["near_y"]),
-                    raw_distance=float(cand["near_dist"]),
-                    candidate_status="illegal",
-                    status_reason=reason,
+                    **self._make_base_diag_fields(entry.cand, entry.dangle_oid, entry.parent_id, xy, dangle_parent, dangles_key, lines_key),
+                    candidate_scope=cand_scope,
+                    network_scope=None,
+                    kruskal_scope=None,
+                    deferred_scope=None,
+                    final_status=cand_scope,
                     best_fit_score=None,
                     best_fit_rank=None,
                     bonus_applied=None,
+                    norm_dist=None,
+                    norm_angle=None,
                     assess=None,
-                    target_parent_id=self._resolve_target_parent_id(
-                        cand, dangle_parent, dangles_key, lines_key
-                    ),
                     final_gap_source=None,
                     start_z=_sz,
                     end_z=_ez,
-                    dangle_norm_z=None,
-                    connection_norm_z=None,
-                    global_norm_z=None,
                 )
             )
 
-        # Step-1B angle-blocked illegals: z values carried in tuple
-        for d_oid, p_id, cand, assess, reason, _sz, _ez in step1b_illegal:
-            xy = dangle_xy.get(int(d_oid))
+        # Step-1B angle/Z-blocked illegals: z values carried in entry
+        for entry in state.step1b_illegal:
+            xy = dangle_xy.get(int(entry.dangle_oid))
             if xy is None:
                 continue
+            cand_scope = ScopeRecord(status=entry.reason)
             result.append(
                 CandidateDiagnostic(
-                    parent_id=p_id,
-                    dangle_oid=d_oid,
-                    dangle_x=float(xy[0]),
-                    dangle_y=float(xy[1]),
-                    near_fc_key=str(cand["near_fc_key"]),
-                    near_fid=int(cand["near_fid"]),
-                    near_x=float(cand["near_x"]),
-                    near_y=float(cand["near_y"]),
-                    raw_distance=float(cand["near_dist"]),
-                    candidate_status="illegal",
-                    status_reason=reason,
+                    **self._make_base_diag_fields(entry.cand, entry.dangle_oid, entry.parent_id, xy, dangle_parent, dangles_key, lines_key),
+                    candidate_scope=cand_scope,
+                    network_scope=None,
+                    kruskal_scope=None,
+                    deferred_scope=None,
+                    final_status=cand_scope,
                     best_fit_score=None,
                     best_fit_rank=None,
                     bonus_applied=None,
-                    assess=assess,
-                    target_parent_id=self._resolve_target_parent_id(
-                        cand, dangle_parent, dangles_key, lines_key
-                    ),
+                    norm_dist=None,
+                    norm_angle=None,
+                    assess=entry.assess,
                     final_gap_source=None,
-                    start_z=_sz,
-                    end_z=_ez,
-                    dangle_norm_z=None,
-                    connection_norm_z=None,
-                    global_norm_z=None,
+                    start_z=entry.start_z,
+                    end_z=entry.end_z,
                 )
             )
 
         # Compute per-dangle rank for scored candidates (1 = local winner)
-        scored_by_dangle: dict[int, list[_Step1BScoredEntry]] = {}
-        for entry in step1b_scored:
-            scored_by_dangle.setdefault(int(entry[0]), []).append(entry)
+        scored_by_dangle: dict[int, list[_CandidateScored]] = {}
+        for entry in state.step1b_scored:
+            scored_by_dangle.setdefault(int(entry.dangle_oid), []).append(entry)
         rank_map: dict[tuple[int, str, int], int] = {}
         for d_oid, entries in scored_by_dangle.items():
-            for rank, entry in enumerate(sorted(entries, key=lambda e: e[8]), start=1):
-                cand = entry[2]
-                rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = (
-                    rank
-                )
+            for rank, entry in enumerate(sorted(entries, key=lambda e: e.score_tuple), start=1):
+                rank_map[(d_oid, str(entry.cand["near_fc_key"]), int(entry.cand["near_fid"]))] = rank
 
-        # Step-1B scored candidates; z values carried in tuple
-        for (
-            d_oid,
-            p_id,
-            cand,
-            assess,
-            raw_dist,
-            best_fit,
-            bonus,
-            is_local_winner,
-            _score,
-            sc_norm_z,
-            sc_start_z,
-            sc_end_z,
-        ) in step1b_scored:
-            xy = dangle_xy.get(int(d_oid))
+        # Step-1B scored candidates
+        for entry in state.step1b_scored:
+            xy = dangle_xy.get(int(entry.dangle_oid))
             if xy is None:
                 continue
             rank = rank_map.get(
-                (d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))
+                (entry.dangle_oid, str(entry.cand["near_fc_key"]), int(entry.cand["near_fid"]))
             )
+            d_oid = int(entry.dangle_oid)
+            cand_scope = ScopeRecord(status="scored", norm_z=entry.dangle_norm_z)
 
-            if not is_local_winner:
-                status = "legal_not_selected"
-                reason = "outscored_within_dangle"
+            if not entry.is_local_winner:
+                net_scope = ScopeRecord(status="outscored_within_dangle")
+                kru_scope: Optional[ScopeRecord] = None
+                final_scope = net_scope
                 final_gs: Optional[str] = None
-                conn_nz: Optional[float] = None
-                glob_nz: Optional[float] = None
-            elif int(d_oid) in connection_loser_oids:
-                status = "selected_for_dangle"
-                reason = "lost_connection_selection"
+            elif d_oid in state.connection_loser_oids:
+                net_scope = ScopeRecord(
+                    status="lost_connection_selection",
+                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                )
+                kru_scope = None
+                final_scope = net_scope
                 final_gs = None
-                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
-                glob_nz = None
-            elif int(d_oid) in kruskal_rejected_oids:
-                status = "selected_for_dangle"
-                reason = "lost_kruskal_selection"
+            elif d_oid in state.kruskal_rejected_oids:
+                net_scope = ScopeRecord(
+                    status="passed",
+                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                )
+                kru_scope = ScopeRecord(
+                    status="lost_kruskal_selection",
+                    norm_z=state.global_norm_z_by_dangle.get(d_oid),
+                )
+                final_scope = kru_scope
                 final_gs = None
-                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
-                glob_nz = global_norm_z_by_dangle.get(int(d_oid))
-            elif int(d_oid) in kruskal_crossing_rejected_oids:
-                status = "selected_for_dangle"
-                reason = "crosses_accepted_connector"
+            elif d_oid in state.kruskal_crossing_rejected_oids:
+                net_scope = ScopeRecord(
+                    status="passed",
+                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                )
+                kru_scope = ScopeRecord(
+                    status="crosses_accepted_connector",
+                    norm_z=state.global_norm_z_by_dangle.get(d_oid),
+                )
+                final_scope = kru_scope
                 final_gs = None
-                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
-                glob_nz = global_norm_z_by_dangle.get(int(d_oid))
-            elif int(d_oid) in accepted_dangle_oids:
-                status = "applied_to_output"
-                reason = "applied_main"
-                final_gs = gap_source_by_dangle.get(int(d_oid))
-                conn_nz = connection_norm_z_by_dangle.get(int(d_oid))
-                glob_nz = global_norm_z_by_dangle.get(int(d_oid))
+            elif d_oid in state.accepted_dangle_oids:
+                net_scope = ScopeRecord(
+                    status="passed",
+                    norm_z=state.connection_norm_z_by_dangle.get(d_oid),
+                )
+                kru_scope = ScopeRecord(
+                    status="accepted",
+                    norm_z=state.global_norm_z_by_dangle.get(d_oid),
+                )
+                final_scope = kru_scope
+                final_gs = state.gap_source_by_dangle.get(d_oid)
             else:
                 # Local winner that didn't reach proposal construction
                 # (e.g. target dangle had no resolvable parent)
-                status = "selected_for_dangle"
-                reason = None
+                net_scope = ScopeRecord(status="passed")
+                kru_scope = None
+                final_scope = net_scope
                 final_gs = None
-                conn_nz = None
-                glob_nz = None
 
             result.append(
                 CandidateDiagnostic(
-                    parent_id=p_id,
-                    dangle_oid=d_oid,
-                    dangle_x=float(xy[0]),
-                    dangle_y=float(xy[1]),
-                    near_fc_key=str(cand["near_fc_key"]),
-                    near_fid=int(cand["near_fid"]),
-                    near_x=float(cand["near_x"]),
-                    near_y=float(cand["near_y"]),
-                    raw_distance=float(raw_dist),
-                    candidate_status=status,
-                    status_reason=reason,
-                    best_fit_score=float(best_fit),
+                    **self._make_base_diag_fields(entry.cand, entry.dangle_oid, entry.parent_id, xy, dangle_parent, dangles_key, lines_key),
+                    candidate_scope=cand_scope,
+                    network_scope=net_scope,
+                    kruskal_scope=kru_scope,
+                    deferred_scope=None,
+                    final_status=final_scope,
+                    best_fit_score=float(entry.best_fit),
                     best_fit_rank=rank,
-                    bonus_applied=bool(bonus),
-                    assess=assess,
-                    target_parent_id=self._resolve_target_parent_id(
-                        cand, dangle_parent, dangles_key, lines_key
-                    ),
+                    bonus_applied=bool(entry.bonus),
+                    norm_dist=float(entry.norm_dist),
+                    norm_angle=entry.norm_angle,
+                    assess=entry.assess,
                     final_gap_source=final_gs,
-                    start_z=sc_start_z,
-                    end_z=sc_end_z,
-                    dangle_norm_z=sc_norm_z,
-                    connection_norm_z=conn_nz,
-                    global_norm_z=glob_nz,
+                    start_z=entry.start_z,
+                    end_z=entry.end_z,
                 )
             )
         return result
@@ -5093,6 +5119,87 @@ class FillLineGaps:
             )
         return tuple(row)
 
+    @staticmethod
+    def _diag_field_names() -> tuple[str, ...]:
+        """Canonical ordered field list for the candidate-connections FC (excluding SHAPE@)."""
+        return (
+            "src_line_id",
+            "src_dangle_oid",
+            "target_ds_key",
+            "target_fid",
+            "target_parent_id",
+            "raw_distance",
+            "best_fit_score",
+            "best_fit_rank",
+            "bonus_applied",
+            "norm_dist",
+            "norm_angle",
+            "angle_metric_deg",
+            "src_connector_diff",
+            "connector_target_diff",
+            "src_target_diff",
+            "connector_transition_diff",
+            "candidate_scope_status",
+            "candidate_scope_reason",
+            "candidate_scope_norm_z",
+            "network_scope_status",
+            "network_scope_reason",
+            "network_scope_norm_z",
+            "kruskal_scope_status",
+            "kruskal_scope_reason",
+            "kruskal_scope_norm_z",
+            "deferred_scope_status",
+            "deferred_scope_reason",
+            "final_status",
+            "final_status_reason",
+            "final_gap_source",
+            "start_z",
+            "end_z",
+        )
+
+    @staticmethod
+    def _diag_row(d: "CandidateDiagnostic", geom: Any) -> tuple:
+        """Build one InsertCursor row tuple from a CandidateDiagnostic."""
+        a = d.assess
+        net = d.network_scope
+        kru = d.kruskal_scope
+        def_ = d.deferred_scope
+        return (
+            geom,
+            d.parent_id,
+            d.dangle_oid,
+            d.near_fc_key,
+            d.near_fid,
+            d.target_parent_id,
+            d.raw_distance,
+            d.best_fit_score,
+            d.best_fit_rank,
+            int(bool(d.bonus_applied)) if d.bonus_applied is not None else None,
+            d.norm_dist,
+            d.norm_angle,
+            a.angle_metric_deg if a is not None else None,
+            a.src_connector_diff if a is not None else None,
+            a.connector_target_diff if a is not None else None,
+            a.src_target_diff if a is not None else None,
+            a.connector_transition_diff if a is not None else None,
+            d.candidate_scope.status,
+            d.candidate_scope.reason,
+            d.candidate_scope.norm_z,
+            net.status if net is not None else None,
+            net.reason if net is not None else None,
+            net.norm_z if net is not None else None,
+            kru.status if kru is not None else None,
+            kru.reason if kru is not None else None,
+            kru.norm_z if kru is not None else None,
+            def_.status if def_ is not None else None,
+            def_.reason if def_ is not None else None,
+            d.final_status.status,
+            d.final_status.reason,
+            d.final_gap_source,
+            d.start_z,
+            d.end_z,
+        )
+
     def _setup_candidate_connections_output(self, fc_path: str) -> None:
         """Create and schema the candidate-connections diagnostic feature class."""
         sr = arcpy.Describe(self.lines_copy).spatialReference
@@ -5105,31 +5212,46 @@ class FillLineGaps:
             geometry_type="POLYLINE",
             spatial_reference=sr,
         )
-        arcpy.management.AddField(fc_path, "src_line_id", "LONG")
-        arcpy.management.AddField(fc_path, "src_dangle_oid", "LONG")
-        arcpy.management.AddField(fc_path, "target_ds_key", "TEXT", field_length=100)
-        arcpy.management.AddField(fc_path, "target_fid", "LONG")
-        arcpy.management.AddField(fc_path, "target_parent_id", "LONG")
-        arcpy.management.AddField(fc_path, "raw_distance", "DOUBLE")
-        arcpy.management.AddField(fc_path, "best_fit_score", "DOUBLE")
-        arcpy.management.AddField(fc_path, "best_fit_rank", "SHORT")
-        arcpy.management.AddField(fc_path, "bonus_applied", "SHORT")
-        for fname in (
-            "angle_metric_deg",
-            "src_connector_diff",
-            "connector_target_diff",
-            "src_target_diff",
-            "connector_transition_diff",
-        ):
-            arcpy.management.AddField(fc_path, fname, "DOUBLE")
-        arcpy.management.AddField(fc_path, "final_gap_source", "TEXT", field_length=20)
-        arcpy.management.AddField(fc_path, "candidate_status", "TEXT", field_length=25)
-        arcpy.management.AddField(fc_path, "status_reason", "TEXT", field_length=50)
-        arcpy.management.AddField(fc_path, "start_z", "DOUBLE")
-        arcpy.management.AddField(fc_path, "end_z", "DOUBLE")
-        arcpy.management.AddField(fc_path, "dangle_norm_z", "DOUBLE")
-        arcpy.management.AddField(fc_path, "connection_norm_z", "DOUBLE")
-        arcpy.management.AddField(fc_path, "global_norm_z", "DOUBLE")
+        _text50 = {"field_type": "TEXT", "field_length": 50}
+        _dbl = {"field_type": "DOUBLE"}
+        _long = {"field_type": "LONG"}
+        _short = {"field_type": "SHORT"}
+        field_specs: list[tuple[str, dict]] = [
+            ("src_line_id", _long),
+            ("src_dangle_oid", _long),
+            ("target_ds_key", {"field_type": "TEXT", "field_length": 100}),
+            ("target_fid", _long),
+            ("target_parent_id", _long),
+            ("raw_distance", _dbl),
+            ("best_fit_score", _dbl),
+            ("best_fit_rank", _short),
+            ("bonus_applied", _short),
+            ("norm_dist", _dbl),
+            ("norm_angle", _dbl),
+            ("angle_metric_deg", _dbl),
+            ("src_connector_diff", _dbl),
+            ("connector_target_diff", _dbl),
+            ("src_target_diff", _dbl),
+            ("connector_transition_diff", _dbl),
+            ("candidate_scope_status", _text50),
+            ("candidate_scope_reason", _text50),
+            ("candidate_scope_norm_z", _dbl),
+            ("network_scope_status", _text50),
+            ("network_scope_reason", _text50),
+            ("network_scope_norm_z", _dbl),
+            ("kruskal_scope_status", _text50),
+            ("kruskal_scope_reason", _text50),
+            ("kruskal_scope_norm_z", _dbl),
+            ("deferred_scope_status", _text50),
+            ("deferred_scope_reason", _text50),
+            ("final_status", _text50),
+            ("final_status_reason", _text50),
+            ("final_gap_source", {"field_type": "TEXT", "field_length": 20}),
+            ("start_z", _dbl),
+            ("end_z", _dbl),
+        ]
+        for fname, kwargs in field_specs:
+            arcpy.management.AddField(fc_path, fname, **kwargs)
 
     def _write_candidate_connections_output(
         self,
@@ -5140,31 +5262,7 @@ class FillLineGaps:
         """Write one row per CandidateDiagnostic to the candidate-connections feature class."""
         if not diagnostics:
             return
-        fields = [
-            "SHAPE@",
-            "src_line_id",
-            "src_dangle_oid",
-            "target_ds_key",
-            "target_fid",
-            "target_parent_id",
-            "raw_distance",
-            "best_fit_score",
-            "best_fit_rank",
-            "bonus_applied",
-            "angle_metric_deg",
-            "src_connector_diff",
-            "connector_target_diff",
-            "src_target_diff",
-            "connector_transition_diff",
-            "final_gap_source",
-            "candidate_status",
-            "status_reason",
-            "start_z",
-            "end_z",
-            "dangle_norm_z",
-            "connection_norm_z",
-            "global_norm_z",
-        ]
+        fields = ("SHAPE@",) + self._diag_field_names()
         with arcpy.da.InsertCursor(fc_path, fields) as cur:
             for d in diagnostics:
                 arr = arcpy.Array(
@@ -5174,34 +5272,7 @@ class FillLineGaps:
                     ]
                 )
                 geom = arcpy.Polyline(arr, spatial_reference)
-                a = d.assess
-                cur.insertRow(
-                    (
-                        geom,
-                        d.parent_id,
-                        d.dangle_oid,
-                        d.near_fc_key,
-                        d.near_fid,
-                        d.target_parent_id,
-                        d.raw_distance,
-                        d.best_fit_score,
-                        d.best_fit_rank,
-                        int(bool(d.bonus_applied)),
-                        a.angle_metric_deg if a is not None else None,
-                        a.src_connector_diff if a is not None else None,
-                        a.connector_target_diff if a is not None else None,
-                        a.src_target_diff if a is not None else None,
-                        a.connector_transition_diff if a is not None else None,
-                        d.final_gap_source,
-                        d.candidate_status,
-                        d.status_reason,
-                        d.start_z,
-                        d.end_z,
-                        d.dangle_norm_z,
-                        d.connection_norm_z,
-                        d.global_norm_z,
-                    )
-                )
+                cur.insertRow(self._diag_row(d, geom))
 
     def _apply_plan(self, plan) -> None:
         if not plan:
@@ -5402,6 +5473,7 @@ class FillLineGaps:
                     resnap_plan,
                     resnap_crossing_rejected_oids,
                     resnap_crossing_displaced_oids,
+                    resnap_crossing_winner_oids,
                 ) = self._recheck_resnap_crossings(
                     resnap_plan=resnap_plan,
                     accepted_connector_raw=accepted_connector_raw,
@@ -5414,6 +5486,7 @@ class FillLineGaps:
             else:
                 resnap_crossing_rejected_oids: set[int] = set()
                 resnap_crossing_displaced_oids: set[int] = set()
+                resnap_crossing_winner_oids: set[int] = set()
 
             self._apply_plan(resnap_plan)
 
@@ -5427,14 +5500,21 @@ class FillLineGaps:
                 }
                 for diag in diagnostics:
                     d_oid = int(diag.dangle_oid)
-                    if diag.candidate_status == "applied_to_output":
+                    if diag.kruskal_scope is not None and diag.kruskal_scope.status == "accepted":
                         if d_oid in resnap_crossing_displaced_oids:
-                            diag.status_reason = "resnap_crossing_displaced"
+                            deferred = ScopeRecord(status="resnap_crossing_displaced")
+                            diag.deferred_scope = deferred
+                            diag.final_status = deferred
+                        elif d_oid in resnap_crossing_winner_oids:
+                            diag.deferred_scope = ScopeRecord(status="referenced_as_winner")
                         elif d_oid in resnapped_dangle_oids:
-                            diag.status_reason = "applied_resnapped"
-                    elif diag.candidate_status == "selected_for_dangle":
-                        if d_oid in resnap_crossing_rejected_oids:
-                            diag.status_reason = "resnap_crossing_rejected"
+                            deferred = ScopeRecord(status="applied_resnapped")
+                            diag.deferred_scope = deferred
+                            diag.final_status = deferred
+                        elif d_oid in resnap_crossing_rejected_oids:
+                            deferred = ScopeRecord(status="resnap_crossing_rejected")
+                            diag.deferred_scope = deferred
+                            diag.final_status = deferred
 
         if self.candidate_connections_output is not None and diagnostics:
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+from dataclasses import dataclass
 
-from typing import Optional
+from typing import Optional, Callable, Iterable
 
 import arcpy
 
@@ -8,6 +9,692 @@ from env_setup import environment_setup
 from custom_tools.general_tools import custom_arcpy, file_utilities
 from file_manager import WorkFileManager
 from composition_configs import logic_config
+from composition_configs.logic_config import ConnectivityScope, LineConnectivityMode
+
+
+OptionalKey = tuple[str, int]  # (dataset_key, oid)  -- oid is SOURCE oid
+ParentEntityKey = tuple[str, int]  # ("parent", parent_id)
+OptionalEntityKey = tuple[str, str, int]  # ("optional", dataset_key, oid)
+EntityKey = tuple  # union-ish (kept simple)
+
+
+@dataclass(frozen=True)
+class TopologyModel:
+    scope: "ConnectivityScope"
+
+    # Component modes only (INPUT_LINES / ONE_DEGREE / TRANSITIVE)
+    connectivity_id_by_parent: Optional[dict[int, int]]
+    connectivity_id_by_optional: Optional[dict[OptionalKey, int]]
+    entities_by_connectivity_id: Optional[dict[int, set[EntityKey]]]
+
+    # DIRECT_CONNECTION only (required); allowed to be None otherwise
+    direct_neighbors_by_parent: Optional[dict[int, set[int]]]
+    direct_optionals_by_parent: Optional[dict[int, set[OptionalKey]]]
+
+
+class _UnionFind:
+    def __init__(self) -> None:
+        self._parent: dict[EntityKey, EntityKey] = {}
+        self._rank: dict[EntityKey, int] = {}
+
+    def add(self, x: EntityKey) -> None:
+        if x in self._parent:
+            return
+        self._parent[x] = x
+        self._rank[x] = 0
+
+    def find(self, x: EntityKey) -> EntityKey:
+        # Path compression
+        p = self._parent.get(x)
+        if p is None:
+            self.add(x)
+            return x
+        if p != x:
+            self._parent[x] = self.find(p)
+        return self._parent[x]
+
+    def union(self, a: EntityKey, b: EntityKey) -> None:
+        ra = self.find(a)
+        rb = self.find(b)
+        if ra == rb:
+            return
+        rka = self._rank.get(ra, 0)
+        rkb = self._rank.get(rb, 0)
+        if rka < rkb:
+            self._parent[ra] = rb
+        elif rka > rkb:
+            self._parent[rb] = ra
+        else:
+            self._parent[rb] = ra
+            self._rank[ra] = rka + 1
+
+    def components(self) -> dict[EntityKey, set[EntityKey]]:
+        out: dict[EntityKey, set[EntityKey]] = {}
+        for x in list(self._parent.keys()):
+            r = self.find(x)
+            out.setdefault(r, set()).add(x)
+        return out
+
+
+class TopologyBuilder:
+    """
+    Value-neutral connectivity inference.
+
+    IMPORTANT:
+    - Does NOT use dangle candidate layers.
+    - Uses explicit connectivity_tolerance_meters (not arcpy.env.XYTolerance).
+    - Optional objects are keyed by (dataset_key, SOURCE_OID).
+    """
+
+    def __init__(
+        self,
+        *,
+        lines_fc: str,
+        original_id_field: str,
+        connect_to_features: Optional[list[str]],
+        dataset_key_fn: Callable[[str], str],
+        wfm,
+        write_work_files_to_memory: bool,
+        connectivity_tolerance_meters: float,
+        line_connectivity_mode: "LineConnectivityMode",
+    ) -> None:
+        self.lines_fc = lines_fc
+        self.original_id_field = original_id_field
+        self.connect_to_features = connect_to_features or []
+        self.dataset_key_fn = dataset_key_fn
+        self.wfm = wfm
+        self.write_work_files_to_memory = bool(write_work_files_to_memory)
+        self.tol_m = float(connectivity_tolerance_meters)
+        self.line_mode = line_connectivity_mode
+
+    def build(
+        self,
+        *,
+        scope: "ConnectivityScope",
+        relevant_parent_ids: set[int],
+    ) -> TopologyModel:
+        scope = ConnectivityScope(scope)
+
+        if scope == ConnectivityScope.NONE:
+            return TopologyModel(
+                scope=scope,
+                connectivity_id_by_parent=None,
+                connectivity_id_by_optional=None,
+                entities_by_connectivity_id=None,
+                direct_neighbors_by_parent=None,
+                direct_optionals_by_parent=None,
+            )
+
+        if scope == ConnectivityScope.DIRECT_CONNECTION:
+            direct_neighbors = self._build_parent_adjacency(
+                restrict_to_parent_ids=set(relevant_parent_ids)
+            )
+            direct_optionals = self._build_parent_optionals(
+                parent_ids=set(relevant_parent_ids),
+                optional_paths=self.connect_to_features,
+                use_connectivity_layers=False,
+                transitive_expand=False,
+            )
+            # Ensure required keys exist for all relevant parents
+            for pid in relevant_parent_ids:
+                direct_neighbors.setdefault(int(pid), set())
+                direct_optionals.setdefault(int(pid), set())
+
+            return TopologyModel(
+                scope=scope,
+                connectivity_id_by_parent=None,
+                connectivity_id_by_optional=None,
+                entities_by_connectivity_id=None,
+                direct_neighbors_by_parent=direct_neighbors,
+                direct_optionals_by_parent=direct_optionals,
+            )
+
+        # Component modes:
+        # - INPUT_LINES: line-only components
+        # - ONE_DEGREE: merge via shared optionals (no optional↔optional traversal)
+        # - TRANSITIVE: full closure incl optional↔optional edges
+        parent_adjacency = self._build_parent_adjacency(restrict_to_parent_ids=None)
+
+        if scope == ConnectivityScope.INPUT_LINES:
+            cid_by_parent, entities_by_cid = self._components_from_line_only(
+                parent_adjacency=parent_adjacency
+            )
+
+            # Attachments are allowed (optional); compute only for relevant parents
+            direct_optionals = self._build_parent_optionals(
+                parent_ids=set(relevant_parent_ids),
+                optional_paths=self.connect_to_features,
+                use_connectivity_layers=False,
+                transitive_expand=False,
+            )
+
+            return TopologyModel(
+                scope=scope,
+                connectivity_id_by_parent=cid_by_parent,
+                connectivity_id_by_optional=None,
+                entities_by_connectivity_id=entities_by_cid,
+                direct_neighbors_by_parent=None,
+                direct_optionals_by_parent=direct_optionals,
+            )
+
+        # ONE_DEGREE / TRANSITIVE
+        if not self.connect_to_features:
+            # No optionals to participate; degrade to line-only components
+            cid_by_parent, entities_by_cid = self._components_from_line_only(
+                parent_adjacency=parent_adjacency
+            )
+            return TopologyModel(
+                scope=scope,
+                connectivity_id_by_parent=cid_by_parent,
+                connectivity_id_by_optional=None,
+                entities_by_connectivity_id=entities_by_cid,
+                direct_neighbors_by_parent=None,
+                direct_optionals_by_parent=None,
+            )
+
+        transitive_expand = scope == ConnectivityScope.TRANSITIVE
+
+        # Build reduced connectivity layers for optionals (feature layers with selection),
+        # seeded by lines_fc (NOT dangles), optionally expanded within dataset for TRANSITIVE.
+        optional_layers = self._build_optional_connectivity_layers(
+            optional_paths=self.connect_to_features,
+            transitive_expand=transitive_expand,
+        )
+
+        parent_to_optional = self._build_parent_optionals(
+            parent_ids=None,  # compute for all parents that touch selected optionals
+            optional_paths=self.connect_to_features,
+            use_connectivity_layers=True,
+            transitive_expand=transitive_expand,
+            optional_layers=optional_layers,
+        )
+
+        uf = _UnionFind()
+
+        # Ensure all parent nodes exist (so isolated parents get deterministic ids too)
+        for pid in self._iter_all_parent_ids():
+            uf.add(("parent", int(pid)))
+
+        # Add selected optional nodes
+        for ds_key, opt_layer in optional_layers:
+            oid_field = arcpy.Describe(opt_layer).OIDFieldName
+            with arcpy.da.SearchCursor(opt_layer, [oid_field]) as cur:
+                for (oid,) in cur:
+                    uf.add(("optional", str(ds_key), int(oid)))
+
+        # parent↔parent unions
+        for a, nbs in parent_adjacency.items():
+            a_ent: ParentEntityKey = ("parent", int(a))
+            for b in nbs:
+                uf.union(a_ent, ("parent", int(b)))
+
+        # parent↔optional unions (ONE_DEGREE + TRANSITIVE)
+        for pid, opt_keys in parent_to_optional.items():
+            p_ent: ParentEntityKey = ("parent", int(pid))
+            for ds_key, oid in opt_keys:
+                uf.union(p_ent, ("optional", str(ds_key), int(oid)))
+
+        # optional↔optional unions (TRANSITIVE only)
+        if scope == ConnectivityScope.TRANSITIVE:
+            for ds_a, layer_a in optional_layers:
+                # within-dataset
+                self._union_optional_optional_edges(
+                    uf=uf,
+                    in_layer=layer_a,
+                    near_layer=layer_a,
+                    ds_in=str(ds_a),
+                    ds_near=str(ds_a),
+                )
+            # cross-dataset
+            for i in range(len(optional_layers)):
+                ds_i, lyr_i = optional_layers[i]
+                for j in range(i + 1, len(optional_layers)):
+                    ds_j, lyr_j = optional_layers[j]
+                    self._union_optional_optional_edges(
+                        uf=uf,
+                        in_layer=lyr_i,
+                        near_layer=lyr_j,
+                        ds_in=str(ds_i),
+                        ds_near=str(ds_j),
+                    )
+
+        cid_by_parent, cid_by_optional, entities_by_cid = self._assign_component_ids(uf)
+
+        return TopologyModel(
+            scope=scope,
+            connectivity_id_by_parent=cid_by_parent,
+            connectivity_id_by_optional=cid_by_optional,
+            entities_by_connectivity_id=entities_by_cid,
+            direct_neighbors_by_parent=None,
+            direct_optionals_by_parent=parent_to_optional,  # useful primitive
+        )
+
+    # ----------------------------
+    # Parent ids
+    # ----------------------------
+
+    def _iter_all_parent_ids(self) -> Iterable[int]:
+        with arcpy.da.SearchCursor(self.lines_fc, [self.original_id_field]) as cur:
+            for (pid,) in cur:
+                yield int(pid)
+
+    # ----------------------------
+    # Parent↔parent adjacency
+    # ----------------------------
+
+    def _build_parent_adjacency(
+        self, *, restrict_to_parent_ids: Optional[set[int]]
+    ) -> dict[int, set[int]]:
+        if self.line_mode == LineConnectivityMode.INTERSECT:
+            return self._build_parent_adjacency_intersect(restrict_to_parent_ids)
+        return self._build_parent_adjacency_endpoints(restrict_to_parent_ids)
+
+    def _build_parent_adjacency_endpoints(
+        self, restrict_to_parent_ids: Optional[set[int]]
+    ) -> dict[int, set[int]]:
+        endpoints_fc = self.wfm.build_file_path(file_name="topo_line_endpoints")
+        arcpy.management.FeatureVerticesToPoints(
+            self.lines_fc, endpoints_fc, "BOTH_ENDS"
+        )
+
+        endpoints_lyr = "topo_endpoints_lyr"
+        arcpy.management.MakeFeatureLayer(endpoints_fc, endpoints_lyr)
+
+        if restrict_to_parent_ids:
+            where = self._where_in_ints(
+                endpoints_fc, self.original_id_field, restrict_to_parent_ids
+            )
+            arcpy.management.SelectLayerByAttribute(
+                endpoints_lyr, "NEW_SELECTION", where
+            )
+
+        near_table = self.wfm.build_file_path(file_name="topo_endpoints_near_lines")
+        arcpy.analysis.GenerateNearTable(
+            in_features=endpoints_lyr,
+            near_features=[self.lines_fc],
+            out_table=near_table,
+            search_radius=self._meters(self.tol_m),
+            location="NO_LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=100,
+            method="PLANAR",
+        )
+
+        # endpoint OID -> parent_id
+        endpoint_oid = arcpy.Describe(endpoints_lyr).OIDFieldName
+        endpoint_parent: dict[int, int] = {}
+        with arcpy.da.SearchCursor(
+            endpoints_lyr, [endpoint_oid, self.original_id_field]
+        ) as cur:
+            for eo, pid in cur:
+                endpoint_parent[int(eo)] = int(pid)
+
+        # line OID -> parent_id (ORIGINAL_ID space)
+        lines_oid = arcpy.Describe(self.lines_fc).OIDFieldName
+        line_oid_to_parent: dict[int, int] = {}
+        with arcpy.da.SearchCursor(
+            self.lines_fc, [lines_oid, self.original_id_field]
+        ) as cur:
+            for oid, pid in cur:
+                line_oid_to_parent[int(oid)] = int(pid)
+
+        out: dict[int, set[int]] = {}
+        fields = ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+        with arcpy.da.SearchCursor(near_table, fields) as cur:
+            for in_fid, near_fid, near_dist in cur:
+                if near_fid is None or near_dist is None:
+                    continue
+                if float(near_dist) >= float(self.tol_m):
+                    continue
+                a_parent = endpoint_parent.get(int(in_fid))
+                if a_parent is None:
+                    continue
+                b_parent = line_oid_to_parent.get(int(near_fid))
+                if b_parent is None:
+                    continue
+                if int(a_parent) == int(b_parent):
+                    continue
+                out.setdefault(int(a_parent), set()).add(int(b_parent))
+                out.setdefault(int(b_parent), set()).add(int(a_parent))
+        return out
+
+    def _build_parent_adjacency_intersect(
+        self, restrict_to_parent_ids: Optional[set[int]]
+    ) -> dict[int, set[int]]:
+        lines_lyr = "topo_lines_lyr"
+        arcpy.management.MakeFeatureLayer(self.lines_fc, lines_lyr)
+
+        if restrict_to_parent_ids:
+            where = self._where_in_ints(
+                self.lines_fc, self.original_id_field, restrict_to_parent_ids
+            )
+            arcpy.management.SelectLayerByAttribute(lines_lyr, "NEW_SELECTION", where)
+
+        near_table = self.wfm.build_file_path(file_name="topo_lines_near_lines")
+        arcpy.analysis.GenerateNearTable(
+            in_features=lines_lyr,
+            near_features=[self.lines_fc],
+            out_table=near_table,
+            search_radius=self._meters(self.tol_m),
+            location="NO_LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=100,
+            method="PLANAR",
+        )
+
+        lines_oid = arcpy.Describe(self.lines_fc).OIDFieldName
+        line_oid_to_parent: dict[int, int] = {}
+        with arcpy.da.SearchCursor(
+            self.lines_fc, [lines_oid, self.original_id_field]
+        ) as cur:
+            for oid, pid in cur:
+                line_oid_to_parent[int(oid)] = int(pid)
+
+        out: dict[int, set[int]] = {}
+        fields = ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+        with arcpy.da.SearchCursor(near_table, fields) as cur:
+            for in_fid, near_fid, near_dist in cur:
+                if near_fid is None or near_dist is None:
+                    continue
+                if float(near_dist) > float(self.tol_m):
+                    continue
+                a_parent = line_oid_to_parent.get(int(in_fid))
+                b_parent = line_oid_to_parent.get(int(near_fid))
+                if a_parent is None or b_parent is None:
+                    continue
+                if int(a_parent) == int(b_parent):
+                    continue
+                out.setdefault(int(a_parent), set()).add(int(b_parent))
+                out.setdefault(int(b_parent), set()).add(int(a_parent))
+        return out
+
+    # ----------------------------
+    # Parent↔optional links (whole-geometry; value-neutral)
+    # ----------------------------
+
+    def _build_optional_connectivity_layers(
+        self, *, optional_paths: list[str], transitive_expand: bool
+    ) -> list[tuple[str, str]]:
+        """
+        Returns [(dataset_key, selected_feature_layer_name), ...]
+        Selection is seeded by lines_fc (NOT dangles). For TRANSITIVE, expands optional↔optional
+        within the same dataset until stable.
+        """
+        out: list[tuple[str, str]] = []
+        overlap_type, search_distance = self._overlap_for_tol()
+
+        for index, path in enumerate(optional_paths):
+            ds_key = self.dataset_key_fn(path)
+            lyr = f"topo_opt_{index}_lyr"
+            arcpy.management.MakeFeatureLayer(path, lyr)
+
+            arcpy.management.SelectLayerByLocation(
+                in_layer=lyr,
+                overlap_type=overlap_type,
+                select_features=self.lines_fc,
+                search_distance=search_distance,
+                selection_type="NEW_SELECTION",
+            )
+
+            if transitive_expand:
+                # Expansion within dataset:
+                # Repeatedly add optionals that intersect/touch the current selection until stable.
+                # NOTE: passing a layer with a selection uses the selection set as the geometry source.
+                prev = -1
+                while True:
+                    cur = int(arcpy.management.GetCount(lyr)[0])
+                    if cur == prev:
+                        break
+                    prev = cur
+                    arcpy.management.SelectLayerByLocation(
+                        in_layer=lyr,
+                        overlap_type=overlap_type,
+                        select_features=lyr,
+                        search_distance=search_distance,
+                        selection_type="ADD_TO_SELECTION",
+                    )
+
+            out.append((str(ds_key), lyr))
+
+        return out
+
+    def _build_parent_optionals(
+        self,
+        *,
+        parent_ids: Optional[set[int]],
+        optional_paths: list[str],
+        use_connectivity_layers: bool,
+        transitive_expand: bool,
+        optional_layers: Optional[list[tuple[str, str]]] = None,
+    ) -> dict[int, set[OptionalKey]]:
+        """
+        Returns parent_id -> set[(dataset_key, source_oid)].
+
+        - DIRECT_CONNECTION / INPUT_LINES attachments:
+            use_connectivity_layers=False; builds links against original datasets.
+            If parent_ids is provided, only computes for those parents.
+
+        - ONE_DEGREE / TRANSITIVE component modes:
+            use_connectivity_layers=True; links against selected optional layers.
+            parent_ids is ignored (we compute for all parents that touch selected optionals).
+        """
+        out: dict[int, set[OptionalKey]] = {}
+
+        if not optional_paths:
+            return out
+
+        # Lines layer, optionally restricted to specific parents
+        lines_lyr = "topo_lines_for_opt_lyr"
+        arcpy.management.MakeFeatureLayer(self.lines_fc, lines_lyr)
+        if parent_ids is not None:
+            where = self._where_in_ints(
+                self.lines_fc, self.original_id_field, parent_ids
+            )
+            arcpy.management.SelectLayerByAttribute(lines_lyr, "NEW_SELECTION", where)
+
+        overlap_type, search_distance = self._overlap_for_tol()
+
+        if use_connectivity_layers:
+            if optional_layers is None:
+                optional_layers = self._build_optional_connectivity_layers(
+                    optional_paths=optional_paths,
+                    transitive_expand=transitive_expand,
+                )
+
+            # Restrict lines to those near selected optionals (correct + faster than scanning all lines)
+            # Union all optionals by selecting against each optional layer
+            arcpy.management.SelectLayerByAttribute(lines_lyr, "CLEAR_SELECTION")
+            for _, opt_lyr in optional_layers:
+                arcpy.management.SelectLayerByLocation(
+                    in_layer=lines_lyr,
+                    overlap_type=overlap_type,
+                    select_features=opt_lyr,
+                    search_distance=search_distance,
+                    selection_type="ADD_TO_SELECTION",
+                )
+
+            # Now link per dataset-layer (so dataset_key is explicit and stable)
+            for ds_key, opt_lyr in optional_layers:
+                table = self.wfm.build_file_path(
+                    file_name=f"topo_lines_to_opt_{ds_key}"
+                )
+                arcpy.analysis.GenerateNearTable(
+                    in_features=lines_lyr,
+                    near_features=[opt_lyr],
+                    out_table=table,
+                    search_radius=self._meters(self.tol_m),
+                    location="NO_LOCATION",
+                    angle="NO_ANGLE",
+                    closest="ALL",
+                    closest_count=200,
+                    method="PLANAR",
+                )
+
+                # IN_FID is line OID, but we want parent_id from ORIGINAL_ID
+                lines_oid = arcpy.Describe(self.lines_fc).OIDFieldName
+                line_oid_to_parent: dict[int, int] = {}
+                with arcpy.da.SearchCursor(
+                    self.lines_fc, [lines_oid, self.original_id_field]
+                ) as cur:
+                    for oid, pid in cur:
+                        line_oid_to_parent[int(oid)] = int(pid)
+
+                fields = ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+                with arcpy.da.SearchCursor(table, fields) as cur:
+                    for in_fid, near_fid, near_dist in cur:
+                        if near_fid is None or near_dist is None:
+                            continue
+                        if float(near_dist) > float(self.tol_m):
+                            continue
+                        pid = line_oid_to_parent.get(int(in_fid))
+                        if pid is None:
+                            continue
+                        out.setdefault(int(pid), set()).add(
+                            (str(ds_key), int(near_fid))
+                        )
+            return out
+
+        # Non-connectivity-layer mode: link per original dataset path (stable ds_key)
+        for path in optional_paths:
+            ds_key = self.dataset_key_fn(path)
+            table = self.wfm.build_file_path(
+                file_name=f"topo_lines_to_opt_attach_{ds_key}"
+            )
+
+            arcpy.analysis.GenerateNearTable(
+                in_features=lines_lyr,
+                near_features=[path],
+                out_table=table,
+                search_radius=self._meters(self.tol_m),
+                location="NO_LOCATION",
+                angle="NO_ANGLE",
+                closest="ALL",
+                closest_count=200,
+                method="PLANAR",
+            )
+
+            lines_oid = arcpy.Describe(self.lines_fc).OIDFieldName
+            line_oid_to_parent: dict[int, int] = {}
+            with arcpy.da.SearchCursor(
+                self.lines_fc, [lines_oid, self.original_id_field]
+            ) as cur:
+                for oid, pid in cur:
+                    line_oid_to_parent[int(oid)] = int(pid)
+
+            fields = ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+            with arcpy.da.SearchCursor(table, fields) as cur:
+                for in_fid, near_fid, near_dist in cur:
+                    if near_fid is None or near_dist is None:
+                        continue
+                    if float(near_dist) > float(self.tol_m):
+                        continue
+                    pid = line_oid_to_parent.get(int(in_fid))
+                    if pid is None:
+                        continue
+                    out.setdefault(int(pid), set()).add((str(ds_key), int(near_fid)))
+
+        return out
+
+    def _union_optional_optional_edges(
+        self,
+        *,
+        uf: _UnionFind,
+        in_layer: str,
+        near_layer: str,
+        ds_in: str,
+        ds_near: str,
+    ) -> None:
+        """
+        Adds undirected optional↔optional edges to union-find for TRANSITIVE.
+        """
+        table = self.wfm.build_file_path(file_name=f"topo_optopt_{ds_in}_to_{ds_near}")
+        arcpy.analysis.GenerateNearTable(
+            in_features=in_layer,
+            near_features=[near_layer],
+            out_table=table,
+            search_radius=self._meters(self.tol_m),
+            location="NO_LOCATION",
+            angle="NO_ANGLE",
+            closest="ALL",
+            closest_count=500,
+            method="PLANAR",
+        )
+
+        fields = ["IN_FID", "NEAR_FID", "NEAR_DIST"]
+        with arcpy.da.SearchCursor(table, fields) as cur:
+            for in_fid, near_fid, near_dist in cur:
+                if near_fid is None or near_dist is None:
+                    continue
+                if float(near_dist) > float(self.tol_m):
+                    continue
+                if int(in_fid) == int(near_fid) and ds_in == ds_near:
+                    continue
+                uf.union(
+                    ("optional", str(ds_in), int(in_fid)),
+                    ("optional", str(ds_near), int(near_fid)),
+                )
+
+    # ----------------------------
+    # Components + determinism
+    # ----------------------------
+
+    def _components_from_line_only(
+        self, *, parent_adjacency: dict[int, set[int]]
+    ) -> tuple[dict[int, int], dict[int, set[EntityKey]]]:
+        uf = _UnionFind()
+        for pid in self._iter_all_parent_ids():
+            uf.add(("parent", int(pid)))
+        for a, nbs in parent_adjacency.items():
+            for b in nbs:
+                uf.union(("parent", int(a)), ("parent", int(b)))
+        cid_by_parent, _, entities_by_cid = self._assign_component_ids(uf)
+        return cid_by_parent, entities_by_cid
+
+    def _assign_component_ids(
+        self, uf: _UnionFind
+    ) -> tuple[dict[int, int], dict[OptionalKey, int], dict[int, set[EntityKey]]]:
+        comps = uf.components()  # root -> set[entity]
+        # Deterministic ordering by smallest entity key (tuple ordering is deterministic)
+        ordered = sorted((min(members), root) for root, members in comps.items())
+
+        cid_by_parent: dict[int, int] = {}
+        cid_by_optional: dict[OptionalKey, int] = {}
+        entities_by_cid: dict[int, set[EntityKey]] = {}
+
+        for idx, (_, root) in enumerate(ordered, start=1):
+            members = comps[root]
+            entities_by_cid[idx] = set(members)
+            for ent in members:
+                if not ent:
+                    continue
+                if ent[0] == "parent":
+                    cid_by_parent[int(ent[1])] = int(idx)
+                elif ent[0] == "optional":
+                    cid_by_optional[(str(ent[1]), int(ent[2]))] = int(idx)
+
+        return cid_by_parent, cid_by_optional, entities_by_cid
+
+    # ----------------------------
+    # Small helpers
+    # ----------------------------
+
+    def _meters(self, value_m: float) -> str:
+        return f"{float(value_m)} Meters"
+
+    def _overlap_for_tol(self) -> tuple[str, Optional[str]]:
+        if float(self.tol_m) <= 0.0:
+            return "INTERSECT", None
+        return "WITHIN_A_DISTANCE", self._meters(self.tol_m)
+
+    def _where_in_ints(self, fc: str, field_name: str, ids: set[int]) -> str:
+        # Defensive for empty sets
+        safe = sorted({int(v) for v in ids})
+        if not safe:
+            return "1=0"
+        fld = arcpy.AddFieldDelimiters(fc, field_name)
+        return f"{fld} IN ({','.join(str(v) for v in safe)})"
 
 
 class FillLineGaps:
@@ -43,7 +730,12 @@ class FillLineGaps:
             adv.increased_tolerance_edge_case_distance_meters
         )
         self.edit_method = logic_config.EditMethod(adv.edit_method)
-        self.propagate_illigal_targets = adv.propagating_illigal_targets
+
+        self.connectivity_scope = logic_config.ConnectivityScope(adv.connectivity_scope)
+        self.connectivity_tolerance_meters = float(adv.connectivity_tolerance_meters)
+        self.line_connectivity_mode = logic_config.LineConnectivityMode(
+            adv.line_connectivity_mode
+        )
 
         if self.connect_to_features is None and self.fill_gaps_on_self is False:
             raise ValueError(
@@ -95,6 +787,10 @@ class FillLineGaps:
     def _expanded_dangle_tolerance_linear_unit(self) -> str:
         return f"{int(self._expanded_dangle_tolerance_meters())} Meters"
 
+    def _connectivity_tolerance_linear_unit(self) -> str:
+        meters = max(0.0, float(self.connectivity_tolerance_meters))
+        return f"{meters} Meters"
+
     def _dataset_key(self, value: str) -> str:
         text = str(value).replace("\\", "/")
         return text.split("/")[-1]
@@ -132,6 +828,30 @@ class FillLineGaps:
         if str(gap_source) == self.GAP_SOURCE_PAIR_DANGLE:
             return logic_config.EditOp.SNAP
         return logic_config.EditOp.EXTEND
+
+    def _same_network(
+        self,
+        *,
+        a_parent: int,
+        b_parent: int,
+        topology: TopologyModel,
+    ) -> bool:
+        scope = topology.scope
+
+        if scope == logic_config.ConnectivityScope.NONE:
+            return False
+
+        if scope == logic_config.ConnectivityScope.DIRECT_CONNECTION:
+            direct = topology.direct_neighbors_by_parent or {}
+            return int(b_parent) in direct.get(int(a_parent), set())
+
+        # Component modes:
+        cid = topology.connectivity_id_by_parent
+        if not cid:
+            return False
+        a = cid.get(int(a_parent))
+        b = cid.get(int(b_parent))
+        return a is not None and b is not None and int(a) == int(b)
 
     def _choose_endpoint_index(
         self, *, points: list, dangle_x: float, dangle_y: float, tol: float = 0.001
@@ -341,13 +1061,17 @@ class FillLineGaps:
         *,
         dangle_parent: dict[int, int],
         target_layers: list[str],
-    ) -> tuple[dict[int, dict[str, set[int]]], dict[int, set[int]]]:
+        topology: TopologyModel,
+    ) -> dict[int, dict[str, set[int]]]:
         """
         illegal[parent_id][dataset_key] -> set(objectid)
 
         Clauses:
-          - self line
-          - objects connected to parent line endpoints
+        - self line
+        - objects connected to parent line endpoints
+
+        Propagation:
+        - Scope-dependent, using topology connectivity ids (not local BFS adjacency).
         """
         illegal: dict[int, dict[str, set[int]]] = {}
 
@@ -355,16 +1079,83 @@ class FillLineGaps:
             illegal=illegal,
             parent_ids=set(dangle_parent.values()),
         )
-        adjacency = self._illegal_connected_features(
+
+        # Keep existing illegal detection semantics (connected endpoints rule).
+        # We don't return adjacency anymore.
+        _ = self._illegal_connected_features(
             illegal=illegal,
             target_layers=target_layers,
         )
-        if self.propagate_illigal_targets:
-            self._propagate_external_illegal_within_components(
-                illegal=illegal,
-                adjacency=adjacency,
-            )
-        return illegal, adjacency
+
+        # Scope-driven propagation using topology output (no propagation for NONE/DIRECT).
+        self._propagate_external_illegal_by_scope(
+            illegal=illegal,
+            topology=topology,
+        )
+
+        return illegal
+
+    def _propagate_external_illegal_by_scope(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        topology: TopologyModel,
+    ) -> None:
+        scope = topology.scope
+
+        if scope in (
+            logic_config.ConnectivityScope.NONE,
+            logic_config.ConnectivityScope.DIRECT_CONNECTION,
+        ):
+            return
+
+        cid = topology.connectivity_id_by_parent
+        if not cid:
+            return
+
+        self._propagate_external_illegal_within_connectivity_ids(
+            illegal=illegal,
+            connectivity_id_by_parent=cid,
+        )
+
+    def _propagate_external_illegal_within_connectivity_ids(
+        self,
+        *,
+        illegal: dict[int, dict[str, set[int]]],
+        connectivity_id_by_parent: dict[int, int],
+    ) -> None:
+        """
+        For each connectivity_id group (scope-defined component), union external illegal targets
+        and apply to every parent in that group.
+
+        External illegal targets = everything except the canonical lines_key (self-line rule).
+        Self-line rule remains local and never propagates.
+        """
+        lines_key = self._dataset_key(self.lines_copy)
+
+        groups: dict[int, list[int]] = {}
+        for pid in illegal.keys():
+            cid = connectivity_id_by_parent.get(int(pid))
+            if cid is None:
+                continue
+            groups.setdefault(int(cid), []).append(int(pid))
+
+        for _, members in groups.items():
+            union_external: dict[str, set[int]] = {}
+
+            for member in members:
+                ds_map = illegal.get(int(member), {})
+                for ds_key, ids in ds_map.items():
+                    if ds_key == lines_key:
+                        continue
+                    union_external.setdefault(str(ds_key), set()).update(
+                        {int(v) for v in ids}
+                    )
+
+            for member in members:
+                illegal.setdefault(int(member), {})
+                for ds_key, ids in union_external.items():
+                    illegal[int(member)].setdefault(str(ds_key), set()).update(ids)
 
     def _illegal_self_line(
         self,
@@ -401,7 +1192,7 @@ class FillLineGaps:
         if self.lines_copy not in near_features:
             near_features.append(self.lines_copy)
 
-        connect_tol_m = 0.02
+        connect_tol_m = float(self.connectivity_tolerance_meters)
         connect_tol = f"{connect_tol_m} Meters"
 
         arcpy.analysis.GenerateNearTable(
@@ -690,14 +1481,12 @@ class FillLineGaps:
         parent_id: int,
         cand: dict,
         base_tol: float,
-        dangle_candidate_tol: float,  # NEW
-        component_id: dict[int, int] | None = None,
+        dangle_candidate_tol: float,
+        topology: TopologyModel | None = None,
     ) -> bool:
         ds_key = cand["near_fc_key"]
         oid = int(cand["near_fid"])
         dist = float(cand["near_dist"])
-
-        a_comp = component_id.get(int(parent_id)) if component_id is not None else None
 
         if ds_key == dangles_fc_key:
             # IMPORTANT: use dangle_candidate_tol, not expanded tolerance by default
@@ -708,10 +1497,15 @@ class FillLineGaps:
             if other_parent is None:
                 return False
 
-            if a_comp is not None and component_id is not None:
-                if component_id.get(int(other_parent)) == a_comp:
-                    return False
+            # Same-network restriction (value-neutral topology)
+            if topology is not None and self._same_network(
+                a_parent=int(parent_id),
+                b_parent=int(other_parent),
+                topology=topology,
+            ):
+                return False
 
+            # Dangle->dangle still illegal-checks against the other parent line id
             if self._is_illegal(
                 illegal=illegal,
                 parent_id=parent_id,
@@ -729,9 +1523,17 @@ class FillLineGaps:
         if ds_key == lines_fc_key and int(oid) == int(parent_id):
             return False
 
-        if ds_key == lines_fc_key and a_comp is not None and component_id is not None:
-            if component_id.get(int(oid)) == a_comp:
-                return False
+        # Same-network restriction for line targets (oid is in ORIGINAL_ID space in your grouped rows)
+        if (
+            ds_key == lines_fc_key
+            and topology is not None
+            and self._same_network(
+                a_parent=int(parent_id),
+                b_parent=int(oid),
+                topology=topology,
+            )
+        ):
+            return False
 
         if self._is_illegal(
             illegal=illegal,
@@ -777,7 +1579,7 @@ class FillLineGaps:
         lines_fc_key: str,
         parent_id: int,
         base_tol: float,
-        component_id: dict[int, int] | None = None,
+        topology: TopologyModel | None = None,
     ) -> Optional[dict]:
         for cand in candidates_sorted:
             if self._candidate_is_legal(
@@ -789,7 +1591,7 @@ class FillLineGaps:
                 cand=cand,
                 base_tol=base_tol,
                 dangle_candidate_tol=base_tol,
-                component_id=component_id,
+                topology=topology,
             ):
                 return cand
         return None
@@ -958,16 +1760,28 @@ class FillLineGaps:
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
-        illegal, adjacency = self.detect_illegal_targets(
+        # Value-neutral topology (computed independently of dangle candidate layers)
+        relevant_parent_ids = set(dangle_parent.values())
+        topology = TopologyBuilder(
+            lines_fc=self.lines_copy,
+            original_id_field=self.ORIGINAL_ID,
+            connect_to_features=self.connect_to_features,
+            dataset_key_fn=self._dataset_key,
+            wfm=self.wfm,
+            write_work_files_to_memory=self.write_work_files_to_memory,
+            connectivity_tolerance_meters=self.connectivity_tolerance_meters,
+            line_connectivity_mode=self.line_connectivity_mode,
+        ).build(
+            scope=self.connectivity_scope,
+            relevant_parent_ids=relevant_parent_ids,
+        )
+
+        illegal = self.detect_illegal_targets(
             dangle_parent=dangle_parent,
             target_layers=target_layers,
+            topology=topology,
         )
-        nodes = set(dangle_parent.values())
-        component_id = (
-            self._build_component_ids(adjacency=adjacency, nodes=nodes)
-            if self.propagate_illigal_targets
-            else None
-        )
+
         dangles_key = self._dataset_key(dangles_fc)
 
         lines_key = self._dataset_key(self.lines_copy)
@@ -986,6 +1800,7 @@ class FillLineGaps:
             if self.fill_gaps_on_self
             else {}
         )
+
         # One near-table for everything (expanded radius so we can see dangle pairs)
         self._generate_near_table(
             in_dangles=dangles_fc,
@@ -1001,6 +1816,8 @@ class FillLineGaps:
             lines_copy_oid_to_orig=lines_copy_oid_to_orig,
             target_self_oid_to_orig=target_self_oid_to_orig,
         )
+
+        # ... rest unchanged (except passing topology further down)
 
         # DEBUG: inspect first candidates
         lines_key = self._dataset_key(self.lines_copy)
@@ -1038,6 +1855,7 @@ class FillLineGaps:
                 continue
 
             rows = sorted(candidates, key=lambda r: r["near_dist"])
+
             first_legal = self._select_first_legal_candidate(
                 candidates_sorted=rows,
                 illegal=illegal,
@@ -1046,8 +1864,9 @@ class FillLineGaps:
                 lines_fc_key=lines_key,
                 parent_id=int(parent_id),
                 base_tol=base_tol,
-                component_id=component_id,
+                topology=topology,
             )
+
             if first_legal is None:
                 no_legal += 1
                 continue
@@ -1256,7 +2075,7 @@ class FillLineGaps:
                 cand=a_to_b_line,
                 base_tol=float(base_tol),
                 dangle_candidate_tol=base_tol,
-                component_id=component_id,
+                topology=topology,
             ):
                 a_to_b_line = None
 
@@ -1269,7 +2088,7 @@ class FillLineGaps:
                 cand=b_to_a_line,
                 base_tol=float(base_tol),
                 dangle_candidate_tol=base_tol,
-                component_id=component_id,
+                topology=topology,
             ):
                 b_to_a_line = None
 

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -780,17 +780,30 @@ class AngleAssessment:
     line_match_diff: Optional[float] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class CandidateDiagnostic:
     """
     Diagnostic record for one candidate connection evaluated during the main planning phase.
 
     One record exists per (dangle, target) pair, excluding the self parent line target.
-    Covers all three outcomes: chosen, legal-but-not-chosen, and illegal.
+    The dataclass is mutable so that deferred-acceptance outcomes can be patched by
+    run() after _build_deferred_plan resolves.
 
-    Step-1A illegals (failed topological/distance legality) have assess=None because
-    angle was never computed for them.  Step-1B illegals (angle-blocked or
-    expanded-dangle-gated) carry the computed assess.
+    candidate_status values:
+        "illegal"             — failed legality or angle blocking; could not be selected
+        "legal_not_selected"  — passed legality but lost to a better scored candidate
+                               within the same dangle
+        "selected_for_dangle" — was the local best candidate for its dangle but did not
+                               survive later pipeline stages to become applied output
+        "applied_to_output"   — truly survived the full pipeline and was applied to geometry
+
+    status_reason values per status:
+        illegal:              beyond_distance_tolerance | same_network | illegal_target |
+                              blocked_by_angle | expanded_dangle_angle_disallowed
+        legal_not_selected:   outscored_within_dangle
+        selected_for_dangle:  deferred | lost_pair_competition | lost_cycle_prevention |
+                              deferred_rejected_connectivity
+        applied_to_output:    applied_main | applied_deferred
     """
 
     parent_id: int
@@ -802,12 +815,14 @@ class CandidateDiagnostic:
     near_x: float
     near_y: float
     raw_distance: float
-    candidate_status: str            # "chosen" | "legal_not_chosen" | "illegal"
-    candidate_reason: Optional[str]  # None unless status == "illegal"
+    candidate_status: str           # see class docstring
+    status_reason: Optional[str]    # see class docstring; None only for rare edge cases
     best_fit_score: Optional[float]
+    best_fit_rank: Optional[int]    # 1 = local dangle winner; higher = lower-ranked legal
     bonus_applied: Optional[bool]
     assess: Optional[AngleAssessment]
     target_parent_id: Optional[int]
+    final_gap_source: Optional[str] # gap_source value for applied_to_output rows; None otherwise
 
 
 class FillLineGaps:
@@ -2456,13 +2471,24 @@ class FillLineGaps:
         _step1a_illegal: list[tuple[int, int, dict, str]] = []
         # (dangle_oid, parent_id, cand, assess, reason) — passed step-1A but blocked in step-1B
         _step1b_illegal: list[tuple[int, int, dict, AngleAssessment, str]] = []
-        # (dangle_oid, parent_id, cand, assess, raw_dist, best_fit, bonus, is_chosen)
-        _step1b_scored: list[tuple[int, int, dict, AngleAssessment, float, float, bool, bool]] = []
+        # (dangle_oid, parent_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner, score_tuple)
+        _step1b_scored: list[tuple[int, int, dict, AngleAssessment, float, float, bool, bool, tuple]] = []
+
+        # Pipeline stage fate sets — populated as _build_plan progresses;
+        # _assemble_diagnostics captures them by reference so early-return calls
+        # always see whatever has been filled in at that point.
+        deferred_dangles: set[int] = set()         # dangle_oids routed to deferred pass
+        stage_a_loser_oids: set[int] = set()       # local winners that lost Stage-A pair competition
+        stage_b_rejected_oids: set[int] = set()    # Stage-A winners dropped by Kruskal
+        accepted_dangle_oids: set[int] = set()     # proposals that made it into the main plan
+        gap_source_by_dangle: dict[int, str] = {}  # gap_source for accepted main-plan candidates
 
         def _assemble_diagnostics() -> list[CandidateDiagnostic]:
             if not collect_diags:
                 return []
             result: list[CandidateDiagnostic] = []
+
+            # Step-1A illegals: angle never computed for these
             for d_oid, p_id, cand, reason in _step1a_illegal:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
@@ -2478,14 +2504,18 @@ class FillLineGaps:
                     near_y=float(cand["near_y"]),
                     raw_distance=float(cand["near_dist"]),
                     candidate_status="illegal",
-                    candidate_reason=reason,
+                    status_reason=reason,
                     best_fit_score=None,
+                    best_fit_rank=None,
                     bonus_applied=None,
                     assess=None,
                     target_parent_id=self._resolve_target_parent_id(
                         cand, dangle_parent, dangles_key, lines_key
                     ),
+                    final_gap_source=None,
                 ))
+
+            # Step-1B angle-blocked illegals: angle computed
             for d_oid, p_id, cand, assess, reason in _step1b_illegal:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
@@ -2501,20 +2531,65 @@ class FillLineGaps:
                     near_y=float(cand["near_y"]),
                     raw_distance=float(cand["near_dist"]),
                     candidate_status="illegal",
-                    candidate_reason=reason,
+                    status_reason=reason,
                     best_fit_score=None,
+                    best_fit_rank=None,
                     bonus_applied=None,
                     assess=assess,
                     target_parent_id=self._resolve_target_parent_id(
                         cand, dangle_parent, dangles_key, lines_key
                     ),
+                    final_gap_source=None,
                 ))
+
+            # Compute per-dangle rank for scored candidates (1 = local winner)
+            scored_by_dangle: dict[int, list] = {}
+            for entry in _step1b_scored:
+                scored_by_dangle.setdefault(int(entry[0]), []).append(entry)
+            rank_map: dict[tuple[int, str, int], int] = {}
+            for d_oid, entries in scored_by_dangle.items():
+                for rank, entry in enumerate(
+                    sorted(entries, key=lambda e: e[8]), start=1
+                ):
+                    cand = entry[2]
+                    rank_map[(d_oid, str(cand["near_fc_key"]), int(cand["near_fid"]))] = rank
+
+            # Step-1B scored candidates
             for (
-                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus, is_chosen
+                d_oid, p_id, cand, assess, raw_dist, best_fit, bonus, is_local_winner, _score
             ) in _step1b_scored:
                 xy = dangle_xy.get(int(d_oid))
                 if xy is None:
                     continue
+                rank = rank_map.get((d_oid, str(cand["near_fc_key"]), int(cand["near_fid"])))
+
+                if not is_local_winner:
+                    status = "legal_not_selected"
+                    reason = "outscored_within_dangle"
+                    final_gs: Optional[str] = None
+                elif int(d_oid) in deferred_dangles:
+                    status = "selected_for_dangle"
+                    reason = "deferred"
+                    final_gs = None
+                elif int(d_oid) in stage_a_loser_oids:
+                    status = "selected_for_dangle"
+                    reason = "lost_pair_competition"
+                    final_gs = None
+                elif int(d_oid) in stage_b_rejected_oids:
+                    status = "selected_for_dangle"
+                    reason = "lost_cycle_prevention"
+                    final_gs = None
+                elif int(d_oid) in accepted_dangle_oids:
+                    status = "applied_to_output"
+                    reason = "applied_main"
+                    final_gs = gap_source_by_dangle.get(int(d_oid))
+                else:
+                    # Local winner that didn't reach proposal construction
+                    # (e.g. target dangle had no resolvable parent)
+                    status = "selected_for_dangle"
+                    reason = None
+                    final_gs = None
+
                 result.append(CandidateDiagnostic(
                     parent_id=p_id,
                     dangle_oid=d_oid,
@@ -2525,14 +2600,16 @@ class FillLineGaps:
                     near_x=float(cand["near_x"]),
                     near_y=float(cand["near_y"]),
                     raw_distance=float(raw_dist),
-                    candidate_status="chosen" if is_chosen else "legal_not_chosen",
-                    candidate_reason=None,
+                    candidate_status=status,
+                    status_reason=reason,
                     best_fit_score=float(best_fit),
+                    best_fit_rank=rank,
                     bonus_applied=bool(bonus),
                     assess=assess,
                     target_parent_id=self._resolve_target_parent_id(
                         cand, dangle_parent, dangles_key, lines_key
                     ),
+                    final_gap_source=final_gs,
                 ))
             return result
 
@@ -2852,6 +2929,7 @@ class FillLineGaps:
                         float(sc_best_fit),
                         bool(sc_bonus),
                         sc_tuple is winner_item,
+                        sc_score,  # score tuple for per-dangle rank computation
                     ))
 
             # ----------------------------
@@ -2928,7 +3006,6 @@ class FillLineGaps:
 
         deferred_by_parent: dict[int, DeferredCapture] = {}
         deferred_score_by_parent: dict[int, tuple] = {}
-        deferred_dangles: set[int] = set()
 
         for p in proposals_by_dangle.values():
             b_parent = p.target_parent_id
@@ -3013,6 +3090,14 @@ class FillLineGaps:
 
             stage_a_winners.append((winner, str(gap_source)))
 
+        if collect_diags:
+            _stage_a_winner_oids = {int(prop.dangle_oid) for prop, _ in stage_a_winners}
+            stage_a_loser_oids.update(
+                int(prop.dangle_oid)
+                for prop in active
+                if int(prop.dangle_oid) not in _stage_a_winner_oids
+            )
+
         # ----------------------------
         # Stage B: Kruskal-style cycle prevention (component scopes only)
         # ----------------------------
@@ -3033,6 +3118,18 @@ class FillLineGaps:
         else:
             # NONE / DIRECT_CONNECTION: only Stage A
             accepted = list(stage_a_winners)
+
+        if collect_diags and accepted:
+            _accepted_oids = {int(prop.dangle_oid) for prop, _ in accepted}
+            accepted_dangle_oids.update(_accepted_oids)
+            stage_b_rejected_oids.update(
+                int(prop.dangle_oid)
+                for prop, _ in stage_a_winners
+                if int(prop.dangle_oid) not in _accepted_oids
+            )
+            gap_source_by_dangle.update(
+                {int(prop.dangle_oid): str(gs) for prop, gs in accepted}
+            )
 
         if not accepted:
             return {}, deferred_by_parent, _assemble_diagnostics()
@@ -3451,6 +3548,7 @@ class FillLineGaps:
         arcpy.management.AddField(fc_path, "target_parent_id", "LONG")
         arcpy.management.AddField(fc_path, "raw_distance", "DOUBLE")
         arcpy.management.AddField(fc_path, "best_fit_score", "DOUBLE")
+        arcpy.management.AddField(fc_path, "best_fit_rank", "SHORT")
         arcpy.management.AddField(fc_path, "bonus_applied", "SHORT")
         for fname in (
             "angle_metric_deg",
@@ -3461,8 +3559,9 @@ class FillLineGaps:
             "line_match_diff",
         ):
             arcpy.management.AddField(fc_path, fname, "DOUBLE")
-        arcpy.management.AddField(fc_path, "candidate_status", "TEXT", field_length=20)
-        arcpy.management.AddField(fc_path, "candidate_reason", "TEXT", field_length=50)
+        arcpy.management.AddField(fc_path, "final_gap_source", "TEXT", field_length=20)
+        arcpy.management.AddField(fc_path, "candidate_status", "TEXT", field_length=25)
+        arcpy.management.AddField(fc_path, "status_reason", "TEXT", field_length=50)
 
     def _write_candidate_connections_output(
         self,
@@ -3482,6 +3581,7 @@ class FillLineGaps:
             "target_parent_id",
             "raw_distance",
             "best_fit_score",
+            "best_fit_rank",
             "bonus_applied",
             "angle_metric_deg",
             "src_connector_diff",
@@ -3489,8 +3589,9 @@ class FillLineGaps:
             "src_target_diff",
             "connector_transition_diff",
             "line_match_diff",
+            "final_gap_source",
             "candidate_status",
-            "candidate_reason",
+            "status_reason",
         ]
         with arcpy.da.InsertCursor(fc_path, fields) as cur:
             for d in diagnostics:
@@ -3508,6 +3609,7 @@ class FillLineGaps:
                     d.target_parent_id,
                     d.raw_distance,
                     d.best_fit_score,
+                    d.best_fit_rank,
                     int(d.bonus_applied) if d.bonus_applied is not None else None,
                     a.angle_metric_deg if a is not None else None,
                     a.src_connector_diff if a is not None else None,
@@ -3515,8 +3617,9 @@ class FillLineGaps:
                     a.src_target_diff if a is not None else None,
                     a.connector_transition_diff if a is not None else None,
                     a.line_match_diff if a is not None else None,
+                    d.final_gap_source,
                     d.candidate_status,
-                    d.candidate_reason,
+                    d.status_reason,
                 ))
 
     def _apply_plan(self, plan) -> None:
@@ -3698,6 +3801,26 @@ class FillLineGaps:
                 deferred=deferred, dangles_fc=dangles_for_plan
             )
             self._apply_plan(deferred_plan)
+
+            # Patch diagnostic status for deferred candidates now that we know
+            # which ones were accepted vs rejected by _build_deferred_plan.
+            if self.candidate_connections_output is not None and diagnostics:
+                applied_deferred_dangle_oids = {
+                    int(v["dangle_oid"])
+                    for v in deferred_plan.values()
+                    if isinstance(v, dict) and "dangle_oid" in v
+                }
+                for diag in diagnostics:
+                    if (
+                        diag.candidate_status == "selected_for_dangle"
+                        and diag.status_reason == "deferred"
+                    ):
+                        if int(diag.dangle_oid) in applied_deferred_dangle_oids:
+                            diag.candidate_status = "applied_to_output"
+                            diag.status_reason = "applied_deferred"
+                            diag.final_gap_source = self.GAP_SOURCE_DEFERRED
+                        else:
+                            diag.status_reason = "deferred_rejected_connectivity"
 
         if self.candidate_connections_output is not None and diagnostics:
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1198,6 +1198,46 @@ class BuildPlanResult:
 
 
 class FillLineGaps:
+    """Fill small end-of-line gaps by snapping or extending dangle endpoints.
+
+    A dangle is an open polyline end.  For each dangle, this class picks the
+    best legal target within ``gap_tolerance_meters`` and edits the source
+    line so the gap closes.  Targets come from ``connect_to_features``, from
+    the input itself (``fill_gaps_on_self``), or both; at least one mode must
+    be enabled.
+
+    How:
+        ``run`` orchestrates the full workflow.  ``_build_plan`` drives the
+        four-scope decision pipeline and ``_apply_plan`` commits the edits.
+        The scopes are, in order:
+
+          - CANDIDATE:  angle and polyline caches, legality gates (distance,
+            network membership, illegal-target, barrier/crossing), and one
+            angle-aware proposal per dangle.
+          - NETWORK:    one winner per undirected A<->B connection, with Z
+            re-normalized inside each connection group.
+          - KRUSKAL:    cycle prevention and accepted-connector crossing
+            checks across all connection winners.
+          - DEFERRED:   post-apply resnap pass for connections whose target
+            endpoint moved during ``_apply_plan``, with an optional crossing
+            recheck.
+
+    Why:
+        Scope-based staging attributes every rejected candidate to the
+        earliest scope that can prove it.  The optional diagnostic feature
+        class ``candidate_connections_output`` relies on that separation so
+        each row carries the scope that decided its fate.
+
+    Outputs:
+        output_lines:
+            Required.  The edited polyline feature class.
+        line_changes_output:
+            Optional per-edit metadata feature class.
+        candidate_connections_output:
+            Optional diagnostic feature class.  One row per evaluated
+            ``(dangle, candidate)`` pair.
+    """
+
     ORIGINAL_ID = "line_gap_original_id"
 
     # Change output fields
@@ -1213,6 +1253,21 @@ class FillLineGaps:
     F_NEAR_Y = "NEAR_Y"
 
     def __init__(self, line_gap_config: logic_config.FillLineGapsConfig):
+        """Transcribe the config bundle into flat instance attributes.
+
+        The ``FillLineGapsConfig`` groups settings by concern (``advanced_config``,
+        ``output_config``, ``angle_config``, ``z_config``, ``crossing_config``,
+        ``connectivity_config``); ``__init__`` flattens those groups onto
+        ``self`` so hot-path methods can read one attribute instead of walking
+        the config tree.  It also resolves work-file names via
+        ``WorkFileManager`` and preloads the local angle cache.
+
+        Raises:
+            ValueError: if ``connect_to_features`` is ``None`` while
+                ``fill_gaps_on_self`` is ``False`` (no legal target source),
+                or if ``lines_are_directed`` is enabled with an angle weight
+                of zero (directed scoring would have no effect).
+        """
         self.input_lines = line_gap_config.input_lines
         self.output_lines = line_gap_config.output_lines
         self.connect_to_features = line_gap_config.connect_to_features
@@ -1373,6 +1428,12 @@ class FillLineGaps:
         return out
 
     def _resolve_edit_op(self, *, gap_source: GapSource) -> EditOp:
+        """Map ``edit_method`` + ``gap_source`` onto the geometry edit to perform.
+
+        ``FORCED_SNAP`` and ``FORCED_EXTEND`` ignore ``gap_source``.
+        ``AUTO`` snaps dangle-to-dangle pairs
+        (``GapSource.PAIR_DANGLE``) and extends everything else.
+        """
         method = self.edit_method
 
         if method == logic_config.EditMethod.FORCED_SNAP:
@@ -1392,6 +1453,14 @@ class FillLineGaps:
         b_parent: int,
         topology: TopologyModel,
     ) -> bool:
+        """Return ``True`` if two parent lines share a network under the topology scope.
+
+          - NONE: always ``False``.
+          - DIRECT_CONNECTION: ``True`` iff ``b`` is in ``a``'s direct
+            neighbor set.
+          - Component scopes: ``True`` iff both parents share a
+            connectivity id.
+        """
         scope = topology.scope
 
         if scope == logic_config.ConnectivityScope.NONE:
@@ -1740,6 +1809,15 @@ class FillLineGaps:
         target_layers: list[str],
         lines_key: DatasetKey,
     ) -> _AngleCaches:
+        """Build the polyline caches and line-like flags used by angle scoring.
+
+        Populates one cache per parent id for the source lines and one
+        OID-keyed cache per external dataset.  Line-like status is
+        resolved by the configured ``AngleTargetMode`` (falling back to
+        ``Describe.shapeType``).  When ``fill_gaps_on_self`` is enabled,
+        the self-lines dataset key is added to the line-like set so
+        self-targets participate in angle-aware scoring.
+        """
         polyline_by_parent = self._build_polyline_by_parent_id()
 
         polyline_by_external: dict[DatasetKey, dict[int, Any]] = {}
@@ -1913,6 +1991,17 @@ class FillLineGaps:
     # ----------------------------
 
     def _build_external_target_layers_once(self) -> None:
+        """Pre-filter each ``connect_to_features`` layer to its tolerance window.
+
+        Runs ``SELECT_LOCATION`` with ``WITHIN_A_DISTANCE`` at the
+        configured gap tolerance so downstream near-table queries and
+        angle caches only scan features that can possibly matter.  Each
+        output layer's angle mode is resolved from
+        ``connect_to_features_angle_mode`` (keyed by source path, source
+        dataset key, or output dataset key) and recorded in
+        ``_angle_mode_by_external_ds_key``.  Idempotent — skips work on
+        re-entry.
+        """
         if self.external_target_layers:
             return
         if self.connect_to_features is None:
@@ -1956,6 +2045,12 @@ class FillLineGaps:
             self._angle_mode_by_external_ds_key[str(out_key)] = mode
 
     def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
+        """Return the combined target layer list for the near table.
+
+        Includes the tolerance-filtered self-lines layer (``target_self``)
+        when ``fill_gaps_on_self`` is enabled, followed by the external
+        target layers built in ``_build_external_target_layers_once``.
+        """
         targets: list[str] = []
         if self.fill_gaps_on_self:
             if self.write_work_files_to_memory:
@@ -3380,6 +3475,52 @@ class FillLineGaps:
     def _build_plan(
         self, *, dangles_fc: str, target_layers: list[str]
     ) -> BuildPlanResult:
+        """Decide which dangles to fill and how, in four staged scopes.
+
+        Each scope narrows the set of surviving proposals.  Rejected
+        candidates carry the scope label of the earliest stage that
+        rejected them, which drives the diagnostic feature class.
+
+        How:
+            CANDIDATE scope
+                Build the near table and angle caches, then run legality
+                gates (``_filter_legal_candidates``) and crossing
+                pre-filters (barrier + existing-feature CROSSES checks).
+                For each surviving dangle, pick the best line-target parent
+                (``_compute_best_line_parent_by_dangle``) and emit one
+                angle-aware proposal per dangle
+                (``_select_dangle_proposals``).
+
+            NETWORK scope
+                Detect mutual pairs, re-normalize Z inside each undirected
+                A<->B connection group (``_run_connection_normalization``),
+                and pick one winner per connection
+                (``_run_connection_selection``).  The winner is stamped
+                with its authoritative ``gap_source``.
+
+            KRUSKAL scope
+                Re-normalize Z globally (``_run_global_normalization``),
+                then run Kruskal-style cycle prevention plus
+                accepted-connector crossing checks (``_run_kruskal``).
+
+            DEFERRED scope
+                Identify proposals whose target endpoint will move during
+                ``_apply_plan`` (``_identify_resnap_captures``) and
+                assemble the per-parent plan entries
+                (``_assemble_plan_entries``).  Their final status is not
+                resolved here — it is filled in by
+                ``_update_deferred_diagnostics`` after the resnap pass in
+                ``run``.
+
+            Each scope short-circuits to a diagnostics-only
+            ``BuildPlanResult`` when no survivors remain, so the caller
+            still receives a complete rejection record.
+
+        Returns:
+            ``BuildPlanResult`` — plan keyed by parent id, plus resnap
+            captures, diagnostics, and the Kruskal bookkeeping needed for
+            the post-apply passes in ``run``.
+        """
         dangle_parent = self._build_dangle_parent_lookup(dangles_fc=dangles_fc)
         dangle_xy = self._build_dangle_xy_lookup(dangles_fc=dangles_fc)
 
@@ -5407,6 +5548,27 @@ class FillLineGaps:
                 cur.insertRow(self._diag_row(d, geom))
 
     def _apply_plan(self, plan: PlanByParent) -> None:
+        """Commit plan entries to ``lines_copy`` and optionally record changes.
+
+        Iterates ``lines_copy`` via ``UpdateCursor``.  For each parent line
+        with pending plan entries, applies each entry in order — SNAP moves
+        the dangle endpoint exactly to the target point; EXTEND inserts the
+        target point as the new endpoint while preserving the existing
+        vertices.  When ``line_changes_output`` is set and metadata writing
+        is enabled, a per-edit row is collected and inserted after all
+        geometry updates are complete.
+
+        How:
+            Each ``PlanEntry`` carries ``skip`` and ``processed`` flags.
+            Entries with ``skip=True`` (e.g. a losing side of a mutual pair
+            or a resnap capture displaced by a crossing recheck) are never
+            applied.  ``processed`` is set as soon as an entry is applied,
+            so calling ``_apply_plan`` a second time with the same plan is
+            a no-op for already-applied entries — this is what lets
+            ``run`` invoke ``_apply_plan`` twice (once for the initial
+            plan, once for the resnap plan) without double-editing any
+            line.
+        """
         if not plan:
             return
 
@@ -5539,6 +5701,39 @@ class FillLineGaps:
     # ----------------------------
 
     def run(self) -> None:
+        """Execute the full gap-fill workflow.
+
+        How:
+            1. Set up the arcpy environment and resolve work-file paths via
+               ``WorkFileManager``.
+            2. Copy inputs, stamp ``ORIGINAL_ID``, extract dangle endpoints
+               and (optionally) load raster handles for Z scoring.
+            3. Build the target universe: self-lines filtered by tolerance
+               (``fill_gaps_on_self``) plus external ``connect_to_features``
+               layers (``_build_external_target_layers_once``).
+            4. Keep only true dangles — those not already touching an
+               external target (``_filter_true_dangles``).
+            5. Initialize optional diagnostic feature classes
+               (``line_changes_output``, ``candidate_connections_output``).
+            6. Run the four-scope decision pipeline in ``_build_plan`` and
+               apply the resulting edits with ``_apply_plan``.
+            7. If any proposals deferred into the resnap scope, resolve
+               their final geometry with ``_resnap_connections``; when
+               ``reject_crossing_connectors`` is enabled, re-check the
+               resnapped geometry against accepted connectors via
+               ``_recheck_resnap_crossings`` before applying the second
+               pass and annotating diagnostics.
+            8. Write the diagnostic feature class (if requested), copy
+               ``lines_copy`` to ``output_lines``, and delete work files.
+
+        Why:
+            The resnap pass runs after the first ``_apply_plan`` because a
+            snap moves the target line's endpoint, which can invalidate any
+            connector previously anchored on that endpoint's last segment.
+            Resolving that re-projection pre-apply would require predicting
+            the snapped geometry; doing it post-apply reads the real
+            geometry and is exact.
+        """
         environment_setup.main()
 
         self.work_file_list = self.wfm.setup_work_file_paths(

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -714,9 +714,15 @@ class Proposal:
     src_node: EntityKey
     tgt_node: EntityKey
     chosen: dict  # the chosen candidate row dict
-    score: tuple[
-        float, int, int, str, int
-    ]  # (dist, src_parent, dangle_oid, near_fc_key, near_fid)
+
+    raw_distance: float
+    effective_distance: float
+    bonus_applied: bool
+
+    # (effective_dist, bonus_rank, raw_dist, src_parent, dangle_oid, near_fc_key, near_fid)
+    # bonus_rank: 0 when edge-case bonus applied, else 1
+    score: tuple[float, int, float, int, int, str, int]
+
     pair_key: tuple[EntityKey, EntityKey]  # unordered network pair
     target_parent_id: Optional[int]  # only for line/dangle targets (ORIGINAL_ID space)
     target_dangle_oid: Optional[int]  # only if chosen is a dangle target
@@ -980,6 +986,117 @@ class FillLineGaps:
         Isolated behind a function so it can be upgraded later if SOURCE_OID becomes available.
         """
         return ("optional_candidate", str(dataset_key), int(near_fid))
+
+    def _best_legal_line_target_parent(
+        self,
+        *,
+        legal_rows: list[dict],
+        lines_fc_key: str,
+    ) -> Optional[int]:
+        """
+        Return the parent line id of the closest legal line target for this dangle.
+
+        `legal_rows` must already be sorted by raw candidate order.
+        """
+        for cand in legal_rows:
+            if str(cand["near_fc_key"]) == str(lines_fc_key):
+                return int(cand["near_fid"])
+        return None
+
+    def _edge_case_bonus_applies(
+        self,
+        *,
+        dangle_oid: int,
+        cand: dict,
+        dangles_fc_key: str,
+        dangle_parent: dict[int, int],
+        best_line_parent_by_dangle: dict[int, int],
+    ) -> bool:
+        """
+        Edge-case bonus applies only for dangle targets when:
+
+        - source dangle's best legal line target is the target dangle's parent line
+        - target dangle's best legal line target is the source dangle's parent line
+
+        This is the explicit implementation of:
+        "if both dangles want each other's parent line, prioritize the dangle".
+        """
+        extra = max(0, int(self.increased_tolerance_edge_case_distance_meters))
+        if extra <= 0:
+            return False
+
+        if str(cand["near_fc_key"]) != str(dangles_fc_key):
+            return False
+
+        src_parent = dangle_parent.get(int(dangle_oid))
+        if src_parent is None:
+            return False
+
+        other_dangle_oid = int(cand["near_fid"])
+        other_parent = dangle_parent.get(int(other_dangle_oid))
+        if other_parent is None:
+            return False
+
+        src_best_line_parent = best_line_parent_by_dangle.get(int(dangle_oid))
+        other_best_line_parent = best_line_parent_by_dangle.get(int(other_dangle_oid))
+
+        if src_best_line_parent is None or other_best_line_parent is None:
+            return False
+
+        return int(src_best_line_parent) == int(other_parent) and int(
+            other_best_line_parent
+        ) == int(src_parent)
+
+    def _candidate_score_details(
+        self,
+        *,
+        dangle_oid: int,
+        parent_id: int,
+        cand: dict,
+        dangles_fc_key: str,
+        dangle_parent: dict[int, int],
+        best_line_parent_by_dangle: dict[int, int],
+    ) -> tuple[float, float, bool, tuple[float, int, float, int, int, str, int]]:
+        """
+        Returns:
+        - raw_distance
+        - effective_distance
+        - bonus_applied
+        - deterministic score tuple
+
+        Negative effective distances are allowed intentionally.
+        """
+        raw_distance = float(cand["near_dist"])
+        bonus_applied = self._edge_case_bonus_applies(
+            dangle_oid=int(dangle_oid),
+            cand=cand,
+            dangles_fc_key=dangles_fc_key,
+            dangle_parent=dangle_parent,
+            best_line_parent_by_dangle=best_line_parent_by_dangle,
+        )
+
+        if bonus_applied:
+            effective_distance = raw_distance - float(
+                max(0, int(self.increased_tolerance_edge_case_distance_meters))
+            )
+        else:
+            effective_distance = raw_distance
+
+        # If effective distances tie, prefer the bonus-applied candidate.
+        # That preserves the intended "prioritize the dangle" behavior at the boundary.
+        bonus_rank = 0 if bonus_applied else 1
+
+        score = (
+            float(effective_distance),
+            int(bonus_rank),
+            float(raw_distance),
+            int(parent_id),
+            int(dangle_oid),
+            str(cand["near_fc_key"]),
+            int(cand["near_fid"]),
+        )
+
+        return raw_distance, effective_distance, bool(bonus_applied), score
 
     # ----------------------------
     # Preprocessing
@@ -1888,12 +2005,16 @@ class FillLineGaps:
             return {}, {}
 
         # ----------------------------
-        # Step 1: build exactly ONE proposal per dangle (best-fit legal)
+        # Step 1A: collect legal candidates per dangle
         # ----------------------------
-        proposals_by_dangle: dict[int, Proposal] = {}
+        legal_rows_by_dangle: dict[int, list[dict]] = {}
+        parent_id_by_dangle: dict[int, int] = {}
+        best_line_parent_by_dangle: dict[int, int] = {}
 
-        for dangle_oid, candidates in grouped.items():
+        for dangle_oid in sorted(grouped.keys()):
+            candidates = grouped[dangle_oid]
             dangle_oid = int(dangle_oid)
+
             parent_id = dangle_parent.get(dangle_oid)
             if parent_id is None:
                 continue
@@ -1901,7 +2022,7 @@ class FillLineGaps:
 
             rows = sorted(candidates, key=self._candidate_sort_key)
 
-            chosen = None
+            legal_rows: list[dict] = []
             for cand in rows:
                 if self._candidate_is_legal(
                     illegal=illegal,
@@ -1911,14 +2032,66 @@ class FillLineGaps:
                     parent_id=parent_id,
                     cand=cand,
                     base_tol=base_tol,
-                    dangle_candidate_tol=dangle_tol,  # expanded tolerance applies ONLY for dangle targets
+                    dangle_candidate_tol=dangle_tol,  # expanded tolerance still applies here
                     topology=topology,
                 ):
-                    chosen = cand
-                    break
+                    legal_rows.append(cand)
 
-            if chosen is None:
+            if not legal_rows:
                 continue
+
+            legal_rows_by_dangle[dangle_oid] = legal_rows
+            parent_id_by_dangle[dangle_oid] = parent_id
+
+            best_line_parent = self._best_legal_line_target_parent(
+                legal_rows=legal_rows,
+                lines_fc_key=lines_key,
+            )
+            if best_line_parent is not None:
+                best_line_parent_by_dangle[dangle_oid] = int(best_line_parent)
+
+        if not legal_rows_by_dangle:
+            return {}, {}
+
+        # ----------------------------
+        # Step 1B: choose exactly ONE proposal per dangle using edge-case adjusted scoring
+        # ----------------------------
+        proposals_by_dangle: dict[int, Proposal] = {}
+
+        for dangle_oid in sorted(legal_rows_by_dangle.keys()):
+            dangle_oid = int(dangle_oid)
+            parent_id = int(parent_id_by_dangle[dangle_oid])
+            legal_rows = legal_rows_by_dangle[dangle_oid]
+
+            scored_candidates: list[
+                tuple[
+                    tuple[float, int, float, int, int, str, int],
+                    dict,
+                    float,
+                    float,
+                    bool,
+                ]
+            ] = []
+
+            for cand in legal_rows:
+                raw_distance, effective_distance, bonus_applied, score = (
+                    self._candidate_score_details(
+                        dangle_oid=dangle_oid,
+                        parent_id=parent_id,
+                        cand=cand,
+                        dangles_fc_key=dangles_key,
+                        dangle_parent=dangle_parent,
+                        best_line_parent_by_dangle=best_line_parent_by_dangle,
+                    )
+                )
+                scored_candidates.append(
+                    (score, cand, raw_distance, effective_distance, bonus_applied)
+                )
+
+            score, chosen, raw_distance, effective_distance, bonus_applied = min(
+                scored_candidates,
+                key=lambda item: item[0],
+            )
 
             src_node = self._node_for_parent(parent_id=parent_id, topology=topology)
 
@@ -1932,33 +2105,26 @@ class FillLineGaps:
                 target_dangle_oid = near_fid
                 other_parent = dangle_parent.get(int(target_dangle_oid))
                 if other_parent is None:
-                    # Defensive; should be blocked by _candidate_is_legal already
                     continue
                 target_parent_id = int(other_parent)
                 tgt_node = self._node_for_parent(
-                    parent_id=target_parent_id, topology=topology
+                    parent_id=target_parent_id,
+                    topology=topology,
                 )
 
             elif ds_key == lines_key:
                 target_parent_id = near_fid  # already in ORIGINAL_ID space
                 tgt_node = self._node_for_parent(
-                    parent_id=target_parent_id, topology=topology
+                    parent_id=target_parent_id,
+                    topology=topology,
                 )
 
             else:
-                # Optional/other target: keep as standalone candidate node for now
                 tgt_node = self._node_for_optional_candidate(
-                    dataset_key=ds_key, near_fid=near_fid
+                    dataset_key=ds_key,
+                    near_fid=near_fid,
                 )
 
-            # Deterministic proposal score and pair key
-            score = (
-                float(chosen["near_dist"]),
-                int(parent_id),
-                int(dangle_oid),
-                str(chosen["near_fc_key"]),
-                int(chosen["near_fid"]),
-            )
             pair_key = self._unordered_pair_key(src_node, tgt_node)
 
             proposals_by_dangle[dangle_oid] = Proposal(
@@ -1967,6 +2133,9 @@ class FillLineGaps:
                 src_node=src_node,
                 tgt_node=tgt_node,
                 chosen=chosen,
+                raw_distance=float(raw_distance),
+                effective_distance=float(effective_distance),
+                bonus_applied=bool(bonus_applied),
                 score=score,
                 pair_key=pair_key,
                 target_parent_id=target_parent_id,

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -3179,6 +3179,17 @@ class FillLineGaps:
             logic_config.ConnectivityScope.TRANSITIVE,
         ):
             uf = _UnionFind()
+            # Map topology ds_keys (from original connect_to_features paths) to the
+            # candidate ds_keys (from work layer paths) so seeded nodes match tgt_node.
+            topo_to_cand_ds_key: dict[str, str] = {
+                self._dataset_key(orig): self._dataset_key(work)
+                for orig, work in zip(
+                    self.connect_to_features or [], self.external_target_layers
+                )
+            }
+            for (ds_key, oid), cid in (topology.connectivity_id_by_optional or {}).items():
+                cand_ds_key = topo_to_cand_ds_key.get(ds_key, ds_key)
+                uf.union(("component", int(cid)), ("optional_candidate", str(cand_ds_key), int(oid)))
             for prop, gap_source in sorted(stage_a_winners, key=lambda t: t[0].score):
                 if uf.find(prop.src_node) == uf.find(prop.tgt_node):
                     continue

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import arcpy
+
+from env_setup import environment_setup
+from custom_tools.general_tools import custom_arcpy
+from file_manager import WorkFileManager
+from composition_configs import logic_config
+
+
+class FillLineGaps:
+    """
+    What:
+        Fills small gaps by extending dangling endpoints of input lines to the nearest location
+        on target features within a tolerance distance.
+
+    How:
+        - Copies input lines to avoid modifying originals.
+        - Adds ORIGINAL_ID field on the copied lines (set to OID).
+        - Creates dangle points.
+        - Removes lines that produced dangles from the "self target" candidate set.
+        - Selects target features (self + optional external) within tolerance of dangles.
+        - Filters dangles that are within tolerance of any target feature.
+        - Runs Near (LOCATION) to obtain NEAR_X/NEAR_Y.
+        - Updates the correct endpoint of each line to the NEAR_X/NEAR_Y location.
+
+    Why:
+        Used to close small digitizing gaps while keeping edits limited to endpoints.
+    """
+
+    ORIGINAL_ID = "line_gap_original_id"
+
+    def __init__(self, line_gap_config: logic_config.FillLineGapsConfig):
+        self.input_lines = line_gap_config.input_lines
+        self.output_lines = line_gap_config.output_lines
+
+        self.gap_tolerance_meters = line_gap_config.gap_tolerance_meters
+        self.connect_to_features = line_gap_config.connect_to_features
+        self.fill_gaps_on_self = line_gap_config.fill_gaps_on_self
+
+        self.write_work_files_to_memory = (
+            line_gap_config.work_file_manager_config.write_to_memory
+        )
+        self.keep_work_files = line_gap_config.work_file_manager_config.keep_files
+        self.root_file = line_gap_config.work_file_manager_config.root_file
+
+        if self.connect_to_features is None and self.fill_gaps_on_self is False:
+            raise ValueError(
+                "Invalid config: fill_gaps_on_self cannot be False when connect_to_features is None."
+            )
+
+        self.wfm = WorkFileManager(config=line_gap_config.work_file_manager_config)
+
+        self.lines_copy = "lines_copy"
+        self.dangles = "dangles"
+        self.input_lines_filtered = "input_lines_filtered"
+        self.filtered_dangles = "filtered_dangles"
+
+        self.target_self = "target_self"
+        self.target_feature_layers: list[str] = []
+
+        self.work_file_list = [
+            self.lines_copy,
+            self.dangles,
+            self.input_lines_filtered,
+            self.filtered_dangles,
+            self.target_self,
+        ]
+
+    def _tolerance_linear_unit(self) -> str:
+        return f"{self.gap_tolerance_meters} Meters"
+
+    def _copy_input_lines(self) -> None:
+        arcpy.management.CopyFeatures(
+            in_features=self.input_lines,
+            out_feature_class=self.lines_copy,
+        )
+
+    def _add_original_id_field(self) -> None:
+        existing_fields = {
+            field.name for field in arcpy.ListFields(dataset=self.lines_copy)
+        }
+        if self.ORIGINAL_ID not in existing_fields:
+            arcpy.management.AddField(
+                in_table=self.lines_copy,
+                field_name=self.ORIGINAL_ID,
+                field_type="LONG",
+            )
+
+        oid_field = arcpy.Describe(self.lines_copy).OIDFieldName
+        arcpy.management.CalculateField(
+            in_table=self.lines_copy,
+            field=self.ORIGINAL_ID,
+            expression=f"!{oid_field}!",
+            expression_type="PYTHON3",
+        )
+
+    def _create_dangles(self) -> None:
+        arcpy.management.FeatureVerticesToPoints(
+            in_features=self.lines_copy,
+            out_feature_class=self.dangles,
+            point_location="DANGLE",
+        )
+
+    def _remove_lines_that_produced_dangles(self) -> None:
+        """
+        What:
+            Creates a filtered version of the copied lines where any line that produced
+            a dangle is excluded (so self-targeting does not snap back onto itself).
+
+        How:
+            - Select lines within tolerance of dangles.
+            - Invert selection to keep only lines not near those dangles.
+        """
+        if self.write_work_files_to_memory:
+            custom_arcpy.select_location_and_make_feature_layer(
+                input_layer=self.lines_copy,
+                overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                select_features=self.dangles,
+                output_name=self.input_lines_filtered,
+                inverted=True,
+                search_distance=self._tolerance_linear_unit(),
+            )
+
+        if not self.write_work_files_to_memory:
+            custom_arcpy.select_location_and_make_permanent_feature(
+                input_layer=self.lines_copy,
+                overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                select_features=self.dangles,
+                output_name=self.input_lines_filtered,
+                inverted=True,
+                search_distance=self._tolerance_linear_unit(),
+            )
+
+    def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
+        """
+        What:
+            Builds the list of target feature datasets to be used by Near.
+
+        How:
+            - If fill_gaps_on_self: select from input_lines_filtered within tolerance of dangles.
+            - For each connect_to_features: select within tolerance of dangles into its own output.
+        """
+        target_layers: list[str] = []
+
+        if self.fill_gaps_on_self:
+            if self.write_work_files_to_memory:
+                custom_arcpy.select_location_and_make_feature_layer(
+                    input_layer=self.input_lines_filtered,
+                    overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                    select_features=self.dangles,
+                    output_name=self.target_self,
+                    search_distance=self._tolerance_linear_unit(),
+                )
+
+            if not self.write_work_files_to_memory:
+                custom_arcpy.select_location_and_make_permanent_feature(
+                    input_layer=self.input_lines_filtered,
+                    overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                    select_features=self.dangles,
+                    output_name=self.target_self,
+                    search_distance=self._tolerance_linear_unit(),
+                )
+
+            target_layers.append(self.target_self)
+
+        if self.connect_to_features is not None:
+            for index, feature_path in enumerate(self.connect_to_features):
+                output_name = self.wfm.build_file_path(
+                    file_name=f"target_feature_{index}",
+                )
+
+                if self.write_work_files_to_memory:
+                    custom_arcpy.select_location_and_make_feature_layer(
+                        input_layer=feature_path,
+                        overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                        select_features=self.dangles,
+                        output_name=output_name,
+                        search_distance=self._tolerance_linear_unit(),
+                    )
+
+                if not self.write_work_files_to_memory:
+                    custom_arcpy.select_location_and_make_permanent_feature(
+                        input_layer=feature_path,
+                        overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
+                        select_features=self.dangles,
+                        output_name=output_name,
+                        search_distance=self._tolerance_linear_unit(),
+                    )
+
+                self.target_feature_layers.append(output_name)
+                target_layers.append(output_name)
+
+        return target_layers
+
+    def _filter_dangles_within_tolerance_of_targets(
+        self, target_layers: list[str]
+    ) -> None:
+        """
+        What:
+            Keeps only dangles that are within tolerance of any target feature.
+
+        How:
+            - Creates a layer/view of dangles.
+            - Accumulates selections (ADD_TO_SELECTION) per target.
+            - Writes the selected dangles to filtered_dangles.
+        """
+        dangles_layer = "dangles_lyr"
+        arcpy.management.MakeFeatureLayer(
+            in_features=self.dangles,
+            out_layer=dangles_layer,
+        )
+
+        arcpy.management.SelectLayerByAttribute(
+            in_layer_or_view=dangles_layer,
+            selection_type="CLEAR_SELECTION",
+        )
+
+        for target in target_layers:
+            arcpy.management.SelectLayerByLocation(
+                in_layer=dangles_layer,
+                overlap_type="WITHIN_A_DISTANCE",
+                select_features=target,
+                search_distance=self._tolerance_linear_unit(),
+                selection_type="ADD_TO_SELECTION",
+            )
+
+        arcpy.management.CopyFeatures(
+            in_features=dangles_layer,
+            out_feature_class=self.filtered_dangles,
+        )
+
+    def _run_near(self, target_layers: list[str]) -> None:
+        arcpy.analysis.Near(
+            in_features=self.filtered_dangles,
+            near_features=target_layers,
+            search_radius=self._tolerance_linear_unit(),
+            location="LOCATION",
+            angle="NO_ANGLE",
+            method="PLANAR",
+        )
+
+    def _build_plan(self) -> dict[int, dict]:
+        """
+        What:
+            Builds a dict keyed by ORIGINAL_ID with everything needed to update line endpoints.
+
+        Note:
+            Under current assumptions, each line produces max one dangle.
+            Edge cases (two dangles per line) handled later.
+        """
+        plan: dict[int, dict] = {}
+
+        fields = [
+            self.ORIGINAL_ID,
+            "SHAPE@XY",
+            "NEAR_FID",
+            "NEAR_X",
+            "NEAR_Y",
+        ]
+
+        with arcpy.da.SearchCursor(
+            in_table=self.filtered_dangles,
+            field_names=fields,
+        ) as cursor:
+            for original_id, (dx, dy), near_fid, near_x, near_y in cursor:
+                if near_fid is None:
+                    continue
+
+                plan[int(original_id)] = {
+                    "processed": False,
+                    "dangle_x": float(dx),
+                    "dangle_y": float(dy),
+                    "near_x": float(near_x),
+                    "near_y": float(near_y),
+                }
+
+        return plan
+
+    def _apply_symmetric_pair_skip(self, plan: dict[int, dict]) -> None:
+        """
+        What:
+            Avoids processing a mutual dangle↔dangle pair twice.
+
+        How:
+            - Only possible/meaningful when dangles are included as near_features.
+            - In this implementation, Near is run against target layers, and may include dangles
+              only if you later decide to add them as a target. Kept here to support your stated intent.
+        """
+        _ = plan
+
+    def _move_endpoint(
+        self, shape, dangle_x: float, dangle_y: float, near_x: float, near_y: float
+    ):
+        """
+        What:
+            Moves the endpoint vertex that corresponds to the dangle point to NEAR_X/NEAR_Y.
+
+        Assumptions:
+            - No multipart polylines in input.
+            - Dangle point equals one endpoint (within a small tolerance).
+        """
+        if shape is None:
+            return shape
+
+        part = shape.getPart(0)
+        points = [pt for pt in part]
+        if len(points) < 2:
+            return shape
+
+        first = points[0]
+        last = points[-1]
+
+        tol = 0.001
+
+        def matches(point, x: float, y: float) -> bool:
+            return abs(point.X - x) <= tol and abs(point.Y - y) <= tol
+
+        if matches(point=first, x=dangle_x, y=dangle_y):
+            points[0] = arcpy.Point(X=near_x, Y=near_y)
+        elif matches(point=last, x=dangle_x, y=dangle_y):
+            points[-1] = arcpy.Point(X=near_x, Y=near_y)
+        else:
+            # Fallback: choose closer endpoint to the dangle XY
+            d_first = (first.X - dangle_x) ** 2 + (first.Y - dangle_y) ** 2
+            d_last = (last.X - dangle_x) ** 2 + (last.Y - dangle_y) ** 2
+            if d_first <= d_last:
+                points[0] = arcpy.Point(X=near_x, Y=near_y)
+            else:
+                points[-1] = arcpy.Point(X=near_x, Y=near_y)
+
+        new_array = arcpy.Array(points)
+        return arcpy.Polyline(
+            inputs=new_array,
+            spatial_reference=shape.spatialReference,
+        )
+
+    def _apply_edits(self, plan: dict[int, dict]) -> None:
+        if not plan:
+            arcpy.management.CopyFeatures(
+                in_features=self.lines_copy,
+                out_feature_class=self.output_lines,
+            )
+            return
+
+        fields = [self.ORIGINAL_ID, "SHAPE@"]
+
+        with arcpy.da.UpdateCursor(
+            in_table=self.lines_copy,
+            field_names=fields,
+        ) as cursor:
+            for original_id, shape in cursor:
+                original_id_int = int(original_id)
+                if original_id_int not in plan:
+                    continue
+
+                info = plan[original_id_int]
+                if info["processed"] is True:
+                    continue
+
+                new_shape = self._move_endpoint(
+                    shape=shape,
+                    dangle_x=info["dangle_x"],
+                    dangle_y=info["dangle_y"],
+                    near_x=info["near_x"],
+                    near_y=info["near_y"],
+                )
+                cursor.updateRow((original_id, new_shape))
+
+        arcpy.management.CopyFeatures(
+            in_features=self.lines_copy,
+            out_feature_class=self.output_lines,
+        )
+
+    def run(self) -> None:
+        environment_setup.main()
+
+        self.work_file_list = self.wfm.setup_work_file_paths(
+            instance=self,
+            file_structure=self.work_file_list,
+        )
+
+        self._copy_input_lines()
+        self._add_original_id_field()
+        self._create_dangles()
+
+        self._remove_lines_that_produced_dangles()
+
+        target_layers = self._select_targets_within_tolerance_of_dangles()
+        self._filter_dangles_within_tolerance_of_targets(target_layers=target_layers)
+
+        self._run_near(target_layers=target_layers)
+
+        plan = self._build_plan()
+        self._apply_symmetric_pair_skip(plan=plan)
+        self._apply_edits(plan=plan)
+
+        self.wfm.delete_created_files()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -3347,7 +3347,7 @@ class FillLineGaps:
 
         return out
 
-    def _candidate_is_legal(
+    def _candidate_legality_reason(
         self,
         *,
         illegal: _IllegalTargets,
@@ -3361,25 +3361,31 @@ class FillLineGaps:
         dangle_candidate_tol: float,
         topology: TopologyModel | None = None,
         cid_by_optional_candidate: dict[tuple[DatasetKey, int], int] | None = None,
-    ) -> bool:
+    ) -> Optional[str]:
+        """Return ``None`` if the candidate is legal, else a reason string.
+
+        Reasons are one of ``'beyond_distance_tolerance'``,
+        ``'same_network'``, ``'illegal_target'``.  Callers wanting a
+        boolean check use ``self._candidate_legality_reason(...) is None``.
+        """
         ds_key = cand.near_fc_key
         oid = cand.near_fid
         dist = cand.near_dist
 
         if ds_key == dangles_fc_key:
             if dist > float(dangle_candidate_tol):
-                return False
+                return "beyond_distance_tolerance"
 
             other_parent = dangle_parent.get(int(oid))
             if other_parent is None:
-                return False
+                return "illegal_target"
 
             if topology is not None and self._same_network(
                 a_parent=int(parent_id),
                 b_parent=int(other_parent),
                 topology=topology,
             ):
-                return False
+                return "same_network"
 
             # Dangle->dangle illegal-checks against the other parent line id
             if self._is_illegal(
@@ -3388,9 +3394,9 @@ class FillLineGaps:
                 target_fc_key=lines_fc_key,
                 target_oid=int(other_parent),
             ):
-                return False
+                return "illegal_target"
 
-            return True
+            return None
 
         # Line-like targets (self-lines and connect_to_features polylines) use the
         # expanded tolerance so true-dangle connections beyond base_tol are reachable.
@@ -3398,10 +3404,14 @@ class FillLineGaps:
             dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
         )
         if dist > float(effective_tol):
-            return False
+            return "beyond_distance_tolerance"
 
+        # Self-target rejection (candidate is the parent line itself).
+        # _filter_legal_candidates already pre-filters this case via an
+        # early `continue`, so this branch is defensive — kept to keep the
+        # function self-contained for any future caller.
         if ds_key == lines_fc_key and int(oid) == int(parent_id):
-            return False
+            return "illegal_target"
 
         if (
             ds_key == lines_fc_key
@@ -3412,7 +3422,7 @@ class FillLineGaps:
                 topology=topology,
             )
         ):
-            return False
+            return "same_network"
 
         # External-optional same-network rejection. Covers the case where the
         # source parent and an external optional (polygon-as-topology or
@@ -3430,7 +3440,7 @@ class FillLineGaps:
             if src_cid is not None:
                 tgt_cid = cid_by_optional_candidate.get((ds_key, int(oid)))
                 if tgt_cid is not None and int(tgt_cid) == int(src_cid):
-                    return False
+                    return "same_network"
 
         if self._is_illegal(
             illegal=illegal,
@@ -3438,78 +3448,9 @@ class FillLineGaps:
             target_fc_key=ds_key,
             target_oid=oid,
         ):
-            return False
-
-        return True
-
-    def _candidate_rejection_reason(
-        self,
-        *,
-        illegal: _IllegalTargets,
-        dangle_parent: dict[DangleOid, ParentId],
-        dangles_fc_key: DatasetKey,
-        lines_fc_key: DatasetKey,
-        line_like_ds_keys: set[DatasetKey],
-        parent_id: ParentId,
-        cand: NearCandidate,
-        base_tol: float,
-        dangle_candidate_tol: float,
-        topology: "TopologyModel | None",
-        cid_by_optional_candidate: dict[tuple[DatasetKey, int], int] | None = None,
-    ) -> str:
-        """Return the legality-failure reason for a candidate, mirroring _candidate_is_legal."""
-        ds_key = cand.near_fc_key
-        oid = cand.near_fid
-        dist = cand.near_dist
-
-        if ds_key == dangles_fc_key:
-            if dist > float(dangle_candidate_tol):
-                return "beyond_distance_tolerance"
-            other_parent = dangle_parent.get(int(oid))
-            if other_parent is None:
-                return "illegal_target"
-            if topology is not None and self._same_network(
-                a_parent=int(parent_id), b_parent=int(other_parent), topology=topology
-            ):
-                return "same_network"
-            if self._is_illegal(
-                illegal=illegal,
-                parent_id=parent_id,
-                target_fc_key=lines_fc_key,
-                target_oid=int(other_parent),
-            ):
-                return "illegal_target"
             return "illegal_target"
 
-        effective_tol = (
-            dangle_candidate_tol if ds_key in line_like_ds_keys else base_tol
-        )
-        if dist > float(effective_tol):
-            return "beyond_distance_tolerance"
-        if (
-            topology is not None
-            and ds_key == lines_fc_key
-            and self._same_network(
-                a_parent=int(parent_id), b_parent=int(oid), topology=topology
-            )
-        ):
-            return "same_network"
-        if (
-            ds_key != lines_fc_key
-            and topology is not None
-            and topology.connectivity_id_by_parent is not None
-            and cid_by_optional_candidate
-        ):
-            src_cid = topology.connectivity_id_by_parent.get(int(parent_id))
-            if src_cid is not None:
-                tgt_cid = cid_by_optional_candidate.get((ds_key, int(oid)))
-                if tgt_cid is not None and int(tgt_cid) == int(src_cid):
-                    return "same_network"
-        if self._is_illegal(
-            illegal=illegal, parent_id=parent_id, target_fc_key=ds_key, target_oid=oid
-        ):
-            return "illegal_target"
-        return "illegal_target"
+        return None
 
     def _resolve_target_parent_id(
         self,
@@ -4047,7 +3988,7 @@ class FillLineGaps:
         topology: TopologyModel | None = None,
     ) -> Optional[NearCandidate]:
         for cand in candidates_sorted:
-            if self._candidate_is_legal(
+            reason = self._candidate_legality_reason(
                 illegal=illegal,
                 dangle_parent=dangle_parent,
                 dangles_fc_key=dangles_fc_key,
@@ -4058,7 +3999,8 @@ class FillLineGaps:
                 base_tol=base_tol,
                 dangle_candidate_tol=base_tol,
                 topology=topology,
-            ):
+            )
+            if reason is None:
                 return cand
         return None
 
@@ -4885,7 +4827,7 @@ class FillLineGaps:
                 if cand.near_fc_key == lines_key and cand.near_fid == parent_id:
                     continue
 
-                is_legal = self._candidate_is_legal(
+                reason = self._candidate_legality_reason(
                     illegal=illegal,
                     dangle_parent=dangle_parent,
                     dangles_fc_key=dangles_key,
@@ -4898,22 +4840,9 @@ class FillLineGaps:
                     topology=topology,
                     cid_by_optional_candidate=cid_by_optional_candidate,
                 )
-                if is_legal:
+                if reason is None:
                     legal_rows.append(cand)
                 elif collect_diags:
-                    reason = self._candidate_rejection_reason(
-                        illegal=illegal,
-                        dangle_parent=dangle_parent,
-                        dangles_fc_key=dangles_key,
-                        lines_fc_key=lines_key,
-                        line_like_ds_keys=line_like_ds_keys,
-                        parent_id=parent_id,
-                        cand=cand,
-                        base_tol=base_tol,
-                        dangle_candidate_tol=dangle_tol,
-                        topology=topology,
-                        cid_by_optional_candidate=cid_by_optional_candidate,
-                    )
                     _step1a_illegal.append(
                         _CandidateIllegalA(dangle_oid, parent_id, cand, reason)
                     )
@@ -5596,7 +5525,7 @@ class FillLineGaps:
         ):
             uf = _UnionFind()
             # Optional-candidate ↔ component pre-merging used to live here but
-            # has moved to the candidate scope (see _candidate_is_legal's
+            # has moved to the candidate scope (see _candidate_legality_reason's
             # cid_by_optional_candidate check). Under polygon connect_to_features
             # the old seed could not align OID spaces (polygon-vs-polyline);
             # the candidate-scope check resolves both polygon and polyline

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -16,7 +16,6 @@ from composition_configs import logic_config
 from composition_configs.logic_config import ConnectivityScope, LineConnectivityMode
 from custom_tools.general_tools import geometry_tools
 
-
 OptionalKey = tuple[str, int]  # (dataset_key, oid)  -- oid is SOURCE oid
 ParentEntityKey = tuple[str, int]  # ("parent", parent_id)
 OptionalEntityKey = tuple[str, str, int]  # ("optional", dataset_key, oid)
@@ -1951,12 +1950,8 @@ class FillLineGaps:
         if self.FIELD_GAP_GENERATED in existing:
             return
 
-        arcpy.management.AddField(
-            self.lines_copy, self.FIELD_GAP_GENERATED, "SHORT"
-        )
-        with arcpy.da.UpdateCursor(
-            self.lines_copy, [self.FIELD_GAP_GENERATED]
-        ) as cur:
+        arcpy.management.AddField(self.lines_copy, self.FIELD_GAP_GENERATED, "SHORT")
+        with arcpy.da.UpdateCursor(self.lines_copy, [self.FIELD_GAP_GENERATED]) as cur:
             for _ in cur:
                 cur.updateRow((0,))
 
@@ -2315,9 +2310,7 @@ class FillLineGaps:
 
             self._angle_mode_by_external_ds_key[str(out_key)] = mode
 
-    def _stage_polygon_target_as_polyline(
-        self, feature_path: str, index: int
-    ) -> str:
+    def _stage_polygon_target_as_polyline(self, feature_path: str, index: int) -> str:
         """Convert a polygon ``connect_to_features`` entry to a polyline work FC.
 
         Runs ``PolygonToLine`` on the *source* polygon FC (not a
@@ -2358,12 +2351,8 @@ class FillLineGaps:
                 for poly_oid in (left, right):
                     if poly_oid is None or int(poly_oid) < 0:
                         continue
-                    poly_to_lines.setdefault(int(poly_oid), set()).add(
-                        int(line_oid)
-                    )
-        self._polygon_to_polyline_oid[self._dataset_key(feature_path)] = (
-            poly_to_lines
-        )
+                    poly_to_lines.setdefault(int(poly_oid), set()).add(int(line_oid))
+        self._polygon_to_polyline_oid[self._dataset_key(feature_path)] = poly_to_lines
 
         self._ensure_original_id_field(polyline_work_path)
         return polyline_work_path
@@ -2426,9 +2415,9 @@ class FillLineGaps:
                 tail_tolerance=float(seg_cfg.tail_tolerance_meters),
             )
             self.external_target_layers_segmented.append(seg_path)
-            self._segmented_oid_to_parent_id[
-                self._dataset_key(seg_path)
-            ] = self._oid_to_original_id_lookup(seg_path)
+            self._segmented_oid_to_parent_id[self._dataset_key(seg_path)] = (
+                self._oid_to_original_id_lookup(seg_path)
+            )
 
     def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
         """Return the global target layer list for connectivity-side queries.
@@ -3420,9 +3409,8 @@ class FillLineGaps:
         endpoint_snap = is_dangle_pair or is_dangle_parent_line
 
         if not self.lines_are_directed:
-            if (
-                src_poly_for_norm is not None
-                and self._xy_is_at_line_start(src_poly_for_norm, dangle_x, dangle_y)
+            if src_poly_for_norm is not None and self._xy_is_at_line_start(
+                src_poly_for_norm, dangle_x, dangle_y
             ):
                 src_angle_deg = (float(src_angle_deg) + 180.0) % 360.0
             if not self._xy_is_at_line_start(tgt_poly, tgt_snap_x, tgt_snap_y):
@@ -3824,9 +3812,8 @@ class FillLineGaps:
                     )
                     else None
                 )
-                if (
-                    _parent_dist is not None
-                    and float(_parent_dist) <= float(connector_diff_threshold)
+                if _parent_dist is not None and float(_parent_dist) <= float(
+                    connector_diff_threshold
                 ):
                     metric = float(src_target_diff)
                 else:
@@ -3854,9 +3841,7 @@ class FillLineGaps:
         blocks = block_thr is not None and metric > float(block_thr)
         extra_thr = self.angle_extra_dangle_threshold_degrees
         allow_extra = (
-            ds_key != dangles_fc_key
-            or extra_thr is None
-            or metric <= float(extra_thr)
+            ds_key != dangles_fc_key or extra_thr is None or metric <= float(extra_thr)
         )
 
         return AngleAssessment(
@@ -4393,9 +4378,7 @@ class FillLineGaps:
             else None
         )
 
-        def _apply_filter(
-            reject_keys: set[tuple[int, str, int]], reason: str
-        ) -> None:
+        def _apply_filter(reject_keys: set[tuple[int, str, int]], reason: str) -> None:
             for _dangle_oid in list(legal_rows_by_dangle.keys()):
                 _parent_id = parent_id_by_dangle[_dangle_oid]
                 _remaining: list[NearCandidate] = []
@@ -5059,9 +5042,7 @@ class FillLineGaps:
         Returns (_global_winners, global_norm_z_by_dangle).
         """
         _all_end_z_global = [p.ctx.end_z for p in connection_proposals]
-        _all_eff_dist_global = [
-            p.ctx.effective_distance for p in connection_proposals
-        ]
+        _all_eff_dist_global = [p.ctx.effective_distance for p in connection_proposals]
         _global_winners: list[_GlobalProposal] = []
         global_norm_z_by_dangle: _NormZByDangle = {}
         for n_prop in connection_proposals:
@@ -5182,7 +5163,11 @@ class FillLineGaps:
                 rank_counter += 1
                 d_oid = int(prop.ctx.dangle_oid)
                 kruskal_rank_by_dangle_oid[d_oid] = rank_counter
-                _key = (d_oid, str(prop.ctx.near_fc_key_raw), int(prop.ctx.near_fid_raw))
+                _key = (
+                    d_oid,
+                    str(prop.ctx.near_fc_key_raw),
+                    int(prop.ctx.near_fid_raw),
+                )
                 accepted_keys.add(_key)
                 accepted_connector_raw.append(
                     AcceptedConnectorRaw(
@@ -6379,10 +6364,11 @@ class FillLineGaps:
                     if pid in needed_parent_ids and pid not in parent_attrs:
                         parent_attrs[pid] = tuple(row[1:])
 
-        insert_fields = (
-            copyable_fields
-            + [self.ORIGINAL_ID, self.FIELD_GAP_GENERATED, "SHAPE@"]
-        )
+        insert_fields = copyable_fields + [
+            self.ORIGINAL_ID,
+            self.FIELD_GAP_GENERATED,
+            "SHAPE@",
+        ]
 
         epsilon_sq = 1e-10
         with arcpy.da.InsertCursor(self.lines_copy, insert_fields) as icur:

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1497,13 +1497,21 @@ class FillLineGaps:
 
         self.external_target_layers: list[str] = []
         # FCs to use as against_fcs in the connector-crossing pre-filter.
-        # Polyline connect_to_features are reused as-is; polygon
-        # connect_to_features contribute their boundary as a polyline FC
-        # built once via PolygonToLine in
-        # _build_external_target_layers_once.  Populated only when
-        # reject_crossing_connectors is True; entries are pure paths so
-        # the existing line-vs-line crossing path applies uniformly.
+        # Populated only when reject_crossing_connectors is True.  Polygon
+        # connect_to_features are converted to a polyline FC upfront in
+        # _build_external_target_layers_once, so external_target_layers
+        # already contains the polyline form and this list reuses those
+        # entries — the line-vs-line crossing path applies uniformly.
         self.external_target_crossing_layers: list[str] = []
+
+        # Per polygon connect_to_features entry: maps source-polygon OID to
+        # the set of polyline OIDs that PolygonToLine produced for it
+        # (LEFT_FID/RIGHT_FID can each contribute, with -1 skipped, so the
+        # relation is 1-to-many whenever polygons share edges).  Keyed by
+        # the *source polygon FC's* dataset key — the same space that
+        # TopologyBuilder uses for connectivity_id_by_optional — so
+        # _build_plan can lift topology OIDs into candidate-space OIDs.
+        self._polygon_to_polyline_oid: dict[DatasetKey, dict[int, set[int]]] = {}
 
         self.work_file_list = [
             self.lines_copy,
@@ -2226,8 +2234,16 @@ class FillLineGaps:
         output layer's angle mode is resolved from
         ``connect_to_features_angle_mode`` (keyed by source path, source
         dataset key, or output dataset key) and recorded in
-        ``_angle_mode_by_external_ds_key``.  Idempotent — skips work on
-        re-entry.
+        ``_angle_mode_by_external_ds_key``.
+
+        Polygon ``connect_to_features`` entries are converted to their
+        boundary polyline via ``PolygonToLine`` before the tolerance
+        filter runs, so every entry in ``external_target_layers`` is a
+        polyline (or whatever non-polygon type the caller passed in).
+        The polygon→polyline OID lookup recorded here lets
+        ``_build_plan`` lift topology connectivity ids (keyed in source
+        polygon space) into candidate-space optional ids.  Idempotent —
+        skips work on re-entry.
         """
         if self.external_target_layers:
             return
@@ -2236,6 +2252,65 @@ class FillLineGaps:
 
         for index, feature_path in enumerate(self.connect_to_features):
             output_name = self.wfm.build_file_path(file_name=f"target_feature_{index}")
+
+            # Polygon connect_to_features get a one-shot PolygonToLine on the
+            # source FC.  Running before the tolerance filter is mandatory:
+            # LEFT_FID / RIGHT_FID in the polyline output reference the source
+            # polygon FC's OIDs, which is the same space TopologyBuilder uses
+            # for connectivity_id_by_optional.  Filtering the polygon first
+            # would re-key those FIDs to a staged copy and break the anchor.
+            #
+            # Default flags on PolygonToLine — the neighbor option varies by
+            # ArcGIS version, so the mapping reads both LEFT_FID and RIGHT_FID
+            # and skips -1, which is correct under either neighbor mode.
+            if self._is_polygon_fc(feature_path):
+                polyline_work_path = self.wfm.build_file_path(
+                    file_name=f"target_feature_{index}_polylines"
+                )
+                arcpy.management.PolygonToLine(
+                    in_features=feature_path,
+                    out_feature_class=polyline_work_path,
+                )
+
+                poly_to_lines: dict[int, set[int]] = {}
+                polyline_oid_field = arcpy.Describe(polyline_work_path).OIDFieldName
+                with arcpy.da.SearchCursor(
+                    polyline_work_path,
+                    [polyline_oid_field, "LEFT_FID", "RIGHT_FID"],
+                ) as cur:
+                    for line_oid, left, right in cur:
+                        for poly_oid in (left, right):
+                            if poly_oid is None or int(poly_oid) < 0:
+                                continue
+                            poly_to_lines.setdefault(int(poly_oid), set()).add(
+                                int(line_oid)
+                            )
+                self._polygon_to_polyline_oid[self._dataset_key(feature_path)] = (
+                    poly_to_lines
+                )
+
+                # Stamp ORIGINAL_ID on the polyline work FC so the value
+                # carries through the tolerance-filter copy below and (when
+                # segmentation is enabled) into each segment.  Under the
+                # polygon path ORIGINAL_ID is therefore the polyline_work_path
+                # OID — the same space _polygon_to_polyline_oid maps into.
+                existing = {f.name for f in arcpy.ListFields(polyline_work_path)}
+                if self.ORIGINAL_ID not in existing:
+                    arcpy.management.AddField(
+                        polyline_work_path, self.ORIGINAL_ID, "LONG"
+                    )
+                arcpy.management.CalculateField(
+                    polyline_work_path,
+                    self.ORIGINAL_ID,
+                    expression=f"!{polyline_oid_field}!",
+                    expression_type="PYTHON3",
+                )
+
+                staging_input = polyline_work_path
+                already_stamped = True
+            else:
+                staging_input = feature_path
+                already_stamped = False
 
             # Segmentation needs to stamp ORIGINAL_ID on the output FC so the
             # segmented twin can map back to a stable parent identifier;
@@ -2246,7 +2321,7 @@ class FillLineGaps:
             )
             if use_memory_layer:
                 custom_arcpy.select_location_and_make_feature_layer(
-                    input_layer=feature_path,
+                    input_layer=staging_input,
                     overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
                     select_features=self.dangles,
                     output_name=output_name,
@@ -2254,19 +2329,22 @@ class FillLineGaps:
                 )
             else:
                 custom_arcpy.select_location_and_make_permanent_feature(
-                    input_layer=feature_path,
+                    input_layer=staging_input,
                     overlap_type=custom_arcpy.OverlapType.WITHIN_A_DISTANCE.value,
                     select_features=self.dangles,
                     output_name=output_name,
                     search_distance=self._tolerance_linear_unit(),
                 )
 
-            if self.segmentation is not None:
+            if self.segmentation is not None and not already_stamped:
                 # Stamp ORIGINAL_ID = OID on the staged target FC so the
                 # segmented twin's segments can carry their parent's OID
                 # via segment_line's field-preservation, giving a clean
                 # segmented_oid -> parent_id mapping in the candidate near
-                # table reader.
+                # table reader.  Polygon entries are already stamped above
+                # (on the polyline work FC) and the value is preserved by the
+                # tolerance-filter copy, so we only stamp here for non-polygon
+                # sources.
                 existing = {f.name for f in arcpy.ListFields(output_name)}
                 if self.ORIGINAL_ID not in existing:
                     arcpy.management.AddField(output_name, self.ORIGINAL_ID, "LONG")
@@ -2281,23 +2359,12 @@ class FillLineGaps:
             self.external_target_layers.append(output_name)
 
             # Companion entry for the connector-crossing pre-filter.
-            # Polyline sources reuse output_name; polygon sources are
-            # converted to their boundary polyline once via PolygonToLine
-            # so the line-vs-line crossing path handles them uniformly.
-            # Other shape types (points) are skipped — a connector cannot
-            # cross a point.
-            if self.reject_crossing_connectors:
-                if self._is_polyline_fc(output_name):
-                    self.external_target_crossing_layers.append(output_name)
-                elif self._is_polygon_fc(output_name):
-                    outline_name = self.wfm.build_file_path(
-                        file_name=f"target_feature_{index}_polygon_outline"
-                    )
-                    arcpy.management.PolygonToLine(
-                        in_features=output_name,
-                        out_feature_class=outline_name,
-                    )
-                    self.external_target_crossing_layers.append(outline_name)
+            # Every entry in external_target_layers is now either a polyline
+            # (including polygon sources, converted above) or a non-polyline
+            # type like points; the latter cannot host a crossing connector,
+            # so they are skipped.
+            if self.reject_crossing_connectors and self._is_polyline_fc(output_name):
+                self.external_target_crossing_layers.append(output_name)
 
             out_key = self._dataset_key(output_name)
 
@@ -2328,11 +2395,12 @@ class FillLineGaps:
         each segment carries its parent's ORIGINAL_ID and the OID lookup
         reduces to the existing ``_oid_to_original_id_lookup`` helper.
 
-        Polygon ``connect_to_features`` are not supported with segmentation
-        enabled — callers should convert polygons to polylines before
-        passing them in. Geometry types other than polygon and polyline
-        (e.g. points) pass through unsegmented; the candidate near table
-        reads them directly.
+        Polygon ``connect_to_features`` are converted to a polyline
+        boundary in ``_build_external_target_layers_once`` before
+        reaching here, so every entry in ``external_target_layers`` is
+        either a polyline (segmented) or a non-polyline type like points
+        (passed through unsegmented; the candidate near table reads them
+        directly).
 
         No-op when ``self.segmentation`` is None.
         """
@@ -2356,18 +2424,10 @@ class FillLineGaps:
         print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation lines_copy END (rows={int(arcpy.management.GetCount(self.lines_copy_segmented)[0])})")  # [DBG_LINEGAP]
 
         for index, ext_path in enumerate(self.external_target_layers):
-            if self._is_polygon_fc(ext_path):
-                raise ValueError(
-                    f"connect_to_features[{index}] is a polygon feature class. "
-                    f"Segmentation only supports polyline connect_to_features. "
-                    f"Convert polygons to polylines (e.g. via PolygonToLine) "
-                    f"before passing them to FillLineGaps when segmentation "
-                    f"is enabled."
-                )
             if not self._is_polyline_fc(ext_path):
-                # Non-line, non-polygon (e.g. point) — segmentation does
-                # not apply. Pass the source path through so the segmented
-                # list aligns with external_target_layers.
+                # Non-polyline (e.g. point) — segmentation does not apply.
+                # Pass the source path through so the segmented list aligns
+                # with external_target_layers.
                 self.external_target_layers_segmented.append(ext_path)
                 continue
 
@@ -3200,6 +3260,82 @@ class FillLineGaps:
     # Planning: choose closest legal + detect pairs
     # ----------------------------
 
+    def _build_cid_by_optional_candidate(
+        self, *, topology: TopologyModel
+    ) -> dict[tuple[DatasetKey, int], int]:
+        """Lift topology's source-space optional cids into candidate-space.
+
+        Topology keys optionals by ``(source_path_dataset_key, source_oid)``.
+        After ``_build_external_target_layers_once``:
+
+          - polyline sources stage to a tolerance-filtered polyline FC whose
+            OIDs equal the source OIDs (the existing staging contract);
+          - polygon sources stage to a tolerance-filtered polyline FC whose
+            OIDs were assigned by ``PolygonToLine`` (see
+            ``self._polygon_to_polyline_oid`` for the source-polygon-OID →
+            polyline-OID mapping; the relation is 1-to-many whenever
+            polygons share edges).
+
+        The candidate near table emits ``cand.near_fc_key`` as either the
+        staged FC's dataset key (segmentation off) or the segmented twin's
+        dataset key (segmentation on), with ``cand.near_fid`` already lifted
+        to staged-FC-OID space by ``_read_near_table_grouped``.  Both keys
+        are populated with the same cid so the lookup hits in either mode.
+        Returns an empty dict when topology has no ``connectivity_id_by_optional``
+        (scope = NONE / DIRECT_CONNECTION / INPUT_LINES, or no optionals to
+        unify).
+        """
+        out: dict[tuple[DatasetKey, int], int] = {}
+        source_cid_by_optional = topology.connectivity_id_by_optional
+        if not source_cid_by_optional:
+            return out
+        if not self.connect_to_features:
+            return out
+
+        topology_by_ds: dict[DatasetKey, list[tuple[int, int]]] = {}
+        for (opt_ds_key, opt_oid), cid in source_cid_by_optional.items():
+            topology_by_ds.setdefault(str(opt_ds_key), []).append(
+                (int(opt_oid), int(cid))
+            )
+
+        seg_layers = (
+            self.external_target_layers_segmented
+            if self.segmentation is not None
+            else []
+        )
+
+        for idx, src_path in enumerate(self.connect_to_features):
+            if idx >= len(self.external_target_layers):
+                continue
+            src_ds_key = self._dataset_key(src_path)
+            entries = topology_by_ds.get(src_ds_key)
+            if not entries:
+                continue
+
+            staged_path = self.external_target_layers[idx]
+            candidate_ds_keys = {self._dataset_key(staged_path)}
+            if idx < len(seg_layers):
+                seg_path = seg_layers[idx]
+                if seg_path != staged_path:
+                    candidate_ds_keys.add(self._dataset_key(seg_path))
+
+            poly_to_lines = self._polygon_to_polyline_oid.get(src_ds_key)
+
+            if poly_to_lines is not None:
+                for opt_oid, cid in entries:
+                    line_oids = poly_to_lines.get(opt_oid)
+                    if not line_oids:
+                        continue
+                    for line_oid in line_oids:
+                        for cds in candidate_ds_keys:
+                            out[(cds, int(line_oid))] = cid
+            else:
+                for opt_oid, cid in entries:
+                    for cds in candidate_ds_keys:
+                        out[(cds, opt_oid)] = cid
+
+        return out
+
     def _candidate_is_legal(
         self,
         *,
@@ -3213,6 +3349,7 @@ class FillLineGaps:
         base_tol: float,
         dangle_candidate_tol: float,
         topology: TopologyModel | None = None,
+        cid_by_optional_candidate: dict[tuple[DatasetKey, int], int] | None = None,
     ) -> bool:
         ds_key = cand.near_fc_key
         oid = cand.near_fid
@@ -3266,6 +3403,24 @@ class FillLineGaps:
         ):
             return False
 
+        # External-optional same-network rejection. Covers the case where the
+        # source parent and an external optional (polygon-as-topology or
+        # polyline) already share a connectivity component — those candidates
+        # are redundant fills and must be rejected at candidate scope.
+        # Replaces the Kruskal optional_candidate UF seed; under polygon
+        # connect_to_features that seed could not align OID spaces.
+        if (
+            ds_key != lines_fc_key
+            and topology is not None
+            and topology.connectivity_id_by_parent is not None
+            and cid_by_optional_candidate
+        ):
+            src_cid = topology.connectivity_id_by_parent.get(int(parent_id))
+            if src_cid is not None:
+                tgt_cid = cid_by_optional_candidate.get((ds_key, int(oid)))
+                if tgt_cid is not None and int(tgt_cid) == int(src_cid):
+                    return False
+
         if self._is_illegal(
             illegal=illegal,
             parent_id=parent_id,
@@ -3289,6 +3444,7 @@ class FillLineGaps:
         base_tol: float,
         dangle_candidate_tol: float,
         topology: "TopologyModel | None",
+        cid_by_optional_candidate: dict[tuple[DatasetKey, int], int] | None = None,
     ) -> str:
         """Return the legality-failure reason for a candidate, mirroring _candidate_is_legal."""
         ds_key = cand.near_fc_key
@@ -3327,6 +3483,17 @@ class FillLineGaps:
             )
         ):
             return "same_network"
+        if (
+            ds_key != lines_fc_key
+            and topology is not None
+            and topology.connectivity_id_by_parent is not None
+            and cid_by_optional_candidate
+        ):
+            src_cid = topology.connectivity_id_by_parent.get(int(parent_id))
+            if src_cid is not None:
+                tgt_cid = cid_by_optional_candidate.get((ds_key, int(oid)))
+                if tgt_cid is not None and int(tgt_cid) == int(src_cid):
+                    return "same_network"
         if self._is_illegal(
             illegal=illegal, parent_id=parent_id, target_fc_key=ds_key, target_oid=oid
         ):
@@ -4313,6 +4480,17 @@ class FillLineGaps:
         # Step 2 - Legality gates (distance / network / illegal-target)
         # Collects legal (dangle, target) candidate rows.
         # ----------------------------
+        # Lift topology's source-space connectivity_id_by_optional into
+        # candidate-space. Polygon sources are expanded through
+        # _polygon_to_polyline_oid (1-to-many); polyline sources use the
+        # identity expansion. Both the staged FC's key and the segmented
+        # twin's key (when segmentation is enabled) receive the same cid
+        # value, so the lookup hits regardless of which key cand.near_fc_key
+        # ends up with after _read_near_table_grouped.
+        cid_by_optional_candidate: dict[tuple[DatasetKey, int], int] = (
+            self._build_cid_by_optional_candidate(topology=topology)
+        )
+
         print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_legal_candidates START (grouped={len(grouped)})")  # [DBG_LINEGAP]
         legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
             self._filter_legal_candidates(
@@ -4327,6 +4505,7 @@ class FillLineGaps:
                 topology=topology,
                 collect_diags=collect_diags,
                 directed_source_illegal_oids=directed_start_dangles,
+                cid_by_optional_candidate=cid_by_optional_candidate,
             )
         )
         print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_legal_candidates END (legal_dangles={len(legal_rows_by_dangle)}, illegal_rows={len(_step1a_illegal)})")  # [DBG_LINEGAP]
@@ -4650,6 +4829,7 @@ class FillLineGaps:
         topology: TopologyModel,
         collect_diags: bool,
         directed_source_illegal_oids: set[DangleOid],
+        cid_by_optional_candidate: dict[tuple[DatasetKey, int], int],
     ) -> tuple[
         dict[DangleOid, list[NearCandidate]],
         dict[DangleOid, ParentId],
@@ -4705,6 +4885,7 @@ class FillLineGaps:
                     base_tol=base_tol,
                     dangle_candidate_tol=dangle_tol,
                     topology=topology,
+                    cid_by_optional_candidate=cid_by_optional_candidate,
                 )
                 if is_legal:
                     legal_rows.append(cand)
@@ -4720,6 +4901,7 @@ class FillLineGaps:
                         base_tol=base_tol,
                         dangle_candidate_tol=dangle_tol,
                         topology=topology,
+                        cid_by_optional_candidate=cid_by_optional_candidate,
                     )
                     _step1a_illegal.append(
                         _CandidateIllegalA(dangle_oid, parent_id, cand, reason)
@@ -5402,22 +5584,12 @@ class FillLineGaps:
             logic_config.ConnectivityScope.TRANSITIVE,
         ):
             uf = _UnionFind()
-            # Map topology ds_keys (from original connect_to_features paths) to the
-            # candidate ds_keys (from work layer paths) so seeded nodes match tgt_node.
-            topo_to_cand_ds_key: dict[str, str] = {
-                self._dataset_key(orig): self._dataset_key(work)
-                for orig, work in zip(
-                    self.connect_to_features or [], self.external_target_layers
-                )
-            }
-            for (ds_key, oid), cid in (
-                topology.connectivity_id_by_optional or {}
-            ).items():
-                cand_ds_key = topo_to_cand_ds_key.get(ds_key, ds_key)
-                uf.union(
-                    ("component", int(cid)),
-                    ("optional_candidate", str(cand_ds_key), int(oid)),
-                )
+            # Optional-candidate ↔ component pre-merging used to live here but
+            # has moved to the candidate scope (see _candidate_is_legal's
+            # cid_by_optional_candidate check). Under polygon connect_to_features
+            # the old seed could not align OID spaces (polygon-vs-polyline);
+            # the candidate-scope check resolves both polygon and polyline
+            # entries uniformly through _build_cid_by_optional_candidate.
             for prop in sorted(global_winners, key=lambda p: p.sort_key()):
                 if uf.find(prop.ctx.src_node) == uf.find(prop.ctx.tgt_node):
                     continue

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -103,8 +103,7 @@ class PlanEntryMeta:
 @dataclass
 class PlanEntry:
     """One scheduled edit for a parent line. Mutable so _apply_plan can flip
-    ``processed`` and _apply_pair_symmetric_skip / _recheck_resnap_crossings can
-    flip ``skip``."""
+    ``processed`` and _recheck_resnap_crossings can flip ``skip``."""
 
     dangle_oid: DangleOid
     dangle_x: float
@@ -1542,10 +1541,6 @@ class FillLineGaps:
     def _expanded_dangle_tolerance_linear_unit(self) -> str:
         return f"{int(self._expanded_dangle_tolerance_meters())} Meters"
 
-    def _connectivity_tolerance_linear_unit(self) -> str:
-        meters = max(0.0, float(self.connectivity_tolerance_meters))
-        return f"{meters} Meters"
-
     def _dataset_key(self, value: str) -> str:
         text = str(value).replace("\\", "/")
         return text.split("/")[-1]
@@ -1731,22 +1726,6 @@ class FillLineGaps:
         Isolated behind a function so it can be upgraded later if SOURCE_OID becomes available.
         """
         return ("optional_candidate", str(dataset_key), int(near_fid))
-
-    def _best_legal_line_target_parent(
-        self,
-        *,
-        legal_rows: list[NearCandidate],
-        lines_fc_key: str,
-    ) -> Optional[int]:
-        """
-        Return the parent line id of the closest legal line target for this dangle.
-
-        `legal_rows` must already be sorted by raw candidate order.
-        """
-        for cand in legal_rows:
-            if cand.near_fc_key == lines_fc_key:
-                return cand.near_fid
-        return None
 
     def _mutual_dangle_preference(
         self,
@@ -3094,53 +3073,6 @@ class FillLineGaps:
             return False
         return int(target_oid) in ds.get(str(target_fc_key), set())
 
-    def _parents_share_illegal_target(
-        self,
-        *,
-        illegal: _IllegalTargets,
-        a_parent: ParentId,
-        b_parent: ParentId,
-    ) -> bool:
-        """
-        Your constraint: dangle-pairs must not share an illegal target object.
-
-        Interpreted as:
-          there exists any (dataset_key, oid) that is illegal for both parents.
-        """
-        a = illegal.get(int(a_parent), {})
-        b = illegal.get(int(b_parent), {})
-        if not a or not b:
-            return False
-
-        for ds_key, a_set in a.items():
-            b_set = b.get(ds_key)
-            if not b_set:
-                continue
-            if a_set.intersection(b_set):
-                return True
-        return False
-
-    def _find_specific_line_candidate(
-        self,
-        *,
-        candidates_sorted: list[NearCandidate],
-        lines_fc_keys: set[DatasetKey],
-        other_parent_id: ParentId,
-        base_tol: float,
-    ) -> Optional[NearCandidate]:
-        """
-        Find the row that explicitly targets the other *parent line* (lines_copy),
-        within base_tol.
-        """
-        for cand in candidates_sorted:
-            if cand.near_fc_key not in lines_fc_keys:
-                continue
-            if cand.near_fid != int(other_parent_id):
-                continue
-            if cand.near_dist <= float(base_tol):
-                return cand
-        return None
-
     # ----------------------------
     # Near table reading
     # ----------------------------
@@ -3950,213 +3882,6 @@ class FillLineGaps:
             src_target_diff=float(src_target_diff),
             connector_transition_diff=float(connector_transition_diff),
         )
-
-    def _pair_token_from_candidate(
-        self,
-        *,
-        dangle_parent: dict[DangleOid, ParentId],
-        dangles_fc_key: DatasetKey,
-        lines_fc_keys: set[DatasetKey],
-        cand: NearCandidate,
-    ) -> Optional[ParentId]:
-        """
-        Returns the *other parent line id* if this candidate represents “the other side”
-        of a potential dangle pair (either via dangle feature or via line feature).
-        """
-        ds_key = cand.near_fc_key
-        oid = cand.near_fid
-
-        if ds_key == dangles_fc_key:
-            other_parent = dangle_parent.get(oid)
-            return int(other_parent) if other_parent is not None else None
-
-        if ds_key in lines_fc_keys:
-            return int(oid)
-
-        return None
-
-    def _select_first_legal_candidate(
-        self,
-        *,
-        candidates_sorted: list[NearCandidate],
-        illegal: _IllegalTargets,
-        dangle_parent: dict[DangleOid, ParentId],
-        dangles_fc_key: DatasetKey,
-        lines_fc_key: DatasetKey,
-        parent_id: ParentId,
-        base_tol: float,
-        topology: TopologyModel | None = None,
-    ) -> Optional[NearCandidate]:
-        for cand in candidates_sorted:
-            reason = self._candidate_legality_reason(
-                illegal=illegal,
-                dangle_parent=dangle_parent,
-                dangles_fc_key=dangles_fc_key,
-                lines_fc_key=lines_fc_key,
-                line_like_ds_keys=set(),  # no expanded tolerance in this context
-                parent_id=parent_id,
-                cand=cand,
-                base_tol=base_tol,
-                dangle_candidate_tol=base_tol,
-                topology=topology,
-            )
-            if reason is None:
-                return cand
-        return None
-
-    def _find_best_dangle_candidate_to_parent(
-        self,
-        *,
-        candidates_sorted: list[NearCandidate],
-        dangles_fc_key: DatasetKey,
-        dangle_parent: dict[DangleOid, ParentId],
-        target_parent_id: ParentId,
-        dangle_tol: float,
-    ) -> Optional[NearCandidate]:
-        """
-        From A's candidate rows, find the closest dangle feature that belongs to target_parent_id.
-        This handles "target parent has 2 dangles" correctly by selecting the closest.
-        """
-        best: Optional[NearCandidate] = None
-        best_dist = float("inf")
-
-        for cand in candidates_sorted:
-            if cand.near_fc_key != dangles_fc_key:
-                continue
-
-            other_dangle_oid = cand.near_fid
-            other_parent = dangle_parent.get(other_dangle_oid)
-            if other_parent is None:
-                continue
-            if int(other_parent) != int(target_parent_id):
-                continue
-
-            dist = cand.near_dist
-            if dist <= float(dangle_tol) and dist < best_dist:
-                best = cand
-                best_dist = dist
-
-        return best
-
-    def _best_dangle_for_parent_towards_target_parent(
-        self,
-        *,
-        parent_id: ParentId,
-        target_parent_id: ParentId,
-        parent_to_dangles: dict[ParentId, list[DangleOid]],
-        per_dangle: dict[DangleOid, dict],
-    ) -> DangleOid | None:
-        """
-        Choose the dangle on `parent_id` that is most suitable for pairing with `target_parent_id`.
-
-        Rule:
-        - Only consider dangles whose pair_token_parent == target_parent_id
-        - Pick the one with the smallest first_legal near_dist
-        """
-        dangles = parent_to_dangles.get(int(parent_id), [])
-        if not dangles:
-            return None
-
-        best_dangle = None
-        best_dist = float("inf")
-
-        for d_oid in dangles:
-            info = per_dangle.get(int(d_oid))
-            if not info:
-                continue
-
-            if int(info.get("pair_token_parent") or -1) != int(target_parent_id):
-                continue
-
-            first_legal = info.get("first_legal")
-            if not first_legal:
-                continue
-
-            dist = float(first_legal.get("near_dist", float("inf")))
-            if dist < best_dist:
-                best_dist = dist
-                best_dangle = int(d_oid)
-
-        return best_dangle
-
-    def _find_specific_dangle_candidate(
-        self,
-        *,
-        candidates_sorted: list[NearCandidate],
-        dangles_fc_key: DatasetKey,
-        other_dangle_oid: DangleOid,
-        dangle_tol: float,
-    ) -> Optional[NearCandidate]:
-        """
-        Find candidate row that targets a specific dangle OID (within dangle_tol).
-        """
-        for cand in candidates_sorted:
-            if cand.near_fc_key != dangles_fc_key:
-                continue
-            if cand.near_fid != int(other_dangle_oid):
-                continue
-
-            dist = cand.near_dist
-            if dist <= float(dangle_tol):
-                return cand
-        return None
-
-    def _best_dangle_for_parent(
-        self,
-        *,
-        parent_id: ParentId,
-        parent_to_dangles: dict[ParentId, list[DangleOid]],
-        per_dangle: dict[DangleOid, dict],
-    ) -> DangleOid | None:
-        """
-        Choose which dangle (of possibly many on the same parent line) should represent
-        this parent for default / non-pair behavior.
-
-        Rule: choose the dangle whose first_legal candidate is closest (smallest near_dist).
-        """
-        dangles = parent_to_dangles.get(int(parent_id), [])
-        if not dangles:
-            return None
-
-        best = None
-        best_dist = float("inf")
-        for d_oid in dangles:
-            info = per_dangle.get(int(d_oid))
-            if not info:
-                continue
-            cand = info.get("first_legal")
-            if not cand:
-                continue
-            dist = float(cand.get("near_dist", float("inf")))
-            if dist < best_dist:
-                best_dist = dist
-                best = int(d_oid)
-
-        return best
-
-    def _build_component_ids(
-        self, *, adjacency: dict[int, set[int]], nodes: set[int]
-    ) -> dict[int, int]:
-        comp_id: dict[int, int] = {}
-        visited: set[int] = set()
-        cid = 0
-
-        for start in nodes | set(adjacency.keys()):
-            start = int(start)
-            if start in visited:
-                continue
-            cid += 1
-            stack = [start]
-            while stack:
-                cur = int(stack.pop())
-                if cur in visited:
-                    continue
-                visited.add(cur)
-                comp_id[cur] = cid
-                for nb in adjacency.get(cur, set()):
-                    if nb not in visited:
-                        stack.append(int(nb))
-        return comp_id
 
     def _compute_best_line_parent_by_dangle(
         self,
@@ -6104,31 +5829,6 @@ class FillLineGaps:
             edit_op=edit_op,
             meta=meta,
         )
-
-    def _apply_pair_symmetric_skip(
-        self, decided_by_parent: dict[int, PlanEntry]
-    ) -> None:
-        """
-        If A and B are marked as pair parents, move only one of them.
-        Keep the smaller parent id by default.
-        """
-        for a_parent, entry in list(decided_by_parent.items()):
-            b_parent = entry.pair_parent
-            if b_parent is None:
-                continue
-            b_parent = int(b_parent)
-
-            other = decided_by_parent.get(b_parent)
-            if other is None:
-                continue
-            if (other.pair_parent or -1) != a_parent:
-                continue
-
-            keep = min(int(a_parent), int(b_parent))
-            drop = max(int(a_parent), int(b_parent))
-
-            decided_by_parent[drop].skip = True
-            decided_by_parent[keep].skip = False
 
     # ----------------------------
     # Resnap pass

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 import math
 import os
-import time  # [DBG_LINEGAP]
 
 from typing import Optional, Callable, Iterable, Any, TypeAlias, NamedTuple
 
@@ -1012,14 +1011,11 @@ class ScopeRecord:
     Status snapshot at one pipeline scope for a candidate connection.
 
     status: the outcome at this scope (scope-specific vocabulary; see CandidateDiagnostic).
-    reason: optional detail string; None when status is self-explanatory (e.g. "scored",
-        "accepted").
     norm_z: Z value normalized within this scope's candidate comparison set; None when Z
         is inactive or the scope was not reached.
     """
 
     status: str
-    reason: Optional[str] = None
     norm_z: Optional[float] = None
 
 
@@ -2400,7 +2396,6 @@ class FillLineGaps:
         seg_cfg = self.segmentation
         even = seg_cfg.mode is logic_config.SegmentationMode.EVEN
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation lines_copy START")  # [DBG_LINEGAP]
         segment_line(
             input_fc=self.lines_copy,
             output_fc=self.lines_copy_segmented,
@@ -2411,7 +2406,6 @@ class FillLineGaps:
         self._segmented_oid_to_parent_id[
             self._dataset_key(self.lines_copy_segmented)
         ] = self._oid_to_original_id_lookup(self.lines_copy_segmented)
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation lines_copy END (rows={int(arcpy.management.GetCount(self.lines_copy_segmented)[0])})")  # [DBG_LINEGAP]
 
         for index, ext_path in enumerate(self.external_target_layers):
             if not self._is_polyline_fc(ext_path):
@@ -2421,7 +2415,6 @@ class FillLineGaps:
                 self.external_target_layers_segmented.append(ext_path)
                 continue
 
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation external[{index}] START")  # [DBG_LINEGAP]
             seg_path = self.wfm.build_file_path(
                 file_name=f"target_feature_{index}_segmented"
             )
@@ -2436,7 +2429,6 @@ class FillLineGaps:
             self._segmented_oid_to_parent_id[
                 self._dataset_key(seg_path)
             ] = self._oid_to_original_id_lookup(seg_path)
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _setup_segmentation external[{index}] END (rows={int(arcpy.management.GetCount(seg_path)[0])})")  # [DBG_LINEGAP]
 
     def _select_targets_within_tolerance_of_dangles(self) -> list[str]:
         """Return the global target layer list for connectivity-side queries.
@@ -2477,7 +2469,6 @@ class FillLineGaps:
                 # target_self_segmented is built from lines_copy_segmented at
                 # the same tolerance filter — candidates reach segments by
                 # their segmented OID, the OID lookup maps back to parent_id.
-                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} target_self_segmented build START")  # [DBG_LINEGAP]
                 if self.write_work_files_to_memory:
                     custom_arcpy.select_location_and_make_feature_layer(
                         input_layer=self.lines_copy_segmented,
@@ -2497,7 +2488,6 @@ class FillLineGaps:
                 self._segmented_oid_to_parent_id[
                     self._dataset_key(self.target_self_segmented)
                 ] = self._oid_to_original_id_lookup(self.target_self_segmented)
-                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} target_self_segmented build END (rows={int(arcpy.management.GetCount(self.target_self_segmented)[0])})")  # [DBG_LINEGAP]
 
         targets.extend(self.external_target_layers)
         return targets
@@ -2991,7 +2981,6 @@ class FillLineGaps:
         connect_tol_m = float(self.connectivity_tolerance_meters)
         connect_tol = f"{connect_tol_m} Meters"
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(connectivity) START (in_endpoints={int(arcpy.management.GetCount(self.conn_endpoints)[0])}, near_features={len(near_features)}, radius={connect_tol})")  # [DBG_LINEGAP]
         arcpy.analysis.GenerateNearTable(
             in_features=self.conn_endpoints,
             near_features=near_features,
@@ -3003,7 +2992,6 @@ class FillLineGaps:
             closest_count=self.connectivity_closest_count,
             method="PLANAR",
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(connectivity) END (conn_table_rows={int(arcpy.management.GetCount(self.conn_table)[0])})")  # [DBG_LINEGAP]
 
         lines_key = self._dataset_key(self.lines_copy)
         line_keys = self._line_dataset_keys()
@@ -4021,7 +4009,6 @@ class FillLineGaps:
 
         relevant_parent_ids = set(dangle_parent.values())
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} TopologyBuilder.build START (relevant_parents={len(relevant_parent_ids)})")  # [DBG_LINEGAP]
         topology = TopologyBuilder(
             lines_fc=self.lines_copy,
             original_id_field=self.ORIGINAL_ID,
@@ -4035,15 +4022,12 @@ class FillLineGaps:
             scope=self.connectivity_scope,
             relevant_parent_ids=relevant_parent_ids,
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} TopologyBuilder.build END")  # [DBG_LINEGAP]
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} detect_illegal_targets START")  # [DBG_LINEGAP]
         illegal = self.detect_illegal_targets(
             dangle_parent=dangle_parent,
             target_layers=target_layers,
             topology=topology,
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} detect_illegal_targets END (illegal_dangles={len(illegal)})")  # [DBG_LINEGAP]
 
         dangles_key = self._dataset_key(dangles_fc)
         lines_key = self._dataset_key(self.lines_copy)
@@ -4068,16 +4052,13 @@ class FillLineGaps:
         )
 
         # Expanded radius so we can see dangle→dangle candidates, but legality will enforce tol rules.
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(candidate) START (near_features={len(near_features)}, radius={self._expanded_dangle_tolerance_linear_unit()})")  # [DBG_LINEGAP]
         self._generate_near_table(
             in_dangles=dangles_fc,
             near_features=near_features,
             search_radius=self._expanded_dangle_tolerance_linear_unit(),
             out_table=self.near_table,
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(candidate) END (near_table_rows={int(arcpy.management.GetCount(self.near_table)[0])})")  # [DBG_LINEGAP]
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _read_near_table_grouped START")  # [DBG_LINEGAP]
         grouped = self._read_near_table_grouped(
             near_table=self.near_table,
             dangles_fc_key=dangles_key,
@@ -4086,7 +4067,6 @@ class FillLineGaps:
             lines_copy_oid_to_orig=lines_copy_oid_to_orig,
             target_self_oid_to_orig=target_self_oid_to_orig,
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _read_near_table_grouped END (dangles_with_candidates={len(grouped)})")  # [DBG_LINEGAP]
 
         if not grouped:
             return BuildPlanResult.empty(diagnostics=[])
@@ -4107,6 +4087,12 @@ class FillLineGaps:
 
         def _empty_result(state: _DiagnosticsState) -> BuildPlanResult:
             return BuildPlanResult.empty(diagnostics=_build_diagnostics(state))
+
+        # Single mutable accumulator: each scope/step writes the fields it
+        # produces, every early return passes it as-is, and the final return
+        # consumes it.  Fields default to empty collections so a return at any
+        # stage hands back exactly the diagnostics gathered so far.
+        diag_state = _DiagnosticsState()
 
         # ============================
         # CANDIDATE SCOPE
@@ -4169,7 +4155,6 @@ class FillLineGaps:
             self._build_cid_by_optional_candidate(topology=topology)
         )
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_legal_candidates START (grouped={len(grouped)})")  # [DBG_LINEGAP]
         legal_rows_by_dangle, parent_id_by_dangle, _step1a_illegal = (
             self._filter_legal_candidates(
                 grouped=grouped,
@@ -4186,7 +4171,7 @@ class FillLineGaps:
                 cid_by_optional_candidate=cid_by_optional_candidate,
             )
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_legal_candidates END (legal_dangles={len(legal_rows_by_dangle)}, illegal_rows={len(_step1a_illegal)})")  # [DBG_LINEGAP]
+        diag_state.step1a_illegal = _step1a_illegal
 
         # Eager release: the outer dict's surviving NearCandidate lists are
         # already referenced by legal_rows_by_dangle; the rest is dead weight.
@@ -4198,90 +4183,21 @@ class FillLineGaps:
         # features only processes survivors.  The trimmed connector cache built
         # by _find_crossing_conflict_keys is reused in _run_kruskal.
         # ----------------------------
-        _crossing_trim = 2.0 * float(self.connectivity_tolerance_meters)
-        _crossing_sr = (
-            arcpy.SpatialReference(self.crossing_check_spatial_reference)
-            if self.crossing_check_spatial_reference is not None
-            else None
+        trimmed_connector_cache = self._apply_candidate_crossing_filters(
+            legal_rows_by_dangle=legal_rows_by_dangle,
+            parent_id_by_dangle=parent_id_by_dangle,
+            dangle_xy=dangle_xy,
+            step1a_illegal=_step1a_illegal,
+            collect_diags=collect_diags,
         )
 
-        def _apply_crossing_filter(
-            reject_keys: set[tuple[int, str, int]], reason: str
-        ) -> None:
-            for _dangle_oid in list(legal_rows_by_dangle.keys()):
-                _parent_id = parent_id_by_dangle[_dangle_oid]
-                _remaining: list[NearCandidate] = []
-                for _cand in legal_rows_by_dangle[_dangle_oid]:
-                    _cand_key = (_dangle_oid, _cand.near_fc_key_raw, _cand.near_fid_raw)
-                    if _cand_key in reject_keys:
-                        if collect_diags:
-                            _step1a_illegal.append(
-                                _CandidateIllegalA(
-                                    _dangle_oid, _parent_id, _cand, reason
-                                )
-                            )
-                    else:
-                        _remaining.append(_cand)
-                if _remaining:
-                    legal_rows_by_dangle[_dangle_oid] = _remaining
-                else:
-                    del legal_rows_by_dangle[_dangle_oid]
-                    parent_id_by_dangle.pop(_dangle_oid, None)
-
-        if self.barrier_layers and legal_rows_by_dangle and _crossing_sr is not None:
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_barrier_crossing_keys START (legal_dangles={len(legal_rows_by_dangle)})")  # [DBG_LINEGAP]
-            _barrier_keys = self._find_barrier_crossing_keys(
-                legal_rows_by_dangle=legal_rows_by_dangle,
-                dangle_xy=dangle_xy,
-                barrier_layers=self.barrier_layers,
-                trim_distance=_crossing_trim,
-                spatial_reference=_crossing_sr,
-            )
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_barrier_crossing_keys END (rejected_keys={len(_barrier_keys)})")  # [DBG_LINEGAP]
-            if _barrier_keys:
-                _apply_crossing_filter(_barrier_keys, "crosses_barrier_layer")
-
-        trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
-        if (
-            self.reject_crossing_connectors
-            and legal_rows_by_dangle
-            and _crossing_sr is not None
-        ):
-            # self-lines (lines_copy) plus every connect_to_features layer
-            # eligible for the line-vs-line crossing pre-filter.  Polygon
-            # sources have already been converted to their boundary polyline
-            # in _build_external_target_layers_once so a single uniform path
-            # applies here.
-            _check_layers: list[str] = [
-                self.lines_copy,
-                *self.external_target_crossing_layers,
-            ]
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_crossing_conflict_keys START (legal_dangles={len(legal_rows_by_dangle)}, check_layers={len(_check_layers)})")  # [DBG_LINEGAP]
-            crossing_conflict_keys, trimmed_connector_cache = (
-                self._find_crossing_conflict_keys(
-                    legal_rows_by_dangle=legal_rows_by_dangle,
-                    dangle_xy=dangle_xy,
-                    check_feature_layers=_check_layers,
-                    trim_distance=_crossing_trim,
-                    spatial_reference=_crossing_sr,
-                )
-            )
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _find_crossing_conflict_keys END (rejected_keys={len(crossing_conflict_keys)}, trimmed_cache={len(trimmed_connector_cache)})")  # [DBG_LINEGAP]
-            if crossing_conflict_keys:
-                _apply_crossing_filter(
-                    crossing_conflict_keys, "crosses_existing_feature"
-                )
-
         if not legal_rows_by_dangle:
-            return _empty_result(
-                _DiagnosticsState(step1a_illegal=_step1a_illegal),
-            )
+            return _empty_result(diag_state)
 
         # ----------------------------
         # Step 4 - Best line parent per dangle (angle-aware)
         # Used by edge-case bonus detection in the scoring step.
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _compute_best_line_parent_by_dangle START (legal_dangles={len(legal_rows_by_dangle)})")  # [DBG_LINEGAP]
         best_line_parent_by_dangle = self._compute_best_line_parent_by_dangle(
             legal_rows_by_dangle=legal_rows_by_dangle,
             parent_id_by_dangle=parent_id_by_dangle,
@@ -4294,12 +4210,10 @@ class FillLineGaps:
             polyline_by_segment=polyline_by_segment,
             is_external_line_like=is_external_line_like,
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _compute_best_line_parent_by_dangle END (best_line_parents={len(best_line_parent_by_dangle)})")  # [DBG_LINEGAP]
 
         # ----------------------------
         # Step 5 - Angle-aware selection: one proposal per dangle
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_dangle_proposals START (legal_dangles={len(legal_rows_by_dangle)})")  # [DBG_LINEGAP]
         _dangle_proposals, dangle_norm_z_by_dangle, _step1b_illegal, _step1b_scored = (
             self._select_dangle_proposals(
                 legal_rows_by_dangle=legal_rows_by_dangle,
@@ -4321,17 +4235,12 @@ class FillLineGaps:
                 dist_to_parent_line_by_dangle=dist_to_parent_line_by_dangle,
             )
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_dangle_proposals END (proposals={len(_dangle_proposals)}, illegal_b={len(_step1b_illegal)}, scored_b={len(_step1b_scored)})")  # [DBG_LINEGAP]
+        diag_state.step1b_illegal = _step1b_illegal
+        diag_state.step1b_scored = _step1b_scored
+        diag_state.dangle_norm_z_by_dangle = dangle_norm_z_by_dangle
 
         if not _dangle_proposals:
-            return _empty_result(
-                _DiagnosticsState(
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                ),
-            )
+            return _empty_result(diag_state)
 
         # ============================
         # NETWORK SCOPE
@@ -4345,14 +4254,7 @@ class FillLineGaps:
         # ----------------------------
         active: list[_DangleProposal] = list(_dangle_proposals.values())
         if not active:
-            return _empty_result(
-                _DiagnosticsState(
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                ),
-            )
+            return _empty_result(diag_state)
         active_by_dangle = {int(p.ctx.dangle_oid): p for p in active}
 
         dangle_mutual_oids: set[int] = set()
@@ -4373,23 +4275,21 @@ class FillLineGaps:
         # ----------------------------
         # Step 2 - Connection normalization: re-normalize Z within each undirected A<->B connection group
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_normalization START (dangle_proposals={len(_dangle_proposals)})")  # [DBG_LINEGAP]
         connection_proposals_by_dangle, connection_norm_z_by_dangle = (
             self._run_connection_normalization(_dangle_proposals)
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_normalization END (proposals={len(connection_proposals_by_dangle)})")  # [DBG_LINEGAP]
+        diag_state.connection_norm_z_by_dangle = connection_norm_z_by_dangle
 
         # ----------------------------
         # Step 3 - Connection selection: one winner per undirected connection
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_selection START")  # [DBG_LINEGAP]
         _connection_proposals, connection_loser_oids = self._run_connection_selection(
             connection_proposals_by_dangle=connection_proposals_by_dangle,
             directed_edges=directed_network_edges,
             dangle_mutual_oids=dangle_mutual_oids,
             collect_diags=collect_diags,
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_connection_selection END (winners={len(_connection_proposals)}, losers={len(connection_loser_oids)})")  # [DBG_LINEGAP]
+        diag_state.connection_loser_oids = connection_loser_oids
 
         # ============================
         # KRUSKAL SCOPE
@@ -4399,16 +4299,14 @@ class FillLineGaps:
         # ----------------------------
         # Step 1 - Global normalization: re-normalize Z across all connection winners
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_global_normalization START (connection_proposals={len(_connection_proposals)})")  # [DBG_LINEGAP]
         _global_winners, global_norm_z_by_dangle = self._run_global_normalization(
             _connection_proposals
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_global_normalization END (global_winners={len(_global_winners)})")  # [DBG_LINEGAP]
+        diag_state.global_norm_z_by_dangle = global_norm_z_by_dangle
 
         # ----------------------------
         # Step 2 - Kruskal cycle prevention across accepted connections
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_kruskal START")  # [DBG_LINEGAP]
         (
             _global_proposals,
             accepted_dangle_oids,
@@ -4428,7 +4326,10 @@ class FillLineGaps:
                 else None
             ),
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _run_kruskal END (accepted={len(accepted_dangle_oids)}, kruskal_rejected={len(kruskal_rejected_oids)}, crossing_rejected={len(kruskal_crossing_rejected_oids)})")  # [DBG_LINEGAP]
+        diag_state.kruskal_rejected_oids = kruskal_rejected_oids
+        diag_state.kruskal_crossing_rejected_oids = kruskal_crossing_rejected_oids
+        diag_state.accepted_dangle_oids = accepted_dangle_oids
+        diag_state.gap_source_by_dangle = gap_source_by_dangle
 
         # Eager release: trimmed_connector_cache is consumed by _run_kruskal
         # and not referenced by resnap or output phases; release the Polyline
@@ -4436,21 +4337,7 @@ class FillLineGaps:
         trimmed_connector_cache.clear()
 
         if not _global_proposals:
-            return _empty_result(
-                _DiagnosticsState(
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    connection_loser_oids=connection_loser_oids,
-                    kruskal_rejected_oids=kruskal_rejected_oids,
-                    kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
-                    accepted_dangle_oids=accepted_dangle_oids,
-                    gap_source_by_dangle=gap_source_by_dangle,
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                    connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-                    global_norm_z_by_dangle=global_norm_z_by_dangle,
-                ),
-            )
+            return _empty_result(diag_state)
 
         # ============================
         # DEFERRED SCOPE
@@ -4460,38 +4347,114 @@ class FillLineGaps:
         # ----------------------------
         # Step 1 - Resnap candidate identification
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _identify_resnap_captures START (global_proposals={len(_global_proposals)})")  # [DBG_LINEGAP]
         resnap_captures = self._identify_resnap_captures(_global_proposals)
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _identify_resnap_captures END (resnap_captures={len(resnap_captures)})")  # [DBG_LINEGAP]
 
         # ----------------------------
         # Step 2 - Plan entry assembly: parent_id -> list[plan_entry]
         # ----------------------------
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _assemble_plan_entries START")  # [DBG_LINEGAP]
         plan_by_parent = self._assemble_plan_entries(_global_proposals)
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _assemble_plan_entries END (plan_parents={len(plan_by_parent)})")  # [DBG_LINEGAP]
 
         return BuildPlanResult(
             plan_by_parent=plan_by_parent,
             resnap_captures=resnap_captures,
-            diagnostics=_build_diagnostics(
-                _DiagnosticsState(
-                    step1a_illegal=_step1a_illegal,
-                    step1b_illegal=_step1b_illegal,
-                    step1b_scored=_step1b_scored,
-                    connection_loser_oids=connection_loser_oids,
-                    kruskal_rejected_oids=kruskal_rejected_oids,
-                    kruskal_crossing_rejected_oids=kruskal_crossing_rejected_oids,
-                    accepted_dangle_oids=accepted_dangle_oids,
-                    gap_source_by_dangle=gap_source_by_dangle,
-                    dangle_norm_z_by_dangle=dangle_norm_z_by_dangle,
-                    connection_norm_z_by_dangle=connection_norm_z_by_dangle,
-                    global_norm_z_by_dangle=global_norm_z_by_dangle,
-                ),
-            ),
+            diagnostics=_build_diagnostics(diag_state),
             accepted_connector_raw=accepted_connector_raw,
             kruskal_rank_by_dangle_oid=kruskal_rank_by_dangle_oid,
         )
+
+    def _apply_candidate_crossing_filters(
+        self,
+        *,
+        legal_rows_by_dangle: dict[DangleOid, list[NearCandidate]],
+        parent_id_by_dangle: dict[DangleOid, ParentId],
+        dangle_xy: dict[DangleOid, tuple[float, float]],
+        step1a_illegal: list[_CandidateIllegalA],
+        collect_diags: bool,
+    ) -> dict[tuple[int, str, int], Any]:
+        """Apply the candidate-scope crossing pre-filters in place.
+
+        Runs the barrier-layer crossing check first so the subsequent
+        existing-feature crossing check only processes survivors.  Both
+        mutate ``legal_rows_by_dangle`` and ``parent_id_by_dangle`` in
+        place: rejected candidates are removed from the legal set and
+        appended to ``step1a_illegal`` (when ``collect_diags`` is set),
+        and dangles whose entire legal set is rejected are dropped from
+        both lookups.
+
+        Returns the trimmed-connector polyline cache built by
+        ``_find_crossing_conflict_keys``, reused by ``_run_kruskal`` for
+        accepted-connector crossing checks.  Returns an empty dict when
+        the connector check is disabled or skipped.
+        """
+        crossing_trim = 2.0 * float(self.connectivity_tolerance_meters)
+        crossing_sr = (
+            arcpy.SpatialReference(self.crossing_check_spatial_reference)
+            if self.crossing_check_spatial_reference is not None
+            else None
+        )
+
+        def _apply_filter(
+            reject_keys: set[tuple[int, str, int]], reason: str
+        ) -> None:
+            for _dangle_oid in list(legal_rows_by_dangle.keys()):
+                _parent_id = parent_id_by_dangle[_dangle_oid]
+                _remaining: list[NearCandidate] = []
+                for _cand in legal_rows_by_dangle[_dangle_oid]:
+                    _cand_key = (_dangle_oid, _cand.near_fc_key_raw, _cand.near_fid_raw)
+                    if _cand_key in reject_keys:
+                        if collect_diags:
+                            step1a_illegal.append(
+                                _CandidateIllegalA(
+                                    _dangle_oid, _parent_id, _cand, reason
+                                )
+                            )
+                    else:
+                        _remaining.append(_cand)
+                if _remaining:
+                    legal_rows_by_dangle[_dangle_oid] = _remaining
+                else:
+                    del legal_rows_by_dangle[_dangle_oid]
+                    parent_id_by_dangle.pop(_dangle_oid, None)
+
+        if self.barrier_layers and legal_rows_by_dangle and crossing_sr is not None:
+            barrier_keys = self._find_barrier_crossing_keys(
+                legal_rows_by_dangle=legal_rows_by_dangle,
+                dangle_xy=dangle_xy,
+                barrier_layers=self.barrier_layers,
+                trim_distance=crossing_trim,
+                spatial_reference=crossing_sr,
+            )
+            if barrier_keys:
+                _apply_filter(barrier_keys, "crosses_barrier_layer")
+
+        trimmed_connector_cache: dict[tuple[int, str, int], Any] = {}
+        if (
+            self.reject_crossing_connectors
+            and legal_rows_by_dangle
+            and crossing_sr is not None
+        ):
+            # self-lines (lines_copy) plus every connect_to_features layer
+            # eligible for the line-vs-line crossing pre-filter.  Polygon
+            # sources have already been converted to their boundary polyline
+            # in _build_external_target_layers_once so a single uniform path
+            # applies here.
+            check_layers: list[str] = [
+                self.lines_copy,
+                *self.external_target_crossing_layers,
+            ]
+            crossing_conflict_keys, trimmed_connector_cache = (
+                self._find_crossing_conflict_keys(
+                    legal_rows_by_dangle=legal_rows_by_dangle,
+                    dangle_xy=dangle_xy,
+                    check_feature_layers=check_layers,
+                    trim_distance=crossing_trim,
+                    spatial_reference=crossing_sr,
+                )
+            )
+            if crossing_conflict_keys:
+                _apply_filter(crossing_conflict_keys, "crosses_existing_feature")
+
+        return trimmed_connector_cache
 
     def _filter_legal_candidates(
         self,
@@ -5941,7 +5904,6 @@ class FillLineGaps:
             2 * self.connectivity_tolerance_meters + self.gap_tolerance_meters
         )
         resnap_table = self.wfm.build_file_path(file_name="resnap_near_table")
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(resnap) START (dangles={len(dangle_oids)}, target_parents={len(forced_parents_filtered)}, radius={search_radius} Meters)")  # [DBG_LINEGAP]
         arcpy.analysis.GenerateNearTable(
             in_features=resnap_dangles_lyr,
             near_features=[resnap_lines_lyr],
@@ -5953,7 +5915,6 @@ class FillLineGaps:
             closest_count=self.candidate_closest_count,
             method="PLANAR",
         )
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} GenerateNearTable(resnap) END (resnap_table_rows={int(arcpy.management.GetCount(resnap_table)[0])})")  # [DBG_LINEGAP]
 
         best_xy: dict[tuple[int, int], tuple[float, float, float]] = {}
         fields = [
@@ -6113,18 +6074,13 @@ class FillLineGaps:
             "src_target_diff",
             "connector_transition_diff",
             "candidate_scope_status",
-            "candidate_scope_reason",
             "candidate_scope_norm_z",
             "network_scope_status",
-            "network_scope_reason",
             "network_scope_norm_z",
             "kruskal_scope_status",
-            "kruskal_scope_reason",
             "kruskal_scope_norm_z",
             "deferred_scope_status",
-            "deferred_scope_reason",
             "final_status",
-            "final_status_reason",
             "final_gap_source",
             "start_z",
             "end_z",
@@ -6156,18 +6112,13 @@ class FillLineGaps:
             a.src_target_diff if a is not None else None,
             a.connector_transition_diff if a is not None else None,
             d.candidate_scope.status,
-            d.candidate_scope.reason,
             d.candidate_scope.norm_z,
             net.status if net is not None else None,
-            net.reason if net is not None else None,
             net.norm_z if net is not None else None,
             kru.status if kru is not None else None,
-            kru.reason if kru is not None else None,
             kru.norm_z if kru is not None else None,
             def_.status if def_ is not None else None,
-            def_.reason if def_ is not None else None,
             d.final_status.status,
-            d.final_status.reason,
             d.final_gap_source,
             d.start_z,
             d.end_z,
@@ -6207,18 +6158,13 @@ class FillLineGaps:
             ("src_target_diff", _dbl),
             ("connector_transition_diff", _dbl),
             ("candidate_scope_status", _text50),
-            ("candidate_scope_reason", _text50),
             ("candidate_scope_norm_z", _dbl),
             ("network_scope_status", _text50),
-            ("network_scope_reason", _text50),
             ("network_scope_norm_z", _dbl),
             ("kruskal_scope_status", _text50),
-            ("kruskal_scope_reason", _text50),
             ("kruskal_scope_norm_z", _dbl),
             ("deferred_scope_status", _text50),
-            ("deferred_scope_reason", _text50),
             ("final_status", _text50),
-            ("final_status_reason", _text50),
             ("final_gap_source", {"field_type": "TEXT", "field_length": 20}),
             ("start_z", _dbl),
             ("end_z", _dbl),
@@ -6550,35 +6496,24 @@ class FillLineGaps:
             geometry and is exact.
         """
         environment_setup.main()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} run START")  # [DBG_LINEGAP]
 
         self.work_file_list = self.wfm.setup_work_file_paths(
             instance=self,
             file_structure=self.work_file_list,
         )
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _copy_input_lines START")  # [DBG_LINEGAP]
         self._copy_input_lines()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _copy_input_lines END (lines_copy_rows={int(arcpy.management.GetCount(self.lines_copy)[0])})")  # [DBG_LINEGAP]
         self._build_raster_handles()
         self._add_original_id_field()
         self._ensure_gap_generated_field()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _create_dangles START")  # [DBG_LINEGAP]
         self._create_dangles()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _create_dangles END (dangles_rows={int(arcpy.management.GetCount(self.dangles)[0])})")  # [DBG_LINEGAP]
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_external_target_layers_once START")  # [DBG_LINEGAP]
         self._build_external_target_layers_once()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_external_target_layers_once END")  # [DBG_LINEGAP]
         self._setup_segmentation()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_targets_within_tolerance_of_dangles START")  # [DBG_LINEGAP]
         targets = self._select_targets_within_tolerance_of_dangles()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _select_targets_within_tolerance_of_dangles END (target_layers={len(targets)})")  # [DBG_LINEGAP]
 
         # Keep only dangles that have any candidate within base tolerance
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_true_dangles START")  # [DBG_LINEGAP]
         self._filter_true_dangles()
         dangles_for_plan = self.filtered_dangles
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _filter_true_dangles END (filtered_dangles_rows={int(arcpy.management.GetCount(dangles_for_plan)[0])})")  # [DBG_LINEGAP]
 
         if self.line_changes_output is not None and self.write_output_metadata:
             file_utilities.delete_feature(input_feature=self.line_changes_output)
@@ -6588,14 +6523,12 @@ class FillLineGaps:
             assert self.candidate_connections_output is not None
             self._setup_candidate_connections_output(self.candidate_connections_output)
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_plan START")  # [DBG_LINEGAP]
         result = self._build_plan(dangles_fc=dangles_for_plan, target_layers=targets)
         plan = result.plan_by_parent
         resnap_captures = result.resnap_captures
         diagnostics = result.diagnostics
         accepted_connector_raw = result.accepted_connector_raw
         kruskal_rank_by_dangle_oid = result.kruskal_rank_by_dangle_oid
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _build_plan END (plan_parents={len(plan)}, resnap_captures={len(resnap_captures)}, diagnostics={len(diagnostics)})")  # [DBG_LINEGAP]
 
         # Capture snap-source dangle endpoints before _apply_plan moves them.
         snap_source_dangle_xy: dict[ParentId, tuple[float, float]] = {
@@ -6605,25 +6538,20 @@ class FillLineGaps:
             if info.edit_op is EditOp.SNAP
         }
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan START (plan_parents={len(plan)})")  # [DBG_LINEGAP]
         self._apply_plan(plan)
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan END")  # [DBG_LINEGAP]
 
         if resnap_captures:
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _resnap_connections START (captures={len(resnap_captures)})")  # [DBG_LINEGAP]
             resnap_plan = self._resnap_connections(
                 captures=resnap_captures,
                 dangles_fc=dangles_for_plan,
                 snap_source_dangle_xy=snap_source_dangle_xy,
             )
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _resnap_connections END (resnap_plan={len(resnap_plan)})")  # [DBG_LINEGAP]
 
             if (
                 self.reject_crossing_connectors
                 and resnap_plan
                 and accepted_connector_raw
             ):
-                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _recheck_resnap_crossings START (resnap_plan={len(resnap_plan)})")  # [DBG_LINEGAP]
                 (
                     resnap_plan,
                     resnap_crossing_rejected_oids,
@@ -6638,15 +6566,12 @@ class FillLineGaps:
                         self.crossing_check_spatial_reference
                     ),
                 )
-                print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _recheck_resnap_crossings END (resnap_plan={len(resnap_plan)}, rejected={len(resnap_crossing_rejected_oids)})")  # [DBG_LINEGAP]
             else:
                 resnap_crossing_rejected_oids: set[DangleOid] = set()
                 resnap_crossing_displaced_oids: set[DangleOid] = set()
                 resnap_crossing_winner_oids: set[DangleOid] = set()
 
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan(resnap) START (entries={len(resnap_plan)})")  # [DBG_LINEGAP]
             self._apply_plan({pid: [entry] for pid, entry in resnap_plan.items()})
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _apply_plan(resnap) END")  # [DBG_LINEGAP]
 
             self._update_deferred_diagnostics(
                 diagnostics=diagnostics,
@@ -6658,17 +6583,13 @@ class FillLineGaps:
 
         if self._collect_diags and diagnostics:
             assert self.candidate_connections_output is not None
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _write_candidate_connections_output START (diagnostics={len(diagnostics)})")  # [DBG_LINEGAP]
             spatial_reference = arcpy.Describe(self.lines_copy).spatialReference
             self._write_candidate_connections_output(
                 fc_path=self.candidate_connections_output,
                 diagnostics=diagnostics,
                 spatial_reference=spatial_reference,
             )
-            print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _write_candidate_connections_output END")  # [DBG_LINEGAP]
 
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} _write_output START")  # [DBG_LINEGAP]
         self._write_output()
-        print(f"[DBG_LINEGAP] {time.strftime('%H:%M:%S')} run END")  # [DBG_LINEGAP]
 
         self.wfm.delete_created_files()

--- a/custom_tools/general_tools/line_topology.py
+++ b/custom_tools/general_tools/line_topology.py
@@ -1947,6 +1947,23 @@ class FillLineGaps:
             expression_type="PYTHON3",
         )
 
+    def _ensure_original_id_field(self, fc_path: str) -> None:
+        """Ensure ``ORIGINAL_ID`` (LONG) exists on ``fc_path`` and equals the OID.
+
+        Idempotent: ``AddField`` is skipped when the column already exists;
+        ``CalculateField`` re-assigns regardless (cheap, deterministic).
+        """
+        existing = {f.name for f in arcpy.ListFields(fc_path)}
+        if self.ORIGINAL_ID not in existing:
+            arcpy.management.AddField(fc_path, self.ORIGINAL_ID, "LONG")
+        oid_field = arcpy.Describe(fc_path).OIDFieldName
+        arcpy.management.CalculateField(
+            fc_path,
+            self.ORIGINAL_ID,
+            expression=f"!{oid_field}!",
+            expression_type="PYTHON3",
+        )
+
     def _ensure_gap_generated_field(self) -> None:
         """Idempotently provision ``FIELD_GAP_GENERATED`` on ``lines_copy``.
 
@@ -2253,60 +2270,10 @@ class FillLineGaps:
         for index, feature_path in enumerate(self.connect_to_features):
             output_name = self.wfm.build_file_path(file_name=f"target_feature_{index}")
 
-            # Polygon connect_to_features get a one-shot PolygonToLine on the
-            # source FC.  Running before the tolerance filter is mandatory:
-            # LEFT_FID / RIGHT_FID in the polyline output reference the source
-            # polygon FC's OIDs, which is the same space TopologyBuilder uses
-            # for connectivity_id_by_optional.  Filtering the polygon first
-            # would re-key those FIDs to a staged copy and break the anchor.
-            #
-            # Default flags on PolygonToLine — the neighbor option varies by
-            # ArcGIS version, so the mapping reads both LEFT_FID and RIGHT_FID
-            # and skips -1, which is correct under either neighbor mode.
             if self._is_polygon_fc(feature_path):
-                polyline_work_path = self.wfm.build_file_path(
-                    file_name=f"target_feature_{index}_polylines"
+                staging_input = self._stage_polygon_target_as_polyline(
+                    feature_path, index
                 )
-                arcpy.management.PolygonToLine(
-                    in_features=feature_path,
-                    out_feature_class=polyline_work_path,
-                )
-
-                poly_to_lines: dict[int, set[int]] = {}
-                polyline_oid_field = arcpy.Describe(polyline_work_path).OIDFieldName
-                with arcpy.da.SearchCursor(
-                    polyline_work_path,
-                    [polyline_oid_field, "LEFT_FID", "RIGHT_FID"],
-                ) as cur:
-                    for line_oid, left, right in cur:
-                        for poly_oid in (left, right):
-                            if poly_oid is None or int(poly_oid) < 0:
-                                continue
-                            poly_to_lines.setdefault(int(poly_oid), set()).add(
-                                int(line_oid)
-                            )
-                self._polygon_to_polyline_oid[self._dataset_key(feature_path)] = (
-                    poly_to_lines
-                )
-
-                # Stamp ORIGINAL_ID on the polyline work FC so the value
-                # carries through the tolerance-filter copy below and (when
-                # segmentation is enabled) into each segment.  Under the
-                # polygon path ORIGINAL_ID is therefore the polyline_work_path
-                # OID — the same space _polygon_to_polyline_oid maps into.
-                existing = {f.name for f in arcpy.ListFields(polyline_work_path)}
-                if self.ORIGINAL_ID not in existing:
-                    arcpy.management.AddField(
-                        polyline_work_path, self.ORIGINAL_ID, "LONG"
-                    )
-                arcpy.management.CalculateField(
-                    polyline_work_path,
-                    self.ORIGINAL_ID,
-                    expression=f"!{polyline_oid_field}!",
-                    expression_type="PYTHON3",
-                )
-
-                staging_input = polyline_work_path
                 already_stamped = True
             else:
                 staging_input = feature_path
@@ -2345,16 +2312,7 @@ class FillLineGaps:
                 # (on the polyline work FC) and the value is preserved by the
                 # tolerance-filter copy, so we only stamp here for non-polygon
                 # sources.
-                existing = {f.name for f in arcpy.ListFields(output_name)}
-                if self.ORIGINAL_ID not in existing:
-                    arcpy.management.AddField(output_name, self.ORIGINAL_ID, "LONG")
-                oid_field = arcpy.Describe(output_name).OIDFieldName
-                arcpy.management.CalculateField(
-                    output_name,
-                    self.ORIGINAL_ID,
-                    expression=f"!{oid_field}!",
-                    expression_type="PYTHON3",
-                )
+                self._ensure_original_id_field(output_name)
 
             self.external_target_layers.append(output_name)
 
@@ -2381,6 +2339,59 @@ class FillLineGaps:
                 mode = logic_config.AngleTargetMode(raw_mode)
 
             self._angle_mode_by_external_ds_key[str(out_key)] = mode
+
+    def _stage_polygon_target_as_polyline(
+        self, feature_path: str, index: int
+    ) -> str:
+        """Convert a polygon ``connect_to_features`` entry to a polyline work FC.
+
+        Runs ``PolygonToLine`` on the *source* polygon FC (not a
+        tolerance-filtered copy): ``LEFT_FID`` / ``RIGHT_FID`` in the
+        polyline output reference the source polygon FC's OIDs, which is
+        the same space ``TopologyBuilder`` uses for
+        ``connectivity_id_by_optional``.  Filtering the polygon first
+        would re-key those FIDs to a staged copy and break the anchor.
+
+        Records the source-polygon-OID → polyline-OID map into
+        ``self._polygon_to_polyline_oid`` so ``_build_plan`` can lift
+        topology cids into candidate-space, then stamps ``ORIGINAL_ID``
+        on the polyline work FC so the value carries through the
+        tolerance-filter copy and (when segmentation is enabled) into
+        each segment.
+
+        Returns the polyline work FC path, which the caller passes to
+        the tolerance filter as ``staging_input``.
+        """
+        polyline_work_path = self.wfm.build_file_path(
+            file_name=f"target_feature_{index}_polylines"
+        )
+        # Default flags on PolygonToLine — the neighbor option varies by
+        # ArcGIS version, so the mapping reads both LEFT_FID and RIGHT_FID
+        # and skips -1, which is correct under either neighbor mode.
+        arcpy.management.PolygonToLine(
+            in_features=feature_path,
+            out_feature_class=polyline_work_path,
+        )
+
+        poly_to_lines: dict[int, set[int]] = {}
+        polyline_oid_field = arcpy.Describe(polyline_work_path).OIDFieldName
+        with arcpy.da.SearchCursor(
+            polyline_work_path,
+            [polyline_oid_field, "LEFT_FID", "RIGHT_FID"],
+        ) as cur:
+            for line_oid, left, right in cur:
+                for poly_oid in (left, right):
+                    if poly_oid is None or int(poly_oid) < 0:
+                        continue
+                    poly_to_lines.setdefault(int(poly_oid), set()).add(
+                        int(line_oid)
+                    )
+        self._polygon_to_polyline_oid[self._dataset_key(feature_path)] = (
+            poly_to_lines
+        )
+
+        self._ensure_original_id_field(polyline_work_path)
+        return polyline_work_path
 
     def _setup_segmentation(self) -> None:
         """Build internal segmented twins of ``lines_copy`` and line-like

--- a/env_setup/environment_setup.py
+++ b/env_setup/environment_setup.py
@@ -90,6 +90,8 @@ class ArcGisEnvironmentSetup:
     """
 
     _setup_done_globally = False
+    XY_TOLERANCE = 0.02
+    XY_RESOLUTION = 0.01
 
     def __init__(
         self,
@@ -108,8 +110,8 @@ class ArcGisEnvironmentSetup:
         arcpy.env.outputCoordinateSystem = arcpy.SpatialReference(
             self.spatial_reference
         )
-        arcpy.env.XYTolerance = "0.02 Meters"
-        arcpy.env.XYResolution = "0.01 Meters"
+        arcpy.env.XYTolerance = f"{self.XY_TOLERANCE} Meters"
+        arcpy.env.XYResolution = f"{self.XY_RESOLUTION} Meters"
         arcpy.env.parallelProcessingFactor = config.cpu_percentage
 
         ArcGisEnvironmentSetup._setup_done_globally = True

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -133,6 +133,13 @@ class River_N100(Enum):
         description="river_angles",
     )
 
+    river_topology___fixed_river_orientation___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="fixed_river_orientation",
+        )
+    )
+
     river_topology___river_angles_2___n100_river = file_manager.generate_file_name_gdb(
         script_source_name=river_topology,
         description="river_angles_2",

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -14,6 +14,9 @@ file_manager = BaseFileManager(scale=scale, object_name=object_name)
 
 # All file and function names in correct order
 
+data_selection = "data_selection"
+data_preparation = "data_preparation"
+river_topology = "river_topology"
 selecting_water_polygons = "selecting_water_polygons"
 unconnected_river_geometry = "unconnected_river_geometry"
 extending_river_geometry = "extending_river_geometry"
@@ -62,6 +65,59 @@ class River_N100(Enum):
     ###########################################
     ########### RIVER DATA PREPARATION ##########
     ###########################################
+
+    data_selection___water_lines___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=data_selection,
+        description="water_lines",
+    )
+
+    data_selection___water_polygons___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=data_selection,
+        description="water_polygons",
+    )
+
+    data_selection___water_points___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=data_selection,
+        description="water_points",
+    )
+
+    data_preparation___geometry_validation___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="geometry_validation",
+        )
+    )
+
+    data_preparation___river_lines___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=data_preparation,
+        description="river_lines",
+    )
+
+    data_preparation___river_polygons___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="river_polygons",
+        )
+    )
+
+    data_preparation___river_polygon_outline___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="river_polygon_outline",
+        )
+    )
+
+    river_topology___fixed_river_gaps___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="fixed_river_gaps",
+        )
+    )
+
+    river_topology___root___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=river_topology,
+        description="root",
+    )
 
     selecting_water_polygons__centerline__n100 = file_manager.generate_file_name_gdb(
         script_source_name=selecting_water_polygons,

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -121,6 +121,16 @@ class River_N100(Enum):
         )
     )
 
+    river_topology___river_angles___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=river_topology,
+        description="river_angles",
+    )
+
+    river_topology___river_angles_2___n100_river = file_manager.generate_file_name_gdb(
+        script_source_name=river_topology,
+        description="river_angles_2",
+    )
+
     river_topology___root___n100_river = file_manager.generate_file_name_gdb(
         script_source_name=river_topology,
         description="root",

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -131,6 +131,12 @@ class River_N100(Enum):
         description="river_angles_2",
     )
 
+    river_topology___river_xy_endpoints___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="river_xy_endpoints",
+        )
+    )
     river_topology___root___n100_river = file_manager.generate_file_name_gdb(
         script_source_name=river_topology,
         description="root",

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -156,6 +156,27 @@ class River_N100(Enum):
         description="root",
     )
 
+    river_topology___river_polygons_as_lines___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="river_polygons_as_lines",
+        )
+    )
+
+    river_topology___segmented_river_lines___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="segmented_river_lines",
+        )
+    )
+
+    river_topology___segmented_river_polygon_lines___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="segmented_river_polygon_lines",
+        )
+    )
+
     selecting_water_polygons__centerline__n100 = file_manager.generate_file_name_gdb(
         script_source_name=selecting_water_polygons,
         description="centerline",

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -121,6 +121,13 @@ class River_N100(Enum):
         )
     )
 
+    river_topology___river_gaps_diagnostic___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="river_gaps_diagnostic",
+        )
+    )
+
     river_topology___river_angles___n100_river = file_manager.generate_file_name_gdb(
         script_source_name=river_topology,
         description="river_angles",

--- a/file_manager/n100/file_manager_rivers.py
+++ b/file_manager/n100/file_manager_rivers.py
@@ -114,6 +114,13 @@ class River_N100(Enum):
         )
     )
 
+    river_topology___river_gaps_changes___n100_river = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=river_topology,
+            description="river_gaps_changes",
+        )
+    )
+
     river_topology___root___n100_river = file_manager.generate_file_name_gdb(
         script_source_name=river_topology,
         description="root",

--- a/file_manager/n100/file_manager_roads.py
+++ b/file_manager/n100/file_manager_roads.py
@@ -142,6 +142,51 @@ class Road_N100(Enum):
         description="car_raod",
     )
 
+    data_preparation___nvdb_selection___n100_road = file_manager.generate_file_name_gdb(
+        script_source_name=data_preparation,
+        description="nvdb_selection",
+    )
+
+    data_preparation___tractor_selection___n100_road = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="tractor_selection",
+        )
+    )
+
+    data_preparation___road_gap_changes___n100_road = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="road_gap_changes",
+        )
+    )
+
+    data_preparation___road_gap_diagnostics___n100_road = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="road_gap_diagnostics",
+        )
+    )
+
+    data_preparation___road_gap_root___n100_road = file_manager.generate_file_name_gdb(
+        script_source_name=data_preparation,
+        description="road_gap_root",
+    )
+
+    data_preparation___fixed_road_gaps___n100_road = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="fixed_road_gaps",
+        )
+    )
+
+    data_preparation___integrated_nvdb_traktor_sti___n100_road = (
+        file_manager.generate_file_name_gdb(
+            script_source_name=data_preparation,
+            description="integrated_nvdb_traktor_sti",
+        )
+    )
+
     data_preparation___road_dangle___n100_road = file_manager.generate_file_name_gdb(
         script_source_name=data_preparation,
         description="road_dangle",

--- a/generalization/n100/river/data_preparation.py
+++ b/generalization/n100/river/data_preparation.py
@@ -1,0 +1,90 @@
+# Importing packages
+import arcpy
+
+from file_manager.n100 import file_manager_rivers
+from input_data import input_n100, input_other
+from input_data import input_fkb
+
+from composition_configs import core_config, logic_config, type_defs
+
+# Importing custom modules
+from file_manager.n100.file_manager_rivers import River_N100
+from env_setup import environment_setup
+import config
+from custom_tools.decorators.timing_decorator import timing_decorator
+from custom_tools.general_tools.partition_iterator import PartitionIterator
+from custom_tools.general_tools.study_area_selector import StudyAreaSelector
+from custom_tools.general_tools.geometry_tools import GeometryValidator
+from custom_tools.general_tools import custom_arcpy
+from custom_tools.general_tools import file_utilities
+
+
+MERGE_DIVIDED_ROADS_ALTERATIVE = False
+
+AREA_SELECTOR = "vassOmrNr IN ('016')"
+SCALE = "n100"
+
+
+@timing_decorator
+def main():
+    environment_setup.main()
+    arcpy.env.referenceScale = 100000
+    data_selection_and_validation(AREA_SELECTOR)
+    filter_river_water_features()
+
+
+@timing_decorator
+def data_selection_and_validation(area_selection: str):
+    """
+    "vassOmrNr IN ('016')"
+    """
+
+    selector = StudyAreaSelector(
+        input_output_file_dict={
+            input_fkb.VannLinje: River_N100.data_selection___water_lines___n100_river.value,
+            input_fkb.VannFlate: River_N100.data_selection___water_polygons___n100_river.value,
+            input_fkb.VannPunkt: River_N100.data_selection___water_points___n100_river.value,
+        },
+        selecting_file=input_other.RiverBasins,
+        selecting_sql_expression=area_selection,
+        select_local=config.select_study_area,
+    )
+
+    selector.run()
+
+    # input_features_validation = {
+    #     "water_lines": River_N100.data_selection___water_lines___n100_river.value,
+    #     "water_polygons": River_N100.data_selection___water_polygons___n100_river.value,
+    #     "water_points": River_N100.data_selection___water_points___n100_river.value,
+    # }
+    # road_data_validation = GeometryValidator(
+    #     input_features=input_features_validation,
+    #     output_table_path=River_N100.data_preparation___geometry_validation___n100_river.value,
+    # )
+    # road_data_validation.check_repair_sequence()
+
+
+@timing_decorator
+def filter_river_water_features():
+    # Can consider adding 'VeggrøftÅpen' to river line sellection. Byt really questionable.
+    custom_arcpy.select_attribute_and_make_permanent_feature(
+        input_layer=River_N100.data_selection___water_lines___n100_river.value,
+        expression="objtype IN ('ElvBekk', 'KanalGrøft', 'Kanalkant')",
+        output_name=River_N100.data_preparation___river_lines___n100_river.value,
+    )
+
+    custom_arcpy.select_attribute_and_make_permanent_feature(
+        input_layer=River_N100.data_selection___water_lines___n100_river.value,
+        expression="objtype IN ('Elvekant', 'Innsjøkant', 'Kanalkant')",
+        output_name=River_N100.data_preparation___river_polygon_outline___n100_river.value,
+    )
+
+    custom_arcpy.select_attribute_and_make_permanent_feature(
+        input_layer=River_N100.data_selection___water_polygons___n100_river.value,
+        expression="objtype IN ('Elv', 'Innsjø', 'Kanal')",
+        output_name=River_N100.data_preparation___river_polygons___n100_river.value,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/generalization/n100/river/data_preparation.py
+++ b/generalization/n100/river/data_preparation.py
@@ -69,7 +69,7 @@ def filter_river_water_features():
     # Can consider adding 'VeggrøftÅpen' to river line sellection. Byt really questionable.
     custom_arcpy.select_attribute_and_make_permanent_feature(
         input_layer=River_N100.data_selection___water_lines___n100_river.value,
-        expression="objtype IN ('ElvBekk', 'KanalGrøft', 'Kanalkant')",
+        expression="objtype IN ('ElvBekk', 'KanalGrøft', 'Kanalkant', 'KonnekteringVann')",
         output_name=River_N100.data_preparation___river_lines___n100_river.value,
     )
 

--- a/generalization/n100/river/data_preparation.py
+++ b/generalization/n100/river/data_preparation.py
@@ -21,7 +21,7 @@ from custom_tools.general_tools import file_utilities
 
 MERGE_DIVIDED_ROADS_ALTERATIVE = False
 
-AREA_SELECTOR = "vassOmrNr IN ('016')"
+AREA_SELECTOR = "vassOmrNr IN ('198')"
 SCALE = "n100"
 
 

--- a/generalization/n100/river/data_preparation.py
+++ b/generalization/n100/river/data_preparation.py
@@ -81,7 +81,7 @@ def filter_river_water_features():
 
     custom_arcpy.select_attribute_and_make_permanent_feature(
         input_layer=River_N100.data_selection___water_polygons___n100_river.value,
-        expression="objtype IN ('Elv', 'Innsjø', 'Kanal')",
+        expression="objtype IN ('Elv', 'Innsjø', 'Kanal', 'Havflate')",
         output_name=River_N100.data_preparation___river_polygons___n100_river.value,
     )
 

--- a/generalization/n100/river/data_preparation.py
+++ b/generalization/n100/river/data_preparation.py
@@ -18,7 +18,6 @@ from custom_tools.general_tools.geometry_tools import GeometryValidator
 from custom_tools.general_tools import custom_arcpy
 from custom_tools.general_tools import file_utilities
 
-
 MERGE_DIVIDED_ROADS_ALTERATIVE = False
 
 AREA_SELECTOR = "vassOmrNr IN ('198')"

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -46,6 +46,7 @@ def fill_line_topology_gaps():
     line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
+        write_output_metadata=True,
         increased_tolerance_edge_case_distance_meters=5,
         edit_method=logic_config.EditMethod.AUTO,
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -66,7 +66,6 @@ def fill_line_topology_gaps():
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
         angle_block_threshold_degrees=95,
         angle_extra_dangle_threshold_degrees=70,
-        line_alignment_weight=0.75,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
                 distance=0.5,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -26,6 +26,12 @@ def main():
 
 @timing_decorator
 def fill_line_topology_gaps():
+    line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
+        fill_gaps_on_self=True,
+        line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
+        increased_tolerance_edge_case_distance_meters=3,
+    )
+
     line_fix_config = logic_config.FillLineGapsConfig(
         input_lines=River_N100.data_preparation___river_lines___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
@@ -38,12 +44,9 @@ def fill_line_topology_gaps():
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],
-        advanced_config=logic_config.FillLineGapsAdvancedConfig(
-            fill_gaps_on_self=True,
-            line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
-            increased_tolerance_edge_case_distance_meters=3,
-        ),
+        advanced_config=line_fix_advanced_config,
     )
+
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
 
 

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -66,7 +66,7 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
-        gap_tolerance_meters=150,
+        gap_tolerance_meters=300,
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -49,6 +49,7 @@ def fix_river_orientation():
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
     )
     LineZOrientTool(config=flip_config).run()
+    custom_arcpy.select_location_and_make_feature_layer()
 
 
 def find_angles():
@@ -102,6 +103,7 @@ def fill_line_topology_gaps():
         source_direction_mode=logic_config.SourceDirectionMode.RASTER_DERIVED,
         min_z_drop_meters=1,
         raster_paths=rasters,
+        crossing_check_spatial_reference=environment_setup.project_spatial_reference,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,
@@ -148,6 +150,7 @@ def fill_raod_gaps():
         connectivity_scope=logic_config.ConnectivityScope.DIRECT_CONNECTION,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
+        crossing_check_spatial_reference=environment_setup.project_spatial_reference,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=Road_N100.data_preparation___road_gap_root___n100_road.value,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -12,10 +12,6 @@ from custom_tools.general_tools.partition_iterator import PartitionIterator
 
 from composition_configs import core_config, logic_config
 
-# Importing environment settings
-import env_setup.global_config
-
-# Importing timing decorator
 from custom_tools.decorators.timing_decorator import timing_decorator
 
 

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -3,24 +3,21 @@ import arcpy
 # Importing custom files
 import config
 from custom_tools.general_tools import custom_arcpy, line_topology
-from file_manager import work_file_manager
 from file_manager.n100.file_manager_rivers import River_N100
-
 from env_setup import environment_setup
-from input_data import input_symbology
-from custom_tools.general_tools.partition_iterator import PartitionIterator
 
 from composition_configs import core_config, logic_config
 
 from custom_tools.decorators.timing_decorator import timing_decorator
-from custom_tools.general_tools.geometry_tools import LineAngleTool
+from custom_tools.general_tools.geometry_tools import LineAngleTool, LineEndpointTool
 
 
 @timing_decorator
 def main():
     environment_setup.main()
-    fill_line_topology_gaps()
-    # find_angles()
+    # fill_line_topology_gaps()
+    find_angles()
+    find_xy_endpoints()
 
 
 def find_angles():
@@ -32,6 +29,7 @@ def find_angles():
         write_fields=True,
     )
     returned_angles = LineAngleTool(config=line_angle_config).run()
+    print(f"{returned_angles}")
 
     line_angle_config2 = logic_config.AngleToolConfig(
         input_lines=River_N100.river_topology___river_gaps_changes___n100_river.value,
@@ -72,6 +70,20 @@ def fill_line_topology_gaps():
     )
 
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
+
+
+@timing_decorator
+def find_xy_endpoints():
+    xy_endpoint_config = logic_config.LineEndpointToolConfig(
+        input_lines=River_N100.river_topology___river_angles___n100_river.value,
+        output_lines=River_N100.river_topology___river_xy_endpoints___n100_river.value,
+        endpoint_modes=(logic_config.LineEndpointMode.BOTH_ENDPOINTS,),
+        write_fields=True,
+        return_results=True,
+    )
+
+    results = LineEndpointTool(config=xy_endpoint_config).run()
+    # print(f"{results}")
 
 
 if __name__ == "__main__":

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -21,8 +21,8 @@ from custom_tools.general_tools.geometry_tools import (
 @timing_decorator
 def main():
     environment_setup.main()
-    # fill_line_topology_gaps()
-    fix_river_orientation()
+    fill_line_topology_gaps()
+    # fix_river_orientation()
     # find_angles()
     # find_xy_endpoints()
     # find_relevant_rasters()
@@ -97,6 +97,8 @@ def fill_line_topology_gaps():
             )
         ),
         angle_local_half_window_m=20,
+        source_direction_mode=logic_config.SourceDirectionMode.RASTER_DERIVED,
+        min_z_drop_meters=1,
         raster_paths=rasters,
     )
     work_file_manager_config = core_config.WorkFileConfig(

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -43,7 +43,7 @@ def fix_river_orientation():
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         raster_paths=rasters,
         orientation_mode=logic_config.LineZOrientMode.NETWORK,
-        min_z_drop_meters=1,
+        min_z_drop_meters=1.5,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
     )
     LineZOrientTool(config=flip_config).run()

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -66,7 +66,7 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
-        gap_tolerance_meters=25,
+        gap_tolerance_meters=150,
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],
@@ -86,7 +86,10 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             angle_local_half_window_m=20,
             lines_are_directed=True,
         ),
-        z_config=logic_config.FillLineGapsZConfig(raster_paths=raster_list),
+        z_config=logic_config.FillLineGapsZConfig(
+            raster_paths=raster_list,
+            z_drop_threshold=0,
+        ),
         crossing_config=logic_config.FillLineGapsCrossingConfig(
             reject_crossing_connectors=True,
             crossing_check_spatial_reference=environment_setup.project_spatial_reference,
@@ -96,7 +99,7 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         ),
         advanced_config=logic_config.FillLineGapsAdvancedConfig(
-            increased_tolerance_edge_case_distance_meters=10,
+            increased_tolerance_edge_case_distance_meters=15,
         ),
     )
 

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -24,11 +24,9 @@ from custom_tools.general_tools.geometry_tools import (
 def main():
     environment_setup.main()
     raster = compute_raster_extent()
-    # fix_river_orientation(raster_list=raster)
+    fix_river_orientation(raster_list=raster)
     fill_line_topology_gaps(raster_list=raster)
     # fill_raod_gaps()
-    # find_xy_endpoints()
-    # find_relevant_rasters()
 
 
 def compute_raster_extent() -> list[type_defs.RasterFilePath]:
@@ -161,38 +159,6 @@ def fill_raod_gaps():
         ),
         output=Road_N100.data_preparation___integrated_nvdb_traktor_sti___n100_road.value,
     )
-
-
-@timing_decorator
-def find_xy_endpoints():
-    xy_endpoint_config = logic_config.LineEndpointToolConfig(
-        input_lines=River_N100.river_topology___river_angles___n100_river.value,
-        output_lines=River_N100.river_topology___river_xy_endpoints___n100_river.value,
-        endpoint_modes=(logic_config.LineEndpointMode.BOTH_ENDPOINTS,),
-        write_fields=True,
-        return_results=True,
-    )
-
-    results = LineEndpointTool(config=xy_endpoint_config).run()
-    # print(f"{results}")
-
-
-@timing_decorator
-def find_relevant_rasters():
-    rasters = find_rasters_for_vector_extent(
-        raster_dir=config.raster_directory,
-        input_features=River_N100.data_preparation___river_lines___n100_river.value,
-    )
-    print(rasters)
-
-    line_z_config = logic_config.LineZValueToolConfig(
-        input_lines=River_N100.data_preparation___river_lines___n100_river.value,
-        input_rasters=rasters,
-        endpoint_modes=(logic_config.LineZValueMode.BOTH_ENDPOINTS,),
-        output_lines=River_N100.river_topology___river_angles___n100_river.value,
-        write_fields=True,
-    )
-    LineZValueTool(config=line_z_config).run()
 
 
 if __name__ == "__main__":

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -85,11 +85,11 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             angle_extra_dangle_threshold_degrees=95,
             angle_local_half_window_m=20,
             lines_are_directed=True,
-            connector_angle_diff_required_above_meters=10,
+            connector_angle_diff_required_above_meters=5,
         ),
         z_config=logic_config.FillLineGapsZConfig(
             raster_paths=raster_list,
-            z_drop_threshold=1,
+            z_drop_threshold=2,
         ),
         crossing_config=logic_config.FillLineGapsCrossingConfig(
             reject_crossing_connectors=True,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -60,30 +60,6 @@ def fix_river_orientation(raster_list: list[type_defs.RasterFilePath]):
 @timing_decorator
 def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
 
-    line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
-        fill_gaps_on_self=True,
-        line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
-        write_output_metadata=True,
-        candidate_connections_output=River_N100.river_topology___river_gaps_diagnostic___n100_river.value,
-        increased_tolerance_edge_case_distance_meters=10,
-        edit_method=logic_config.EditMethod.AUTO,
-        connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
-        connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
-        line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
-        angle_block_threshold_degrees=85,
-        angle_extra_dangle_threshold_degrees=95,
-        best_fit_weights=(
-            logic_config.BestFitWeightsConfig(
-                distance=0.5,
-                angle=0.25,
-                z=0.25,
-            )
-        ),
-        angle_local_half_window_m=20,
-        lines_are_directed=True,
-        raster_paths=raster_list,
-        crossing_check_spatial_reference=environment_setup.project_spatial_reference,
-    )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,
     )
@@ -96,7 +72,34 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],
-        advanced_config=line_fix_advanced_config,
+        best_fit_weights=logic_config.BestFitWeightsConfig(
+            distance=0.5,
+            angle=0.25,
+            z=0.25,
+        ),
+        output_config=logic_config.FillLineGapsOutputConfig(
+            line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
+            write_output_metadata=True,
+            candidate_connections_output=River_N100.river_topology___river_gaps_diagnostic___n100_river.value,
+        ),
+        angle_config=logic_config.FillLineGapsAngleConfig(
+            angle_block_threshold_degrees=85,
+            angle_extra_dangle_threshold_degrees=95,
+            angle_local_half_window_m=20,
+            lines_are_directed=True,
+        ),
+        z_config=logic_config.FillLineGapsZConfig(raster_paths=raster_list),
+        crossing_config=logic_config.FillLineGapsCrossingConfig(
+            reject_crossing_connectors=True,
+            crossing_check_spatial_reference=environment_setup.project_spatial_reference,
+        ),
+        connectivity_config=logic_config.FillLineGapsConnectivityConfig(
+            connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
+            connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
+        ),
+        advanced_config=logic_config.FillLineGapsAdvancedConfig(
+            increased_tolerance_edge_case_distance_meters=10,
+        ),
     )
 
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
@@ -117,18 +120,6 @@ def fill_raod_gaps():
         inverted=True,
     )
 
-    line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
-        fill_gaps_on_self=False,
-        line_changes_output=Road_N100.data_preparation___road_gap_changes___n100_road.value,
-        write_output_metadata=True,
-        candidate_connections_output=Road_N100.data_preparation___road_gap_diagnostics___n100_road.value,
-        increased_tolerance_edge_case_distance_meters=10,
-        edit_method=logic_config.EditMethod.AUTO,
-        connectivity_scope=logic_config.ConnectivityScope.DIRECT_CONNECTION,
-        connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
-        line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
-        crossing_check_spatial_reference=environment_setup.project_spatial_reference,
-    )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=Road_N100.data_preparation___road_gap_root___n100_road.value,
         write_to_memory=False,
@@ -143,7 +134,22 @@ def fill_raod_gaps():
         connect_to_features=[
             Road_N100.data_preparation___nvdb_selection___n100_road.value
         ],
-        advanced_config=line_fix_advanced_config,
+        fill_gaps_on_self=False,
+        output_config=logic_config.FillLineGapsOutputConfig(
+            line_changes_output=Road_N100.data_preparation___road_gap_changes___n100_road.value,
+            write_output_metadata=True,
+            candidate_connections_output=Road_N100.data_preparation___road_gap_diagnostics___n100_road.value,
+        ),
+        crossing_config=logic_config.FillLineGapsCrossingConfig(
+            reject_crossing_connectors=True,
+            crossing_check_spatial_reference=environment_setup.project_spatial_reference,
+        ),
+        connectivity_config=logic_config.FillLineGapsConnectivityConfig(
+            connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
+        ),
+        advanced_config=logic_config.FillLineGapsAdvancedConfig(
+            increased_tolerance_edge_case_distance_meters=10,
+        ),
     )
 
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -1,0 +1,45 @@
+import arcpy
+
+# Importing custom files
+import config
+from custom_tools.general_tools import custom_arcpy, line_topology
+from file_manager.n100.file_manager_rivers import River_N100
+
+from env_setup import environment_setup
+from input_data import input_symbology
+from custom_tools.general_tools.partition_iterator import PartitionIterator
+
+from composition_configs import core_config, logic_config
+
+# Importing environment settings
+import env_setup.global_config
+
+# Importing timing decorator
+from custom_tools.decorators.timing_decorator import timing_decorator
+
+
+@timing_decorator
+def main():
+    environment_setup.main()
+    fill_line_topology_gaps()
+
+
+@timing_decorator
+def fill_line_topology_gaps():
+    line_fix_config = logic_config.FillLineGapsConfig(
+        input_lines=River_N100.data_preparation___river_lines___n100_river.value,
+        output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
+        work_file_manager_config=core_config.WorkFileConfig(
+            root_file=River_N100.river_topology___root___n100_river.value
+        ),
+        gap_tolerance_meters=3,
+        fill_gaps_on_self=True,
+        connect_to_features=[
+            River_N100.data_preparation___river_polygons___n100_river.value
+        ],
+    )
+    line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -18,6 +18,7 @@ from custom_tools.general_tools.geometry_tools import (
     LineZValueTool,
     LineZOrientTool,
 )
+from custom_tools.general_tools.line_segmenter import segment_line
 
 
 @timing_decorator
@@ -25,6 +26,7 @@ def main():
     environment_setup.main()
     raster = compute_raster_extent()
     fix_river_orientation(raster_list=raster)
+    prepare_segmented_inputs()
     fill_line_topology_gaps(raster_list=raster)
     # fill_raod_gaps()
 
@@ -56,20 +58,44 @@ def fix_river_orientation(raster_list: list[type_defs.RasterFilePath]):
 
 
 @timing_decorator
+def prepare_segmented_inputs():
+    arcpy.management.PolygonToLine(
+        in_features=River_N100.data_preparation___river_polygons___n100_river.value,
+        out_feature_class=River_N100.river_topology___river_polygons_as_lines___n100_river.value,
+    )
+
+    segment_line(
+        input_fc=River_N100.river_topology___fixed_river_orientation___n100_river.value,
+        output_fc=River_N100.river_topology___segmented_river_lines___n100_river.value,
+        segment_interval=20,
+        even_segments=True,
+    )
+
+    segment_line(
+        input_fc=River_N100.river_topology___river_polygons_as_lines___n100_river.value,
+        output_fc=River_N100.river_topology___segmented_river_polygon_lines___n100_river.value,
+        segment_interval=20,
+        even_segments=True,
+    )
+
+
+@timing_decorator
 def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
 
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,
     )
 
+    segmented_polygon_lines = (
+        River_N100.river_topology___segmented_river_polygon_lines___n100_river.value
+    )
+
     line_fix_config = logic_config.FillLineGapsConfig(
-        input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
+        input_lines=River_N100.river_topology___segmented_river_lines___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
         gap_tolerance_meters=300,
-        connect_to_features=[
-            River_N100.data_preparation___river_polygons___n100_river.value
-        ],
+        connect_to_features=[segmented_polygon_lines],
         best_fit_weights=logic_config.BestFitWeightsConfig(
             distance=0.5,
             angle=0.25,
@@ -86,6 +112,9 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             angle_local_half_window_m=20,
             lines_are_directed=True,
             connector_angle_diff_required_above_meters=5,
+            connect_to_features_angle_mode={
+                segmented_polygon_lines: logic_config.AngleTargetMode.FORCE_NON_LINE,
+            },
         ),
         z_config=logic_config.FillLineGapsZConfig(
             raster_paths=raster_list,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -55,7 +55,14 @@ def fill_line_topology_gaps():
         angle_block_threshold_degrees=None,
         angle_extra_dangle_threshold_degrees=45,
         line_alignment_weight=0.6,
-        angle_local_half_window_m=15,
+        best_fit_weights=(
+            logic_config.BestFitWeightsConfig(
+                distance=0.35,
+                angle=0.65,
+                z=0.0,
+            )
+        ),
+        angle_local_half_window_m=10,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -64,19 +64,19 @@ def prepare_segmented_inputs():
         out_feature_class=River_N100.river_topology___river_polygons_as_lines___n100_river.value,
     )
 
-    segment_line(
-        input_fc=River_N100.river_topology___fixed_river_orientation___n100_river.value,
-        output_fc=River_N100.river_topology___segmented_river_lines___n100_river.value,
-        segment_interval=20,
-        even_segments=True,
-    )
-
-    segment_line(
-        input_fc=River_N100.river_topology___river_polygons_as_lines___n100_river.value,
-        output_fc=River_N100.river_topology___segmented_river_polygon_lines___n100_river.value,
-        segment_interval=20,
-        even_segments=True,
-    )
+    # segment_line(
+    #     input_fc=River_N100.river_topology___fixed_river_orientation___n100_river.value,
+    #     output_fc=River_N100.river_topology___segmented_river_lines___n100_river.value,
+    #     segment_interval=20,
+    #     even_segments=True,
+    # )
+    #
+    # segment_line(
+    #     input_fc=River_N100.river_topology___river_polygons_as_lines___n100_river.value,
+    #     output_fc=River_N100.river_topology___segmented_river_polygon_lines___n100_river.value,
+    #     segment_interval=20,
+    #     even_segments=True,
+    # )
 
 
 @timing_decorator
@@ -87,11 +87,11 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
     )
 
     segmented_polygon_lines = (
-        River_N100.river_topology___segmented_river_polygon_lines___n100_river.value
+        River_N100.river_topology___river_polygons_as_lines___n100_river.value
     )
 
     line_fix_config = logic_config.FillLineGapsConfig(
-        input_lines=River_N100.river_topology___segmented_river_lines___n100_river.value,
+        input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
         gap_tolerance_meters=300,
@@ -131,6 +131,10 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
         advanced_config=logic_config.FillLineGapsAdvancedConfig(
             edit_method=logic_config.EditMethod.NEW_LINE,
             increased_tolerance_edge_case_distance_meters=15,
+        ),
+        segmentation=logic_config.SegmentationConfig(
+            interval_meters=20,
+            mode=logic_config.SegmentationMode.EVEN,
         ),
     )
 

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -13,16 +13,17 @@ from custom_tools.general_tools.geometry_tools import (
     LineAngleTool,
     LineEndpointTool,
     find_rasters_for_vector_extent,
+    LineZValueTool,
 )
 
 
 @timing_decorator
 def main():
     environment_setup.main()
-    # fill_line_topology_gaps()
+    fill_line_topology_gaps()
     # find_angles()
     # find_xy_endpoints()
-    find_relevant_rasters()
+    # find_relevant_rasters()
 
 
 def find_angles():
@@ -48,6 +49,11 @@ def find_angles():
 
 @timing_decorator
 def fill_line_topology_gaps():
+
+    rasters = find_rasters_for_vector_extent(
+        raster_dir=config.raster_directory,
+        input_features=River_N100.data_preparation___river_lines___n100_river.value,
+    )
     line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
@@ -63,12 +69,13 @@ def fill_line_topology_gaps():
         line_alignment_weight=0.75,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
-                distance=0.6,
-                angle=0.4,
-                z=0.0,
+                distance=0.5,
+                angle=0.25,
+                z=0.25,
             )
         ),
         angle_local_half_window_m=20,
+        raster_paths=rasters,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,
@@ -111,6 +118,15 @@ def find_relevant_rasters():
         input_features=River_N100.data_preparation___river_lines___n100_river.value,
     )
     print(rasters)
+
+    line_z_config = logic_config.LineZValueToolConfig(
+        input_lines=River_N100.data_preparation___river_lines___n100_river.value,
+        input_rasters=rasters,
+        endpoint_modes=(logic_config.LineZValueMode.BOTH_ENDPOINTS,),
+        output_lines=River_N100.river_topology___river_angles___n100_river.value,
+        write_fields=True,
+    )
+    LineZValueTool(config=line_z_config).run()
 
 
 if __name__ == "__main__":

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -14,16 +14,37 @@ from custom_tools.general_tools.geometry_tools import (
     LineEndpointTool,
     find_rasters_for_vector_extent,
     LineZValueTool,
+    LineZOrientTool,
 )
 
 
 @timing_decorator
 def main():
     environment_setup.main()
-    fill_line_topology_gaps()
+    # fill_line_topology_gaps()
+    fix_river_orientation()
     # find_angles()
     # find_xy_endpoints()
     # find_relevant_rasters()
+
+
+def fix_river_orientation():
+    arcpy.management.CopyFeatures(
+        in_features=River_N100.data_preparation___river_lines___n100_river.value,
+        out_feature_class=River_N100.river_topology___fixed_river_orientation___n100_river.value,
+    )
+
+    rasters = find_rasters_for_vector_extent(
+        raster_dir=config.raster_directory,
+        input_features=River_N100.data_preparation___river_lines___n100_river.value,
+    )
+    flip_config = logic_config.LineZOrientConfig(
+        input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
+        raster_paths=rasters,
+        orientation_mode=logic_config.LineZOrientMode.NETWORK,
+        connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
+    )
+    LineZOrientTool(config=flip_config).run()
 
 
 def find_angles():

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -47,22 +47,23 @@ def fill_line_topology_gaps():
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
         write_output_metadata=True,
-        increased_tolerance_edge_case_distance_meters=15,
+        candidate_connections_output=River_N100.river_topology___river_gaps_diagnostic___n100_river.value,
+        increased_tolerance_edge_case_distance_meters=10,
         edit_method=logic_config.EditMethod.AUTO,
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
-        angle_block_threshold_degrees=None,
-        angle_extra_dangle_threshold_degrees=75,
+        angle_block_threshold_degrees=90,
+        angle_extra_dangle_threshold_degrees=70,
         line_alignment_weight=0.75,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
-                distance=0.15,
-                angle=0.85,
+                distance=0.5,
+                angle=0.5,
                 z=0.0,
             )
         ),
-        angle_local_half_window_m=10,
+        angle_local_half_window_m=20,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,
@@ -74,7 +75,7 @@ def fill_line_topology_gaps():
         input_lines=River_N100.data_preparation___river_lines___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
-        gap_tolerance_meters=3,
+        gap_tolerance_meters=25,
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -9,15 +9,20 @@ from env_setup import environment_setup
 from composition_configs import core_config, logic_config
 
 from custom_tools.decorators.timing_decorator import timing_decorator
-from custom_tools.general_tools.geometry_tools import LineAngleTool, LineEndpointTool
+from custom_tools.general_tools.geometry_tools import (
+    LineAngleTool,
+    LineEndpointTool,
+    find_rasters_for_vector_extent,
+)
 
 
 @timing_decorator
 def main():
     environment_setup.main()
-    fill_line_topology_gaps()
+    # fill_line_topology_gaps()
     # find_angles()
     # find_xy_endpoints()
+    find_relevant_rasters()
 
 
 def find_angles():
@@ -97,6 +102,15 @@ def find_xy_endpoints():
 
     results = LineEndpointTool(config=xy_endpoint_config).run()
     # print(f"{results}")
+
+
+@timing_decorator
+def find_relevant_rasters():
+    rasters = find_rasters_for_vector_extent(
+        raster_dir=config.raster_directory,
+        input_features=River_N100.data_preparation___river_lines___n100_river.value,
+    )
+    print(rasters)
 
 
 if __name__ == "__main__":

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -42,6 +42,7 @@ def fix_river_orientation():
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         raster_paths=rasters,
         orientation_mode=logic_config.LineZOrientMode.NETWORK,
+        outlet_mode=logic_config.LineZOrientOutletMode.DANGLE_ENDPOINTS,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
     )
     LineZOrientTool(config=flip_config).run()

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -38,11 +38,12 @@ def fix_river_orientation():
         raster_dir=config.raster_directory,
         input_features=River_N100.data_preparation___river_lines___n100_river.value,
     )
+
     flip_config = logic_config.LineZOrientConfig(
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         raster_paths=rasters,
         orientation_mode=logic_config.LineZOrientMode.NETWORK,
-        outlet_mode=logic_config.LineZOrientOutletMode.DANGLE_ENDPOINTS,
+        min_z_drop_meters=1,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
     )
     LineZOrientTool(config=flip_config).run()

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -58,8 +58,8 @@ def fill_line_topology_gaps():
         line_alignment_weight=0.75,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
-                distance=0.5,
-                angle=0.5,
+                distance=0.6,
+                angle=0.4,
                 z=0.0,
             )
         ),

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -15,9 +15,9 @@ from custom_tools.general_tools.geometry_tools import LineAngleTool, LineEndpoin
 @timing_decorator
 def main():
     environment_setup.main()
-    # fill_line_topology_gaps()
-    find_angles()
-    find_xy_endpoints()
+    fill_line_topology_gaps()
+    # find_angles()
+    # find_xy_endpoints()
 
 
 def find_angles():
@@ -51,6 +51,10 @@ def fill_line_topology_gaps():
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
+        angle_block_threshold_degrees=None,
+        angle_extra_dangle_threshold_degrees=45,
+        line_alignment_weight=0.6,
+        angle_local_half_window_m=15,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -8,6 +8,7 @@ from file_manager.n100.file_manager_roads import Road_N100
 from env_setup import environment_setup
 
 from composition_configs import core_config, logic_config
+from composition_configs import type_defs
 
 from custom_tools.decorators.timing_decorator import timing_decorator
 from custom_tools.general_tools.geometry_tools import (
@@ -22,64 +23,43 @@ from custom_tools.general_tools.geometry_tools import (
 @timing_decorator
 def main():
     environment_setup.main()
-    fill_line_topology_gaps()
+    raster = compute_raster_extent()
+    fix_river_orientation(raster_list=raster)
+    fill_line_topology_gaps(raster_list=raster)
     # fill_raod_gaps()
-    # fix_river_orientation()
-    # find_angles()
     # find_xy_endpoints()
     # find_relevant_rasters()
 
 
-def fix_river_orientation():
+def compute_raster_extent() -> list[type_defs.RasterFilePath]:
+
+    rasters = find_rasters_for_vector_extent(
+        raster_dir=config.raster_directory,
+        input_features=River_N100.data_preparation___river_lines___n100_river.value,
+    )
+    return rasters
+
+
+def fix_river_orientation(raster_list: list[type_defs.RasterFilePath]):
     arcpy.management.CopyFeatures(
         in_features=River_N100.data_preparation___river_lines___n100_river.value,
         out_feature_class=River_N100.river_topology___fixed_river_orientation___n100_river.value,
     )
 
-    rasters = find_rasters_for_vector_extent(
-        raster_dir=config.raster_directory,
-        input_features=River_N100.data_preparation___river_lines___n100_river.value,
-    )
-
     flip_config = logic_config.LineZOrientConfig(
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
-        raster_paths=rasters,
+        raster_paths=raster_list,
         orientation_mode=logic_config.LineZOrientMode.NETWORK,
-        min_z_drop_meters=1.5,
+        min_anchor_z_drop_meters=2,
+        min_confident_flip_meters=1.5,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
     )
     LineZOrientTool(config=flip_config).run()
-    custom_arcpy.select_location_and_make_feature_layer()
-
-
-def find_angles():
-    line_angle_config = logic_config.AngleToolConfig(
-        input_lines=River_N100.data_preparation___river_lines___n100_river.value,
-        angle_modes=(logic_config.LineAngleMode.ALL_ANGLES,),
-        output_lines=River_N100.river_topology___river_angles___n100_river.value,
-        return_results=True,
-        write_fields=True,
-    )
-    returned_angles = LineAngleTool(config=line_angle_config).run()
-    print(f"{returned_angles}")
-
-    line_angle_config2 = logic_config.AngleToolConfig(
-        input_lines=River_N100.river_topology___river_gaps_changes___n100_river.value,
-        angle_modes=(logic_config.LineAngleMode.ALL_ANGLES,),
-        output_lines=River_N100.river_topology___river_angles_2___n100_river.value,
-        return_results=True,
-        write_fields=True,
-    )
-    returned_angles2 = LineAngleTool(config=line_angle_config2).run()
 
 
 @timing_decorator
-def fill_line_topology_gaps():
+def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
 
-    rasters = find_rasters_for_vector_extent(
-        raster_dir=config.raster_directory,
-        input_features=River_N100.data_preparation___river_lines___n100_river.value,
-    )
     line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
@@ -100,9 +80,8 @@ def fill_line_topology_gaps():
             )
         ),
         angle_local_half_window_m=20,
-        source_direction_mode=logic_config.SourceDirectionMode.RASTER_DERIVED,
-        min_z_drop_meters=1,
-        raster_paths=rasters,
+        source_direction_mode=logic_config.SourceDirectionMode.PRE_ORIENTED,
+        raster_paths=raster_list,
         crossing_check_spatial_reference=environment_setup.project_spatial_reference,
     )
     work_file_manager_config = core_config.WorkFileConfig(
@@ -112,7 +91,7 @@ def fill_line_topology_gaps():
     )
 
     line_fix_config = logic_config.FillLineGapsConfig(
-        input_lines=River_N100.data_preparation___river_lines___n100_river.value,
+        input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
         gap_tolerance_meters=25,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -37,6 +37,7 @@ def fill_line_topology_gaps():
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],
+        line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
     )
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
 

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -13,12 +13,44 @@ from custom_tools.general_tools.partition_iterator import PartitionIterator
 from composition_configs import core_config, logic_config
 
 from custom_tools.decorators.timing_decorator import timing_decorator
+from custom_tools.general_tools.geometry_tools import LineAngleTool
 
 
 @timing_decorator
 def main():
     environment_setup.main()
-    fill_line_topology_gaps()
+    # fill_line_topology_gaps()
+    find_angles()
+
+
+def find_angles():
+    line_angle_config = logic_config.AngleToolConfig(
+        input_lines=River_N100.data_preparation___river_lines___n100_river.value,
+        angle_modes=(
+            logic_config.LineAngleMode.WHOLE_LINE,
+            logic_config.LineAngleMode.BOTH_ENDPOINT_SEGMENTS,
+            logic_config.LineAngleMode.START_TO_MIDPOINT,
+            logic_config.LineAngleMode.END_TO_MIDPOINT,
+        ),
+        output_lines=River_N100.river_topology___river_angles___n100_river.value,
+        return_results=True,
+        write_fields=True,
+    )
+    returned_angles = LineAngleTool(config=line_angle_config).run()
+
+    line_angle_config2 = logic_config.AngleToolConfig(
+        input_lines=River_N100.river_topology___river_gaps_changes___n100_river.value,
+        angle_modes=(
+            logic_config.LineAngleMode.WHOLE_LINE,
+            logic_config.LineAngleMode.BOTH_ENDPOINT_SEGMENTS,
+            logic_config.LineAngleMode.START_TO_MIDPOINT,
+            logic_config.LineAngleMode.END_TO_MIDPOINT,
+        ),
+        output_lines=River_N100.river_topology___river_angles_2___n100_river.value,
+        return_results=True,
+        write_fields=True,
+    )
+    returned_angles2 = LineAngleTool(config=line_angle_config2).run()
 
 
 @timing_decorator

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -87,8 +87,8 @@ def fill_line_topology_gaps():
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
-        angle_block_threshold_degrees=95,
-        angle_extra_dangle_threshold_degrees=70,
+        angle_block_threshold_degrees=115,
+        angle_extra_dangle_threshold_degrees=95,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
                 distance=0.5,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -30,7 +30,9 @@ def fill_line_topology_gaps():
         input_lines=River_N100.data_preparation___river_lines___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=core_config.WorkFileConfig(
-            root_file=River_N100.river_topology___root___n100_river.value
+            root_file=River_N100.river_topology___root___n100_river.value,
+            write_to_memory=False,
+            keep_files=True,
         ),
         gap_tolerance_meters=3,
         connect_to_features=[

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -24,7 +24,7 @@ from custom_tools.general_tools.geometry_tools import (
 def main():
     environment_setup.main()
     raster = compute_raster_extent()
-    fix_river_orientation(raster_list=raster)
+    # fix_river_orientation(raster_list=raster)
     fill_line_topology_gaps(raster_list=raster)
     # fill_raod_gaps()
     # find_xy_endpoints()
@@ -80,14 +80,12 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             )
         ),
         angle_local_half_window_m=20,
-        source_direction_mode=logic_config.SourceDirectionMode.PRE_ORIENTED,
+        lines_are_directed=True,
         raster_paths=raster_list,
         crossing_check_spatial_reference=environment_setup.project_spatial_reference,
     )
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,
-        write_to_memory=False,
-        keep_files=True,
     )
 
     line_fix_config = logic_config.FillLineGapsConfig(

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -47,18 +47,18 @@ def fill_line_topology_gaps():
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
         write_output_metadata=True,
-        increased_tolerance_edge_case_distance_meters=5,
+        increased_tolerance_edge_case_distance_meters=15,
         edit_method=logic_config.EditMethod.AUTO,
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
         angle_block_threshold_degrees=None,
-        angle_extra_dangle_threshold_degrees=45,
-        line_alignment_weight=0.6,
+        angle_extra_dangle_threshold_degrees=75,
+        line_alignment_weight=0.75,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
-                distance=0.35,
-                angle=0.65,
+                distance=0.15,
+                angle=0.85,
                 z=0.0,
             )
         ),

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -100,6 +100,7 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         ),
         advanced_config=logic_config.FillLineGapsAdvancedConfig(
+            edit_method=logic_config.EditMethod.NEW_LINE,
             increased_tolerance_edge_case_distance_meters=15,
         ),
     )

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -22,8 +22,8 @@ from custom_tools.general_tools.geometry_tools import (
 @timing_decorator
 def main():
     environment_setup.main()
-    # fill_line_topology_gaps()
-    fill_raod_gaps()
+    fill_line_topology_gaps()
+    # fill_raod_gaps()
     # fix_river_orientation()
     # find_angles()
     # find_xy_endpoints()

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -3,6 +3,7 @@ import arcpy
 # Importing custom files
 import config
 from custom_tools.general_tools import custom_arcpy, line_topology
+from file_manager import work_file_manager
 from file_manager.n100.file_manager_rivers import River_N100
 
 from env_setup import environment_setup
@@ -30,16 +31,21 @@ def fill_line_topology_gaps():
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
         increased_tolerance_edge_case_distance_meters=3,
+        edit_method=logic_config.EditMethod.AUTO,
+        connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
+        connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
+        line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
+    )
+    work_file_manager_config = core_config.WorkFileConfig(
+        root_file=River_N100.river_topology___root___n100_river.value,
+        write_to_memory=False,
+        keep_files=True,
     )
 
     line_fix_config = logic_config.FillLineGapsConfig(
         input_lines=River_N100.data_preparation___river_lines___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
-        work_file_manager_config=core_config.WorkFileConfig(
-            root_file=River_N100.river_topology___root___n100_river.value,
-            write_to_memory=False,
-            keep_files=True,
-        ),
+        work_file_manager_config=work_file_manager_config,
         gap_tolerance_meters=3,
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -33,11 +33,14 @@ def fill_line_topology_gaps():
             root_file=River_N100.river_topology___root___n100_river.value
         ),
         gap_tolerance_meters=3,
-        fill_gaps_on_self=True,
         connect_to_features=[
             River_N100.data_preparation___river_polygons___n100_river.value
         ],
-        line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
+        advanced_config=logic_config.FillLineGapsAdvancedConfig(
+            fill_gaps_on_self=True,
+            line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
+            increased_tolerance_edge_case_distance_meters=3,
+        ),
     )
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
 

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -4,6 +4,7 @@ import arcpy
 import config
 from custom_tools.general_tools import custom_arcpy, line_topology
 from file_manager.n100.file_manager_rivers import River_N100
+from file_manager.n100.file_manager_roads import Road_N100
 from env_setup import environment_setup
 
 from composition_configs import core_config, logic_config
@@ -21,7 +22,8 @@ from custom_tools.general_tools.geometry_tools import (
 @timing_decorator
 def main():
     environment_setup.main()
-    fill_line_topology_gaps()
+    # fill_line_topology_gaps()
+    fill_raod_gaps()
     # fix_river_orientation()
     # find_angles()
     # find_xy_endpoints()
@@ -87,7 +89,7 @@ def fill_line_topology_gaps():
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
-        angle_block_threshold_degrees=115,
+        angle_block_threshold_degrees=85,
         angle_extra_dangle_threshold_degrees=95,
         best_fit_weights=(
             logic_config.BestFitWeightsConfig(
@@ -119,6 +121,60 @@ def fill_line_topology_gaps():
     )
 
     line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
+
+
+@timing_decorator
+def fill_raod_gaps():
+    custom_arcpy.select_attribute_and_make_permanent_feature(
+        input_layer=Road_N100.data_selection___nvdb_roads___n100_road.value,
+        expression="objtype IN ('VegSenterlinje')",
+        output_name=Road_N100.data_preparation___nvdb_selection___n100_road.value,
+    )
+
+    custom_arcpy.select_attribute_and_make_permanent_feature(
+        input_layer=Road_N100.data_selection___nvdb_roads___n100_road.value,
+        expression="objtype IN ('VegSenterlinje')",
+        output_name=Road_N100.data_preparation___tractor_selection___n100_road.value,
+        inverted=True,
+    )
+
+    line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
+        fill_gaps_on_self=False,
+        line_changes_output=Road_N100.data_preparation___road_gap_changes___n100_road.value,
+        write_output_metadata=True,
+        candidate_connections_output=Road_N100.data_preparation___road_gap_diagnostics___n100_road.value,
+        increased_tolerance_edge_case_distance_meters=10,
+        edit_method=logic_config.EditMethod.AUTO,
+        connectivity_scope=logic_config.ConnectivityScope.DIRECT_CONNECTION,
+        connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
+        line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
+    )
+    work_file_manager_config = core_config.WorkFileConfig(
+        root_file=Road_N100.data_preparation___road_gap_root___n100_road.value,
+        write_to_memory=False,
+        keep_files=True,
+    )
+
+    line_fix_config = logic_config.FillLineGapsConfig(
+        input_lines=Road_N100.data_preparation___tractor_selection___n100_road.value,
+        output_lines=Road_N100.data_preparation___fixed_road_gaps___n100_road.value,
+        work_file_manager_config=work_file_manager_config,
+        gap_tolerance_meters=25,
+        connect_to_features=[
+            Road_N100.data_preparation___nvdb_selection___n100_road.value
+        ],
+        advanced_config=line_fix_advanced_config,
+    )
+
+    line_topology.FillLineGaps(line_gap_config=line_fix_config).run()
+
+    arcpy.management.Merge(
+        inputs=(
+            Road_N100.data_preparation___nvdb_selection___n100_road.value,
+            Road_N100.data_preparation___fixed_road_gaps___n100_road.value,
+        ),
+        output=Road_N100.data_preparation___integrated_nvdb_traktor_sti___n100_road.value,
+    )
 
 
 @timing_decorator

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -26,12 +26,7 @@ def main():
 def find_angles():
     line_angle_config = logic_config.AngleToolConfig(
         input_lines=River_N100.data_preparation___river_lines___n100_river.value,
-        angle_modes=(
-            logic_config.LineAngleMode.WHOLE_LINE,
-            logic_config.LineAngleMode.BOTH_ENDPOINT_SEGMENTS,
-            logic_config.LineAngleMode.START_TO_MIDPOINT,
-            logic_config.LineAngleMode.END_TO_MIDPOINT,
-        ),
+        angle_modes=(logic_config.LineAngleMode.ALL_ANGLES,),
         output_lines=River_N100.river_topology___river_angles___n100_river.value,
         return_results=True,
         write_fields=True,
@@ -40,12 +35,7 @@ def find_angles():
 
     line_angle_config2 = logic_config.AngleToolConfig(
         input_lines=River_N100.river_topology___river_gaps_changes___n100_river.value,
-        angle_modes=(
-            logic_config.LineAngleMode.WHOLE_LINE,
-            logic_config.LineAngleMode.BOTH_ENDPOINT_SEGMENTS,
-            logic_config.LineAngleMode.START_TO_MIDPOINT,
-            logic_config.LineAngleMode.END_TO_MIDPOINT,
-        ),
+        angle_modes=(logic_config.LineAngleMode.ALL_ANGLES,),
         output_lines=River_N100.river_topology___river_angles_2___n100_river.value,
         return_results=True,
         write_fields=True,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -53,7 +53,7 @@ def fill_line_topology_gaps():
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,
         line_connectivity_mode=logic_config.LineConnectivityMode.ENDPOINTS,
-        angle_block_threshold_degrees=90,
+        angle_block_threshold_degrees=95,
         angle_extra_dangle_threshold_degrees=70,
         line_alignment_weight=0.75,
         best_fit_weights=(

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -85,10 +85,11 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             angle_extra_dangle_threshold_degrees=95,
             angle_local_half_window_m=20,
             lines_are_directed=True,
+            connector_angle_diff_required_above_meters=10,
         ),
         z_config=logic_config.FillLineGapsZConfig(
             raster_paths=raster_list,
-            z_drop_threshold=0,
+            z_drop_threshold=1,
         ),
         crossing_config=logic_config.FillLineGapsCrossingConfig(
             reject_crossing_connectors=True,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -19,8 +19,8 @@ from custom_tools.general_tools.geometry_tools import LineAngleTool
 @timing_decorator
 def main():
     environment_setup.main()
-    # fill_line_topology_gaps()
-    find_angles()
+    fill_line_topology_gaps()
+    # find_angles()
 
 
 def find_angles():
@@ -48,7 +48,7 @@ def fill_line_topology_gaps():
     line_fix_advanced_config = logic_config.FillLineGapsAdvancedConfig(
         fill_gaps_on_self=True,
         line_changes_output=River_N100.river_topology___river_gaps_changes___n100_river.value,
-        increased_tolerance_edge_case_distance_meters=3,
+        increased_tolerance_edge_case_distance_meters=5,
         edit_method=logic_config.EditMethod.AUTO,
         connectivity_scope=logic_config.ConnectivityScope.TRANSITIVE,
         connectivity_tolerance_meters=environment_setup.ArcGisEnvironmentSetup.XY_TOLERANCE,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -31,16 +31,16 @@ def main():
     # fill_raod_gaps()
 
 
-def compute_raster_extent() -> list[type_defs.RasterFilePath]:
+def compute_raster_extent() -> tuple[type_defs.RasterFilePath, ...]:
 
     rasters = find_rasters_for_vector_extent(
         raster_dir=config.raster_directory,
         input_features=River_N100.data_preparation___river_lines___n100_river.value,
     )
-    return rasters
+    return tuple(rasters)
 
 
-def fix_river_orientation(raster_list: list[type_defs.RasterFilePath]):
+def fix_river_orientation(raster_list: tuple[type_defs.RasterFilePath, ...]):
     arcpy.management.CopyFeatures(
         in_features=River_N100.data_preparation___river_lines___n100_river.value,
         out_feature_class=River_N100.river_topology___fixed_river_orientation___n100_river.value,
@@ -79,7 +79,7 @@ def prepare_segmented_inputs():
 
 
 @timing_decorator
-def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
+def fill_line_topology_gaps(raster_list: tuple[type_defs.RasterFilePath, ...]):
 
     work_file_manager_config = core_config.WorkFileConfig(
         root_file=River_N100.river_topology___root___n100_river.value,

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -12,10 +12,7 @@ from composition_configs import type_defs
 
 from custom_tools.decorators.timing_decorator import timing_decorator
 from custom_tools.general_tools.geometry_tools import (
-    LineAngleTool,
-    LineEndpointTool,
     find_rasters_for_vector_extent,
-    LineZValueTool,
     LineZOrientTool,
 )
 from custom_tools.general_tools.line_segmenter import segment_line

--- a/generalization/n100/river/fix_river_topology_gaps.py
+++ b/generalization/n100/river/fix_river_topology_gaps.py
@@ -59,10 +59,8 @@ def fix_river_orientation(raster_list: list[type_defs.RasterFilePath]):
 
 @timing_decorator
 def prepare_segmented_inputs():
-    arcpy.management.PolygonToLine(
-        in_features=River_N100.data_preparation___river_polygons___n100_river.value,
-        out_feature_class=River_N100.river_topology___river_polygons_as_lines___n100_river.value,
-    )
+    # FillLineGaps now converts polygon connect_to_features to their
+    # boundary polyline internally; no upstream PolygonToLine needed.
 
     # segment_line(
     #     input_fc=River_N100.river_topology___fixed_river_orientation___n100_river.value,
@@ -77,6 +75,7 @@ def prepare_segmented_inputs():
     #     segment_interval=20,
     #     even_segments=True,
     # )
+    pass
 
 
 @timing_decorator
@@ -86,16 +85,14 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
         root_file=River_N100.river_topology___root___n100_river.value,
     )
 
-    segmented_polygon_lines = (
-        River_N100.river_topology___river_polygons_as_lines___n100_river.value
-    )
+    river_polygons = River_N100.data_preparation___river_polygons___n100_river.value
 
     line_fix_config = logic_config.FillLineGapsConfig(
         input_lines=River_N100.river_topology___fixed_river_orientation___n100_river.value,
         output_lines=River_N100.river_topology___fixed_river_gaps___n100_river.value,
         work_file_manager_config=work_file_manager_config,
         gap_tolerance_meters=300,
-        connect_to_features=[segmented_polygon_lines],
+        connect_to_features=[river_polygons],
         best_fit_weights=logic_config.BestFitWeightsConfig(
             distance=0.5,
             angle=0.25,
@@ -113,7 +110,7 @@ def fill_line_topology_gaps(raster_list: list[type_defs.RasterFilePath]):
             lines_are_directed=True,
             connector_angle_diff_required_above_meters=5,
             connect_to_features_angle_mode={
-                segmented_polygon_lines: logic_config.AngleTargetMode.FORCE_NON_LINE,
+                river_polygons: logic_config.AngleTargetMode.FORCE_NON_LINE,
             },
         ),
         z_config=logic_config.FillLineGapsZConfig(

--- a/generalization/n100/river/main.py
+++ b/generalization/n100/river/main.py
@@ -1,16 +1,19 @@
 # Importing modules
+from custom_tools import general_tools
 from env_setup import environment_setup
 from custom_tools.decorators.timing_decorator import timing_decorator
 
 
 # Importing building scripts
 from generalization.n100.river import data_preparation
+from generalization.n100.river import fix_river_topology_gaps
 
 
 @timing_decorator
 def main():
     environment_setup.main()
     data_preparation.main()
+    fix_river_topology_gaps.main()
 
 
 if __name__ == "__main__":

--- a/generalization/n100/river/main.py
+++ b/generalization/n100/river/main.py
@@ -1,0 +1,17 @@
+# Importing modules
+from env_setup import environment_setup
+from custom_tools.decorators.timing_decorator import timing_decorator
+
+
+# Importing building scripts
+from generalization.n100.river import data_preparation
+
+
+@timing_decorator
+def main():
+    environment_setup.main()
+    data_preparation.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/generalization/n100/river/main.py
+++ b/generalization/n100/river/main.py
@@ -3,7 +3,6 @@ from custom_tools import general_tools
 from env_setup import environment_setup
 from custom_tools.decorators.timing_decorator import timing_decorator
 
-
 # Importing building scripts
 from generalization.n100.river import data_preparation
 from generalization.n100.river import fix_river_topology_gaps

--- a/generalization/n100/road/data_preparation_2.py
+++ b/generalization/n100/road/data_preparation_2.py
@@ -47,6 +47,7 @@ from input_data.input_symbology import SymbologyN100
 MERGE_DIVIDED_ROADS_ALTERATIVE = False
 
 AREA_SELECTOR = "navn IN ('Oslo', 'Hamar')"
+AREA_SELECTOR = "navn IN ('Ringerike', 'Oslo')"
 SCALE = "n100"
 
 

--- a/input_data/input_fkb.py
+++ b/input_data/input_fkb.py
@@ -2,6 +2,13 @@
 import arcpy
 from config import fkb_path
 
+
+from config import fkb_river
+
+VannLinje = rf"{fkb_river}\fkb_vann_grense"
+VannFlate = rf"{fkb_river}\fkb_vann_omrade"
+VannPunkt = rf"{fkb_river}\fkb_vann_posisjon"
+
 # Defining universal paths for fkb regardless of local path env_setup
 fkb_lufthavn_grense = rf"{fkb_path}\fkb_lufthavn_grense"
 fkb_lufthavn_omrade = rf"{fkb_path}\fkb_lufthavn_omrade"

--- a/input_data/input_other.py
+++ b/input_data/input_other.py
@@ -3,3 +3,4 @@ import config
 
 # Defining universal paths for other files regardless of local path env_setup
 matrikkel_bygningspunkt = rf"{config.matrikkel_path}\bygning"
+RiverBasins = rf"{config.river_basin_polygon}\Nedborfelt_Vassdragsomr"


### PR DESCRIPTION
  1. Summary

  - New class FillLineGaps plus supporting TopologyBuilder and helper dataclasses in line_topology.py
  - Closes small end-of-line gaps by snapping, extending, or inserting a new connector at dangle endpoints.
  - Entry point: FillLineGaps(config).run(); config is logic_config.FillLineGapsConfig.

  2. Motivation

  - A lot of line data contains topology holes which will cause issues when we need to do operations requiring a traversable network. This class and helper classes is tasked with handling this for different types of data such as roads, rivers etc. 

  3. Public surface

  - Inputs: input_lines, optional connect_to_features, fill_gaps_on_self, gap_tolerance_meters.
  - Outputs:
    - output_lines — edited polyline FC (required).
    - line_changes_output — optional per-edit metadata FC.
    - candidate_connections_output — optional diagnostic FC (one row per (dangle, candidate) pair).
  - Sentinel fields stamped on output: ORIGINAL_ID = "line_gap_original_id", FIELD_GAP_GENERATED =
  "fill_line_gap_generated".

  4. Decision pipeline (four scopes)

  Documented inline in the class docstring and orchestrated by _build_plan → _apply_plan:
  - CANDIDATE — angle/polyline caches, legality gates (distance, network, illegal-target, barrier/crossing), one
   angle-aware proposal per dangle.
  - NETWORK — one winner per undirected A↔B connection; Z re-normalized inside each connection group.
  - KRUSKAL — cycle prevention and accepted-connector crossing checks across connection winners.
  - DEFERRED (resnap) — post-apply re-projection for connectors whose target endpoint moved during _apply_plan,
  with optional crossing recheck.
  - Reviewer note: each rejection is attributed to the earliest scope that can prove it — diagnostic rows carry
  the deciding scope.

  5. Edit operations

  - _resolve_edit_op maps edit_method × gap_source to one of SNAP, EXTEND, NEW_LINE.
  - AUTO snaps dangle-to-dangle pairs and extends everything else; FORCED_SNAP, FORCED_EXTEND, NEW_LINE ignore
  gap_source.

  6. Scoring

  - Composite best-fit score over distance, angle, Z (weights from best_fit_weights).
  - Distance-only is the default (angle=0.0, z=0.0).
  - Edge-case bonus governed by increased_tolerance_edge_case_distance_meters and the mutual-dangle-preference
  toggle.

  7. Diagnostics & observability

  - candidate_connections_output writes per-candidate rows tagged with the scope that decided the outcome —
  useful for explaining why a specific gap was or was not closed.
  - line_changes_output records gap distance, source, and edit op per applied edit.

