### PR TITLE
563 frequent shifting between over and under line cut off

### DIFF
--- a/file_manager/n10/file_manager_arealdekke.py
+++ b/file_manager/n10/file_manager_arealdekke.py
@@ -31,6 +31,7 @@ fill_holes = "fill_holes"
 small_features_changer = "small_features_changer"
 poly_to_point = "poly_to_point"
 remove_thin_tracks = "remove_thin_tracks"
+river_lines = "river_lines"
 
 
 class Arealdekke_N10(Enum):
@@ -161,6 +162,10 @@ class Arealdekke_N10(Enum):
 
     buffed_polygon_segments__n10_land_use = file_manager.generate_file_name_gdb(
         script_source_name=buff_polygon_segments, description="buffed_polygon_segments"
+    )
+
+    river_lines__n10_land_use = file_manager.generate_file_name_gdb(
+        script_source_name=river_lines, description="river_lines"
     )
 
     # ========================================

--- a/generalization/n10/arealdekke/category_tools/area_aggregator.py
+++ b/generalization/n10/arealdekke/category_tools/area_aggregator.py
@@ -4,21 +4,13 @@ import arcpy
 
 arcpy.env.overwriteOutput = True
 
-from pathlib import Path
 from collections import defaultdict
 
 from composition_configs import core_config
 from custom_tools.decorators.timing_decorator import timing_decorator
-from custom_tools.general_tools.param_utils import initialize_params
-from custom_tools.general_tools.param_utils import initialize_params
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    EliminateSmallPolygonsParameters,
-)
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    EliminateSmallPolygonsParameters,
-)
+from generalization.n10.arealdekke.parameters.parameter_worker import get_min_area
 
 # ========================
 # Main function
@@ -50,7 +42,7 @@ def aggregate_category(
     wfm = WorkFileManager(config=config)
 
     files = create_wfm_gdbs(wfm=wfm)
-    min_area = fetch_min_area(map_scale=map_scale, target=target)
+    min_area = get_min_area(map_scale=map_scale, target=target)
     sql = ", ".join([f"'{lu}'" for lu in allowed])
 
     data_selection(
@@ -60,9 +52,12 @@ def aggregate_category(
         min_area=min_area,
         sql=sql,
     )
-    if boundary:
-        boundary_adjustments(files=files, target=target, boundary=boundary, sql=sql)
-    rewrite_attribute_info(files=files, target=target, boundary=boundary is not None)
+    if int(arcpy.management.GetCount(files["target"])[0]) > 0:
+        if boundary:
+            boundary_adjustments(files=files, target=target, boundary=boundary, sql=sql)
+        rewrite_attribute_info(
+            files=files, target=target, boundary=boundary is not None
+        )
 
     arcpy.management.CopyFeatures(
         in_features=files["copy_of_input"],
@@ -107,20 +102,6 @@ def create_wfm_gdbs(wfm: WorkFileManager) -> dict:
             file_name="near_expanded", file_type="gdb"
         ),
     }
-
-
-def fetch_min_area(map_scale: str, target: str) -> int:
-    """
-    Fetches the minimum area for the target feature in the given map scale.
-    """
-    params_path = Path(__file__).parent.parent / "parameters" / "parameters.yml"
-    params = initialize_params(
-        params_path=params_path,
-        class_name="EliminateSmallPolygons",
-        map_scale=map_scale.upper(),
-        dataclass=EliminateSmallPolygonsParameters,
-    )
-    return params.min_area[target]
 
 
 def data_selection(

--- a/generalization/n10/arealdekke/category_tools/buff_small_polygon_segments.py
+++ b/generalization/n10/arealdekke/category_tools/buff_small_polygon_segments.py
@@ -1,22 +1,65 @@
-from enum import Enum
-from pathlib import Path
+# Libraries
 
 import arcpy
 
+arcpy.env.overwriteOutput = True
+
+from enum import StrEnum
+
 from composition_configs import core_config
 from custom_tools.decorators.timing_decorator import timing_decorator
-from custom_tools.general_tools.param_utils import initialize_params
 from custom_tools.general_tools.validation import check_valid_feature_class
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 from generalization.n10.arealdekke.overall_tools.overlap_merger import (
     create_overlapping_land_use,
 )
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    buff_small_polygon_segments_parameters,
+from generalization.n10.arealdekke.parameters.parameter_worker import (
+    get_min_width,
 )
 
-arcpy.env.overwriteOutput = True
+# ========================
+# Classes
+# ========================
+
+
+class fc(StrEnum):
+    """
+    What:
+        Enum class used to easier spot when a filepath does not exist in the files dictionary.
+    """
+
+    target_fc = "target_fc"
+    locked_fc = "locked_fc"
+    locked_areas_outside_buffer = "locked_areas_outside_buffer"
+    input_polygon_edge = "input_polygon_edge"
+    input_polygon_minus_buffer = "input_polygon_minus_buffer"
+    core_of_segments_wide_enough = "core_of_segments_wide_enough"
+    segments_wide_enough = "segments_wide_enough"
+    core_wide_enough_segments_singlepart = "core_wide_enough_segments_singlepart"
+    segments_too_small = "segments_too_small"
+    segments_too_small_single = "segments_too_small_single"
+    overkill_buffer = "overkill_buffer"
+    areas_chosen = "areas_chosen"
+    centre_line = "centre_line"
+    small_segments_centre = "small_segments_centre"
+    small_segments_enlarged = "small_segments_enlarged"
+    small_segments_locked_buffed_merged = "small_segments_locked_buffed_merged"
+    small_segments_locked_buffed_dissolved = "small_segments_locked_buffed_dissolved"
+    locked_fc_line = "locked_fc_line"
+    locked_fc_line_clipped = "locked_fc_line_clipped"
+    locked_fc_line_clipped_n_buffed_fc = "locked_fc_line_clipped_n_buffed_fc"
+    locked_fc_line_intersecting = "locked_fc_line_intersecting"
+    locked_fc_outward_buffer = "locked_fc_outward_buffer"
+    only_small_segments_centre = "only_small_segments_centre"
+    test = "test"
+    work_fc = "work_fc"
+    output_fc = "output_fc"
+
+
+# ========================
+# Main function
+# ========================
 
 
 @timing_decorator
@@ -43,11 +86,14 @@ def buff_small_polygon_segments(
     working_fc = Arealdekke_N10.buffed_polygon_segments__n10_land_use.value
     config = core_config.WorkFileConfig(root_file=working_fc)
     wfm = WorkFileManager(config=config)
-    files = files_setup(wfm=wfm)
 
-    min_width = get_min_width(map_scale=map_scale, target=target)
+    files = file_setup(wfm=wfm)
+    min_width = get_min_width(
+        map_scale=map_scale,
+        target=target,
+    )
 
-    extract_data(files=files, target_fc=target, locked_fc=locked_fc, input_fc=input_fc)
+    extract_data(files=files, target_fc=target, input_fc=input_fc, locked_fc=locked_fc)
 
     if check_valid_feature_class(files[fc.target_fc], level=2):
         find_segments_under_min(files=files, min_width=min_width)
@@ -63,43 +109,15 @@ def buff_small_polygon_segments(
     else:
         arcpy.management.CopyFeatures(in_features=input_fc, out_feature_class=output_fc)
 
-    wfm.delete_created_files()
+    # wfm.delete_created_files()
 
 
-class fc(Enum):
-    """
-    What:
-        Enum class used to easier spot when a filepath does not exist in the files dictionary.
-    """
-
-    target_fc = "target_fc"
-    locked_fc = "locked_fc"
-    locked_areas_outside_buffer = "locked_areas_outside_buffer"
-    input_polygon_edge = "input_polygon_edge"
-    input_polygon_minus_buffer = "input_polygon_minus_buffer"
-    core_of_segments_wide_enough = "core_of_segments_wide_enough"
-    segments_wide_enough = "segments_wide_enough"
-    core_wide_enough_segments_singlepart = "core_wide_enough_segments_singlepart"
-    segments_too_small = "segments_too_small"
-    segments_too_small_single = "segments_too_small_single"
-    overkill_buffer = "overkill_buffer"
-    areas_chosen = "areas_chosen"
-    centre_line = "centre_line"
-    small_segments_centre = "small_segments_centre"
-    small_segments_enlarged = "small_segments_enlarged"
-    small_segments_locked_buffed_merged = "small_segments_locked_buffed_merged"
-    small_segments_locked_buffed_dissolved = "small_segments_locked_buffed_dissolved"
-    locked_fc_line = "locked_fc_line"
-    locked_fc_line_clipped = "locked_fc_line_clipped"
-    locked_fc_line_intersecting = "locked_fc_line_intersecting"
-    locked_fc_outward_buffer = "locked_fc_outward_buffer"
-    only_small_segments_centre = "only_small_segments_centre"
-    test = "test"
-    work_fc = "work_fc"
-    output_fc = "output_fc"
+# ========================
+# Helper functions
+# ========================
 
 
-def files_setup(wfm: WorkFileManager) -> dict:
+def file_setup(wfm: WorkFileManager) -> dict:
     """
     Creates all the temporary files that are going to
     be used during the process of buffer thin areas.
@@ -111,125 +129,109 @@ def files_setup(wfm: WorkFileManager) -> dict:
         dict: A dictionary with all the files as variables
     """
     return {
-        fc.target_fc: wfm.build_file_path(file_name="target_fc", file_type="gdb"),
-        fc.locked_fc: wfm.build_file_path(file_name="locked_fc", file_type="gdb"),
+        fc.target_fc: wfm.build_file_path(file_name=fc.target_fc, file_type="gdb"),
+        fc.locked_fc: wfm.build_file_path(file_name=fc.locked_fc, file_type="gdb"),
         fc.locked_areas_outside_buffer: wfm.build_file_path(
-            file_name="locked_areas_outside_buffer", file_type="gdb"
+            file_name=fc.locked_areas_outside_buffer, file_type="gdb"
         ),
         fc.locked_fc_line: wfm.build_file_path(
-            file_name="locked_fc_line", file_type="gdb"
+            file_name=fc.locked_fc_line, file_type="gdb"
         ),
         fc.locked_fc_line_clipped: wfm.build_file_path(
-            file_name="locked_fc_line_clipped", file_type="gdb"
+            file_name=fc.locked_fc_line_clipped, file_type="gdb"
+        ),
+        fc.locked_fc_line_clipped_n_buffed_fc: wfm.build_file_path(
+            file_name=fc.locked_fc_line_clipped_n_buffed_fc, file_type="gdb"
         ),
         fc.input_polygon_edge: wfm.build_file_path(
-            file_name="input_polygon_edge", file_type="gdb"
+            file_name=fc.input_polygon_edge, file_type="gdb"
         ),
         fc.input_polygon_minus_buffer: wfm.build_file_path(
-            file_name="input_polygon_minus_buffer", file_type="gdb"
+            file_name=fc.input_polygon_minus_buffer, file_type="gdb"
         ),
         fc.core_of_segments_wide_enough: wfm.build_file_path(
-            file_name="core_of_segments_wide_enough", file_type="gdb"
+            file_name=fc.core_of_segments_wide_enough, file_type="gdb"
         ),
         fc.segments_wide_enough: wfm.build_file_path(
-            file_name="segments_wide_enough", file_type="gdb"
+            file_name=fc.segments_wide_enough, file_type="gdb"
         ),
         fc.core_wide_enough_segments_singlepart: wfm.build_file_path(
-            file_name="core_wide_enough_segments_singlepart", file_type="gdb"
+            file_name=fc.core_wide_enough_segments_singlepart, file_type="gdb"
         ),
         fc.segments_too_small: wfm.build_file_path(
-            file_name="segments_too_small", file_type="gdb"
+            file_name=fc.segments_too_small, file_type="gdb"
         ),
         fc.segments_too_small_single: wfm.build_file_path(
-            file_name="segments_too_small_single", file_type="gdb"
+            file_name=fc.segments_too_small_single, file_type="gdb"
         ),
         fc.overkill_buffer: wfm.build_file_path(
-            file_name="overkill_buffer", file_type="gdb"
+            file_name=fc.overkill_buffer, file_type="gdb"
         ),
-        fc.areas_chosen: wfm.build_file_path(file_name="areas_chosen", file_type="gdb"),
+        fc.areas_chosen: wfm.build_file_path(
+            file_name=fc.areas_chosen, file_type="gdb"
+        ),
         fc.locked_fc_line_intersecting: wfm.build_file_path(
-            file_name="locked_fc_line_intersecting", file_type="gdb"
+            file_name=fc.locked_fc_line_intersecting, file_type="gdb"
         ),
         fc.locked_fc_outward_buffer: wfm.build_file_path(
-            file_name="locked_fc_outward_buffer", file_type="gdb"
+            file_name=fc.locked_fc_outward_buffer, file_type="gdb"
         ),
         fc.only_small_segments_centre: wfm.build_file_path(
-            file_name="only_small_segments_centre", file_type="gdb"
+            file_name=fc.only_small_segments_centre, file_type="gdb"
         ),
-        fc.centre_line: wfm.build_file_path(file_name="centre_line", file_type="gdb"),
+        fc.centre_line: wfm.build_file_path(file_name=fc.centre_line, file_type="gdb"),
         fc.small_segments_centre: wfm.build_file_path(
-            file_name="small_segments_centre", file_type="gdb"
+            file_name=fc.small_segments_centre, file_type="gdb"
         ),
         fc.small_segments_enlarged: wfm.build_file_path(
-            file_name="small_segments_enlarged", file_type="gdb"
+            file_name=fc.small_segments_enlarged, file_type="gdb"
         ),
         fc.small_segments_locked_buffed_merged: wfm.build_file_path(
-            file_name="small_segments_locked_buffed_merged", file_type="gdb"
+            file_name=fc.small_segments_locked_buffed_merged, file_type="gdb"
         ),
         fc.small_segments_locked_buffed_dissolved: wfm.build_file_path(
-            file_name="small_segments_locked_buffed_dissolved", file_type="gdb"
+            file_name=fc.small_segments_locked_buffed_dissolved, file_type="gdb"
         ),
-        fc.test: wfm.build_file_path(file_name="test", file_type="gdb"),
-        fc.work_fc: wfm.build_file_path(file_name="work_fc", file_type="gdb"),
-        fc.output_fc: wfm.build_file_path(file_name="output_fc", file_type="gdb"),
+        fc.test: wfm.build_file_path(file_name=fc.test, file_type="gdb"),
+        fc.work_fc: wfm.build_file_path(file_name=fc.work_fc, file_type="gdb"),
+        fc.output_fc: wfm.build_file_path(file_name=fc.output_fc, file_type="gdb"),
     }
 
 
-def get_min_width(map_scale: str, target: str) -> int:
-    """
-    Extracts the minimum width for the target land use from the parameters.yml file in the parameters folder.
-
-    Args:
-        map_scale (str): Scale for current map
-        target (str): Name of land use type to consider
-
-    Returns:
-        int: Minimum width for relevant land use type
-    """
-    params_path = Path(__file__).parent.parent / "parameters" / "parameters.yml"
-
-    scale_parameters = initialize_params(
-        params_path=params_path,
-        class_name="BuffSmallPolygonSegments",
-        map_scale=map_scale,
-        dataclass=buff_small_polygon_segments_parameters,
-    )
-
-    return scale_parameters.min_width[target]
-
-
-def extract_data(files: dict, target_fc: str, locked_fc: set, input_fc) -> None:
+def extract_data(files: dict, target_fc: str, input_fc: str, locked_fc: str) -> None:
     """
     What:
         Extracts data for the program from the parameters and insert them into the files dictionary.
         For locked files, only the areas that share a boundry with the target polygons are selected and
         stored.
     """
-
-    target_fc_lyr = "target_fc_lyr"
-    where = f"arealdekke='{target_fc}'"
+    land_use_lyr = "land_use_lyr"
     arcpy.management.MakeFeatureLayer(
-        in_features=input_fc, out_layer=target_fc_lyr, where_clause=where
+        in_features=input_fc,
+        out_layer=land_use_lyr,
+    )
+    arcpy.management.SelectLayerByAttribute(
+        in_layer_or_view=land_use_lyr,
+        selection_type="NEW_SELECTION",
+        where_clause=f"arealdekke='{target_fc}'",
     )
     arcpy.management.CopyFeatures(
-        in_features=target_fc_lyr, out_feature_class=files[fc.target_fc]
+        in_features=land_use_lyr, out_feature_class=files[fc.target_fc]
     )
 
-    if locked_fc:
-        locked_fc_lyr = "locked_fc_lyr"
+    if int(arcpy.management.GetCount(locked_fc)[0]) > 0:
         arcpy.management.MakeFeatureLayer(
-            in_features=input_fc,
-            out_layer=locked_fc_lyr,
+            in_features=locked_fc,
+            out_layer=land_use_lyr,
         )
-
         arcpy.management.SelectLayerByLocation(
-            in_layer=locked_fc_lyr,
+            in_layer=land_use_lyr,
             overlap_type="SHARE_A_LINE_SEGMENT_WITH",
-            select_features=target_fc_lyr,
+            select_features=files[fc.target_fc],
             selection_type="NEW_SELECTION",
         )
         arcpy.management.CopyFeatures(
-            in_features=locked_fc_lyr, out_feature_class=files[fc.locked_fc]
+            in_features=land_use_lyr, out_feature_class=files[fc.locked_fc]
         )
 
 
@@ -248,20 +250,17 @@ def find_segments_under_min(files: dict, min_width: int) -> None:
     arcpy.management.PolygonToLine(
         in_features=files[fc.target_fc], out_feature_class=files[fc.input_polygon_edge]
     )
-
     arcpy.analysis.Buffer(
         in_features=files[fc.input_polygon_edge],
         out_feature_class=files[fc.input_polygon_minus_buffer],
         buffer_distance_or_field=f"{min_width/2} Meters",
         line_side="FULL",
     )
-
     arcpy.analysis.Erase(
         in_features=files[fc.target_fc],
         erase_features=files[fc.input_polygon_minus_buffer],
         out_feature_class=files[fc.core_of_segments_wide_enough],
     )
-
     arcpy.management.RepairGeometry(
         in_features=files[fc.core_of_segments_wide_enough], delete_null="DELETE_NULL"
     )
@@ -269,13 +268,11 @@ def find_segments_under_min(files: dict, min_width: int) -> None:
         in_features=files[fc.core_of_segments_wide_enough],
         out_feature_class=files[fc.core_wide_enough_segments_singlepart],
     )
-
     arcpy.analysis.PairwiseBuffer(
         in_features=files[fc.core_wide_enough_segments_singlepart],
         out_feature_class=files[fc.segments_wide_enough],
         buffer_distance_or_field=f"{min_width/2} Meters",
     )
-
     arcpy.analysis.Erase(
         in_features=files[fc.target_fc],
         erase_features=files[fc.segments_wide_enough],
@@ -297,19 +294,11 @@ def choose_target_areas(files: dict, min_width: int) -> None:
         buffer_distance_or_field=f"{min_width} Meters",
         line_side="FULL",
     )
-
-    try:
-        arcpy.analysis.PairwiseClip(
-            in_features=files[fc.target_fc],
-            clip_features=files[fc.overkill_buffer],
-            out_feature_class=files[fc.areas_chosen],
-        )
-    except:
-        arcpy.analysis.Clip(
-            in_features=files[fc.target_fc],
-            clip_features=files[fc.overkill_buffer],
-            out_feature_class=files[fc.areas_chosen],
-        )
+    arcpy.analysis.PairwiseClip(
+        in_features=files[fc.target_fc],
+        clip_features=files[fc.overkill_buffer],
+        out_feature_class=files[fc.areas_chosen],
+    )
 
 
 def get_shared_locked_boundary(files: dict, min_width: int) -> None:
@@ -318,24 +307,19 @@ def get_shared_locked_boundary(files: dict, min_width: int) -> None:
         Finds the boundaries between the target polygon and the locked polygons. Then, it creates a
         buffer going outwards from the locked areas.
     """
-    locked_fc_lyr = "locked_fc_lyr"
+    land_use_lyr = "land_use_lyr"
     arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.locked_fc], out_layer=locked_fc_lyr
+        in_features=files[fc.locked_fc], out_layer=land_use_lyr
     )
     arcpy.management.SelectLayerByLocation(
-        in_layer=locked_fc_lyr,
+        in_layer=land_use_lyr,
         overlap_type="INTERSECT",
         select_features=files[fc.overkill_buffer],
         selection_type="NEW_SELECTION",
     )
 
     arcpy.management.PolygonToLine(
-        in_features=locked_fc_lyr, out_feature_class=files[fc.locked_fc_line]
-    )
-
-    locked_fc_line_lyr = "locked_fc_line_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.locked_fc_line], out_layer=locked_fc_line_lyr
+        in_features=land_use_lyr, out_feature_class=files[fc.locked_fc_line]
     )
 
     arcpy.analysis.PairwiseClip(
@@ -422,7 +406,7 @@ def get_shared_locked_boundary(files: dict, min_width: int) -> None:
     )
     arcpy.analysis.Erase(
         in_features=locked_areas_outside_buffer_lyr,
-        erase_features=locked_fc_lyr,
+        erase_features=files[fc.locked_fc_line],
         out_feature_class=files[fc.locked_fc_outward_buffer],
     )
 
@@ -487,3 +471,29 @@ def buff_small_segments(files: dict, min_width: int) -> None:
         out_feature_class=files[fc.small_segments_locked_buffed_dissolved],
         buffer_distance_or_field=f"{min_width/2} Meters",
     )
+
+
+if __name__ == "__main__":
+    # """
+    target = "ElvFlate"
+    locked = "Samferdsel"
+
+    input_fc = Arealdekke_N10.attribute_changer_output__n10_land_use.value
+
+    lyr1 = "lyr1"
+    lyr2 = "lyr2"
+    arcpy.management.MakeFeatureLayer(
+        in_features=input_fc, out_layer=lyr1, where_clause=f"arealdekke='{target}'"
+    )
+    arcpy.management.MakeFeatureLayer(
+        in_features=input_fc, out_layer=lyr2, where_clause=f"arealdekke='{locked}'"
+    )
+
+    buff_small_polygon_segments(
+        target=target,
+        input_fc=lyr1,
+        output_fc=Arealdekke_N10.elim_output.value,
+        locked_fc=lyr2,
+        map_scale="N10",
+    )
+    # """

--- a/generalization/n10/arealdekke/category_tools/buff_small_polygon_segments.py
+++ b/generalization/n10/arealdekke/category_tools/buff_small_polygon_segments.py
@@ -1,5 +1,7 @@
 # Libraries
 
+from importlib.metadata import files
+
 import arcpy
 
 arcpy.env.overwriteOutput = True
@@ -17,6 +19,14 @@ from generalization.n10.arealdekke.overall_tools.overlap_merger import (
 from generalization.n10.arealdekke.parameters.parameter_worker import (
     get_min_width,
 )
+
+# ========================
+# Constants
+# ========================
+
+
+LINE = {"ElvFlate": Arealdekke_N10.river_lines__n10_land_use.value}
+
 
 # ========================
 # Classes
@@ -49,12 +59,21 @@ class fc(StrEnum):
     locked_fc_line = "locked_fc_line"
     locked_fc_line_clipped = "locked_fc_line_clipped"
     locked_fc_line_clipped_n_buffed_fc = "locked_fc_line_clipped_n_buffed_fc"
+    areas_chosen_within_locked_fc = "areas_chosen_within_locked_fc"
+    areas_chosen_within_locked_buffed_fc = "areas_chosen_within_locked_buffed_fc"
     locked_fc_line_intersecting = "locked_fc_line_intersecting"
     locked_fc_outward_buffer = "locked_fc_outward_buffer"
     only_small_segments_centre = "only_small_segments_centre"
     test = "test"
     work_fc = "work_fc"
     output_fc = "output_fc"
+    mini_buffer = "mini_buffer"
+    should_expand_candidates = "should_expand_candidates"
+    should_expand = "should_expand"
+    lines_to_keep_multipart = "lines_to_keep_multipart"
+    lines_to_expand = "lines_to_expand"
+    areas_to_delete = "areas_to_delete"
+    intermediate_target = "intermediate_target"
 
 
 # ========================
@@ -92,6 +111,7 @@ def buff_small_polygon_segments(
         map_scale=map_scale,
         target=target,
     )
+    to_line = target in LINE
 
     extract_data(files=files, target_fc=target, input_fc=input_fc, locked_fc=locked_fc)
 
@@ -99,7 +119,9 @@ def buff_small_polygon_segments(
         find_segments_under_min(files=files, min_width=min_width)
         choose_target_areas(files=files, min_width=min_width)
         get_shared_locked_boundary(files=files, min_width=min_width)
-        buff_small_segments(files=files, min_width=min_width)
+        buff_small_segments(
+            files=files, min_width=min_width, target=target, to_line=to_line
+        )
 
         create_overlapping_land_use(
             input_fc=files[fc.target_fc],
@@ -109,7 +131,9 @@ def buff_small_polygon_segments(
     else:
         arcpy.management.CopyFeatures(in_features=input_fc, out_feature_class=output_fc)
 
-    # wfm.delete_created_files()
+    print(f"\n✅ Buffering of small segments finished!\n{'====='*15}\n")
+
+    wfm.delete_created_files()
 
 
 # ========================
@@ -142,6 +166,12 @@ def file_setup(wfm: WorkFileManager) -> dict:
         ),
         fc.locked_fc_line_clipped_n_buffed_fc: wfm.build_file_path(
             file_name=fc.locked_fc_line_clipped_n_buffed_fc, file_type="gdb"
+        ),
+        fc.areas_chosen_within_locked_fc: wfm.build_file_path(
+            file_name=fc.areas_chosen_within_locked_fc, file_type="gdb"
+        ),
+        fc.areas_chosen_within_locked_buffed_fc: wfm.build_file_path(
+            file_name=fc.areas_chosen_within_locked_buffed_fc, file_type="gdb"
         ),
         fc.input_polygon_edge: wfm.build_file_path(
             file_name=fc.input_polygon_edge, file_type="gdb"
@@ -180,6 +210,25 @@ def file_setup(wfm: WorkFileManager) -> dict:
             file_name=fc.only_small_segments_centre, file_type="gdb"
         ),
         fc.centre_line: wfm.build_file_path(file_name=fc.centre_line, file_type="gdb"),
+        fc.mini_buffer: wfm.build_file_path(file_name=fc.mini_buffer, file_type="gdb"),
+        fc.should_expand_candidates: wfm.build_file_path(
+            file_name=fc.should_expand_candidates, file_type="gdb"
+        ),
+        fc.should_expand: wfm.build_file_path(
+            file_name=fc.should_expand, file_type="gdb"
+        ),
+        fc.lines_to_keep_multipart: wfm.build_file_path(
+            file_name=fc.lines_to_keep_multipart, file_type="gdb"
+        ),
+        fc.lines_to_expand: wfm.build_file_path(
+            file_name=fc.lines_to_expand, file_type="gdb"
+        ),
+        fc.areas_to_delete: wfm.build_file_path(
+            file_name=fc.areas_to_delete, file_type="gdb"
+        ),
+        fc.intermediate_target: wfm.build_file_path(
+            file_name=fc.intermediate_target, file_type="gdb"
+        ),
         fc.small_segments_centre: wfm.build_file_path(
             file_name=fc.small_segments_centre, file_type="gdb"
         ),
@@ -234,6 +283,8 @@ def extract_data(files: dict, target_fc: str, input_fc: str, locked_fc: str) -> 
             in_features=land_use_lyr, out_feature_class=files[fc.locked_fc]
         )
 
+    print("📦 Data extracted for target and locked areas")
+
 
 def find_segments_under_min(files: dict, min_width: int) -> None:
     """
@@ -279,6 +330,10 @@ def find_segments_under_min(files: dict, min_width: int) -> None:
         out_feature_class=files[fc.segments_too_small],
     )
 
+    print(
+        f"🔎 Segments under {min_width} meters found and extracted from target polygon"
+    )
+
 
 def choose_target_areas(files: dict, min_width: int) -> None:
     """
@@ -299,6 +354,7 @@ def choose_target_areas(files: dict, min_width: int) -> None:
         clip_features=files[fc.overkill_buffer],
         out_feature_class=files[fc.areas_chosen],
     )
+    print("🎯 Target areas chosen for further processing")
 
 
 def get_shared_locked_boundary(files: dict, min_width: int) -> None:
@@ -317,160 +373,167 @@ def get_shared_locked_boundary(files: dict, min_width: int) -> None:
         select_features=files[fc.overkill_buffer],
         selection_type="NEW_SELECTION",
     )
+    if int(arcpy.management.GetCount(land_use_lyr)[0]) > 0:
+        arcpy.management.PolygonToLine(
+            in_features=land_use_lyr, out_feature_class=files[fc.locked_fc_line]
+        )
+        arcpy.analysis.PairwiseClip(
+            in_features=files[fc.locked_fc_line],
+            clip_features=files[fc.overkill_buffer],
+            out_feature_class=files[fc.locked_fc_line_clipped],
+        )
+        arcpy.analysis.PairwiseBuffer(
+            in_features=files[fc.locked_fc_line_clipped],
+            out_feature_class=files[fc.locked_fc_line_clipped_n_buffed_fc],
+            buffer_distance_or_field=f"{min_width/2} Meters",
+        )
+        arcpy.analysis.Intersect(
+            in_features=[
+                files[fc.locked_fc_line_clipped_n_buffed_fc],
+                files[fc.areas_chosen],
+            ],
+            out_feature_class=files[fc.areas_chosen_within_locked_fc],
+        )
+        arcpy.analysis.PairwiseBuffer(
+            in_features=files[fc.areas_chosen_within_locked_fc],
+            out_feature_class=files[fc.areas_chosen_within_locked_buffed_fc],
+            buffer_distance_or_field=f"{min_width/2} Meter",
+        )
+        arcpy.analysis.Intersect(
+            in_features=[
+                files[fc.locked_fc_line_clipped],
+                files[fc.areas_chosen_within_locked_buffed_fc],
+            ],
+            out_feature_class=files[fc.locked_fc_line_intersecting],
+        )
+        arcpy.analysis.PairwiseBuffer(
+            in_features=files[fc.locked_fc_line_intersecting],
+            out_feature_class=files[fc.locked_areas_outside_buffer],
+            buffer_distance_or_field=f"{min_width/2} Meter",
+        )
+        arcpy.analysis.Erase(
+            in_features=files[fc.locked_areas_outside_buffer],
+            erase_features=land_use_lyr,
+            out_feature_class=files[fc.locked_fc_outward_buffer],
+        )
 
-    arcpy.management.PolygonToLine(
-        in_features=land_use_lyr, out_feature_class=files[fc.locked_fc_line]
+    print(
+        "↔️ Shared boundaries between target and locked areas found and buffered outwards"
     )
 
-    arcpy.analysis.PairwiseClip(
-        in_features=files[fc.locked_fc_line],
-        clip_features=files[fc.overkill_buffer],
-        out_feature_class=files[fc.locked_fc_line_clipped],
-    )
 
-    locked_fc_line_clipped_lyr = "locked_fc_line_clipped_lyr"
-    areas_chosen_lyr = "areas_chosen_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.locked_fc_line_clipped],
-        out_layer=locked_fc_line_clipped_lyr,
-    )
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.areas_chosen], out_layer=areas_chosen_lyr
-    )
-
-    locked_fc_line_clipped_n_buffed_fc = "in_memory/locked_fc_line_clipped_n_buffed_fc"
-    areas_chosen_within_locked_fc = "in_memory/areas_chosen_within_locked_fc"
-    areas_chosen_within_locked_buffed_fc = (
-        "in_memory/areas_chosen_within_locked_buffed_fc"
-    )
-
+def extract_below_limit(files: dict, target: str, min_width: int) -> None:
+    """
+    What:
+        Extracts the small segments from the original polygon.
+    """
+    lim = min_width / 2
+    output_fc = LINE[target]
     arcpy.analysis.PairwiseBuffer(
-        in_features=locked_fc_line_clipped_lyr,
-        out_feature_class=locked_fc_line_clipped_n_buffed_fc,
-        buffer_distance_or_field=f"{min_width/2} Meters",
-    )
-
-    locked_fc_line_clipped_n_buffed_lyr = "locked_fc_line_clipped_n_buffed_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=locked_fc_line_clipped_n_buffed_fc,
-        out_layer=locked_fc_line_clipped_n_buffed_lyr,
-    )
-
-    arcpy.analysis.Intersect(
-        in_features=[[locked_fc_line_clipped_n_buffed_lyr], [areas_chosen_lyr]],
-        out_feature_class=areas_chosen_within_locked_fc,
-    )
-
-    areas_chosen_within_locked_lyr = "areas_chosen_within_locked_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=areas_chosen_within_locked_fc,
-        out_layer=areas_chosen_within_locked_lyr,
-    )
-
-    arcpy.analysis.PairwiseBuffer(
-        in_features=areas_chosen_within_locked_lyr,
-        out_feature_class=areas_chosen_within_locked_buffed_fc,
-        buffer_distance_or_field=f"{min_width/2} Meter",
-    )
-
-    areas_chosen_within_locked_buffed_lyr = "areas_chosen_within_locked_buffed_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=areas_chosen_within_locked_buffed_fc,
-        out_layer=areas_chosen_within_locked_buffed_lyr,
-    )
-
-    arcpy.analysis.Intersect(
-        in_features=[
-            [locked_fc_line_clipped_lyr],
-            [areas_chosen_within_locked_buffed_lyr],
-        ],
-        out_feature_class=files[fc.locked_fc_line_intersecting],
-    )
-
-    locked_fc_line_intersecting_lyr = "locked_fc_line_intersecting_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.locked_fc_line_intersecting],
-        out_layer=locked_fc_line_intersecting_lyr,
-    )
-
-    arcpy.analysis.PairwiseBuffer(
-        in_features=locked_fc_line_intersecting_lyr,
-        out_feature_class=files[fc.locked_areas_outside_buffer],
-        buffer_distance_or_field=f"{min_width/2} Meter",
-    )
-
-    locked_areas_outside_buffer_lyr = "locked_areas_outside_buffer_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.locked_areas_outside_buffer],
-        out_layer=locked_areas_outside_buffer_lyr,
+        in_features=files[fc.input_polygon_edge],
+        out_feature_class=files[fc.mini_buffer],
+        buffer_distance_or_field=f"{lim / 2} Meters",
     )
     arcpy.analysis.Erase(
-        in_features=locked_areas_outside_buffer_lyr,
-        erase_features=files[fc.locked_fc_line],
-        out_feature_class=files[fc.locked_fc_outward_buffer],
+        in_features=files[fc.areas_chosen],
+        erase_features=files[fc.mini_buffer],
+        out_feature_class=files[fc.should_expand_candidates],
+    )
+    arcpy.analysis.PairwiseBuffer(
+        in_features=files[fc.should_expand_candidates],
+        out_feature_class=files[fc.should_expand],
+        buffer_distance_or_field=f"{lim / 2} Meters",
+    )
+    arcpy.analysis.Erase(
+        in_features=files[fc.small_segments_centre],
+        erase_features=files[fc.should_expand],
+        out_feature_class=files[fc.lines_to_keep_multipart],
+    )
+    arcpy.management.MultipartToSinglepart(
+        in_features=files[fc.lines_to_keep_multipart],
+        out_feature_class=output_fc,
+    )
+
+    land_use_lyr = "land_use_lyr"
+    arcpy.management.MakeFeatureLayer(
+        in_features=output_fc,
+        out_layer=land_use_lyr,
+    )
+    arcpy.management.SelectLayerByAttribute(
+        in_layer_or_view=land_use_lyr,
+        selection_type="NEW_SELECTION",
+        where_clause="Shape_Length < 10",
+    )
+    arcpy.management.DeleteFeatures(in_features=land_use_lyr)
+
+    arcpy.analysis.Buffer(
+        in_features=output_fc,
+        out_feature_class=files[fc.areas_to_delete],
+        buffer_distance_or_field=f"{lim} Meters",
+        line_side="FULL",
+        line_end_type="FLAT",
+    )
+    arcpy.analysis.Erase(
+        in_features=files[fc.target_fc],
+        erase_features=files[fc.areas_to_delete],
+        out_feature_class=files[fc.intermediate_target],
+    )
+    arcpy.management.CopyFeatures(
+        in_features=files[fc.intermediate_target], out_feature_class=files[fc.target_fc]
+    )
+
+    arcpy.analysis.Erase(
+        in_features=files[fc.small_segments_centre],
+        erase_features=output_fc,
+        out_feature_class=files[fc.lines_to_expand],
+    )
+
+    print(
+        f"📏 Especially small segments thinner than {lim} meters extracted from target polygon and stored in {LINE[target]}"
     )
 
 
-def buff_small_segments(files: dict, min_width: int) -> None:
+def buff_small_segments(
+    files: dict, min_width: int, target: str, to_line: bool = False
+) -> None:
     """
     What:
         Finds the centre line of the small polygon segments. Then erases large enough areas and
         buffed locked areas from them. Lastly, the line segments are buffed to the minimum width
         requirement for the target polygon and dissolved with the locked areas buffers.
     """
-
-    chosen_areas_lyr = "chosen_areas_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.areas_chosen], out_layer=chosen_areas_lyr
-    )
-
     arcpy.cartography.CollapseHydroPolygon(
-        in_features=chosen_areas_lyr,
+        in_features=files[fc.areas_chosen],
         out_line_feature_class=files[fc.centre_line],
         merge_adjacent_input_polygons="NO_MERGE",
     )
-
-    centre_line_lyr = "centre_line_lyr"
-    large_segments_lyr = "large_segments_lyr"
-    locked_fc_outward_buffer_lyr = "locked_fc_outward_buffer_lyr"
-
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.centre_line], out_layer=centre_line_lyr
-    )
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.segments_wide_enough], out_layer=large_segments_lyr
-    )
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.locked_fc_outward_buffer],
-        out_layer=locked_fc_outward_buffer_lyr,
-    )
     arcpy.analysis.Erase(
-        in_features=centre_line_lyr,
-        erase_features=large_segments_lyr,
+        in_features=files[fc.centre_line],
+        erase_features=files[fc.segments_wide_enough],
         out_feature_class=files[fc.small_segments_centre],
     )
 
-    small_segments_centre_lyr = "small_segments_centre_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.small_segments_centre], out_layer=small_segments_centre_lyr
-    )
-    arcpy.analysis.Erase(
-        in_features=small_segments_centre_lyr,
-        erase_features=locked_fc_outward_buffer_lyr,
-        out_feature_class=files[fc.only_small_segments_centre],
-    )
+    if to_line:
+        extract_below_limit(files=files, target=target, min_width=min_width)
 
-    only_small_segments_centre_lyr = "only_small_segments_centre_lyr"
-    arcpy.management.MakeFeatureLayer(
-        in_features=files[fc.only_small_segments_centre],
-        out_layer=only_small_segments_centre_lyr,
+    lines_to_expand = (
+        files[fc.lines_to_expand] if to_line else files[fc.small_segments_centre]
     )
+    status: bool = arcpy.Exists(files[fc.locked_fc_outward_buffer])
 
+    if status:
+        arcpy.analysis.Erase(
+            in_features=lines_to_expand,
+            erase_features=files[fc.locked_fc_outward_buffer],
+            out_feature_class=files[fc.only_small_segments_centre],
+        )
     arcpy.analysis.PairwiseBuffer(
-        in_features=only_small_segments_centre_lyr,
+        in_features=files[fc.only_small_segments_centre] if status else lines_to_expand,
         out_feature_class=files[fc.small_segments_locked_buffed_dissolved],
         buffer_distance_or_field=f"{min_width/2} Meters",
     )
+
+    print("⭕ Small segments buffered and dissolved with locked areas buffers")
 
 
 if __name__ == "__main__":

--- a/generalization/n10/arealdekke/category_tools/remove_thin_tracks.py
+++ b/generalization/n10/arealdekke/category_tools/remove_thin_tracks.py
@@ -9,8 +9,8 @@ from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 from generalization.n10.arealdekke.category_tools.buff_small_polygon_segments import (
     fc,
     find_segments_under_min,
-    get_min_width,
 )
+from generalization.n10.arealdekke.parameters.parameter_worker import get_min_width
 from generalization.n10.arealdekke.overall_tools.area_aggregator import (
     aggregate_small_features,
 )
@@ -45,7 +45,10 @@ def remove_thin_tracks(
     wfm = WorkFileManager(config=config)
 
     files = create_wfm_gdbs(wfm=wfm)
-    width = get_min_width(map_scale=map_scale, target=track_type)
+    width = get_min_width(
+        map_scale=map_scale,
+        target=target,
+    )
 
     fetch_data(
         files=files,

--- a/generalization/n10/arealdekke/category_tools/thin_poly_to_point.py
+++ b/generalization/n10/arealdekke/category_tools/thin_poly_to_point.py
@@ -15,8 +15,8 @@ from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 from generalization.n10.arealdekke.category_tools.buff_small_polygon_segments import (
     fc,
     find_segments_under_min,
-    get_min_width,
 )
+from generalization.n10.arealdekke.parameters.parameter_worker import get_min_width
 
 # ========================
 # Main function
@@ -49,8 +49,10 @@ def pointify_thin_poly(
     wfm = WorkFileManager(config=config)
 
     files = create_wfm_gdbs(wfm=wfm)
-
-    width = get_min_width(map_scale=map_scale, target=target)
+    width = get_min_width(
+        map_scale=map_scale,
+        target=target,
+    )
     locked_categories = {
         row[0] for row in arcpy.da.SearchCursor(locked_fc, ["arealdekke"])
     }

--- a/generalization/n10/arealdekke/orchestrator/arealdekke_class.py
+++ b/generalization/n10/arealdekke/orchestrator/arealdekke_class.py
@@ -233,7 +233,6 @@ class Arealdekke:
                 key=keys.preprocessed.value, value=True
             )
 
-    @timing_decorator
     def add_categories(self, categories_config_file: Path) -> None:
         """
         What:
@@ -278,6 +277,8 @@ class Arealdekke:
 
             except Exception as e:
                 raise e
+
+        print("\nCategories added to arealdekke object!\n")
 
     @timing_decorator
     def process_categories(self) -> None:
@@ -579,7 +580,9 @@ class Arealdekke:
                 output_fc=Arealdekke_N10.island_merger_output__n10_land_use.value,
             ),
             lambda: change_attribute_value_main(
-                working_fc=Arealdekke_N10.island_merger_output__n10_land_use.value,
+                input_fc=Arealdekke_N10.island_merger_output__n10_land_use.value,
+                map_scale=self.__map_scale,
+                target="Bebygd",
             ),
             lambda: aggregate_areas(
                 input_fc=Arealdekke_N10.island_merger_output__n10_land_use.value,

--- a/generalization/n10/arealdekke/overall_tools/README.md
+++ b/generalization/n10/arealdekke/overall_tools/README.md
@@ -13,7 +13,8 @@
 | Module Name       | Parameters | Return | File path | Description         |
 |-------------------|------------|--------|-----------|---------------------|
 |[**attribute_analyzer**](attribute_analyzer.py) | **** | **** | attribute_analyzer.py | File analyzing attribute data from csv file and lists. Core processes: <br/>- Sort_results <br/>- Write_to_file <br/>- Load_rules |
-|[**attribute_changer**](attribute_changer.py) | input_fc: str,<br/>output_fc: str | None | attribute_changer.py | Re-categorizes *'arealdekke'* based on the fields: *"Arealdekke", "Hovedklasse", "Underklasse", "Grunnforhold"*. Overwrites the original *"arealdekke"* field to replace it with two new fields: *"gammel_arealdekke"* and *"fremkommelighet"*.
+|[**attribute_changer**](attribute_changer.py) | input_fc: str,<br/>output_fc: str | None | attribute_changer.py | Re-categorizes *'arealdekke'* based on the fields: *"Arealdekke", "Hovedklasse", "Underklasse", "Grunnforhold"*. Overwrites the original *"arealdekke"* field to replace it with two new fields: *"gammel_arealdekke"* and *"fremkommelighet"*. |
+|[**change_attribute_value_main**](small_features_changer.py)| input_fc: str, <br/> map_scale: str, <br/> target: str | None | small_features_changer.py | Changes the land use category ('arealdekke') for small features to a secondary type or an exception type of land use because of cartographical cleanness. <br/> (Partially hardcoded for one case.)
 
 ##
 > [**Attribute_prioritizing.csv**](attribute_prioritizing.csv) is a CSV file that outlines how the arealdekke categories must be sorted and reclassified. Can be imported into other files as a dictionary. The file contains the following columns: <br/>- Arealdekke <br/>- Hovedklasse <br/>- Underklasse <br/>- Grunnforhold <br/>- Ny_arealdekke <br/>- Fremkommelighet

--- a/generalization/n10/arealdekke/overall_tools/area_aggregator.py
+++ b/generalization/n10/arealdekke/overall_tools/area_aggregator.py
@@ -15,7 +15,8 @@ from custom_tools.general_tools.param_utils import initialize_params
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 from generalization.n10.arealdekke.parameters.parameter_worker import (
-    get_min_area, get_min_width
+    get_min_area,
+    get_min_width,
 )
 from generalization.n10.arealdekke.overall_tools.overlap_remover import remove_overlaps
 

--- a/generalization/n10/arealdekke/overall_tools/area_aggregator.py
+++ b/generalization/n10/arealdekke/overall_tools/area_aggregator.py
@@ -14,9 +14,8 @@ from custom_tools.decorators.timing_decorator import timing_decorator
 from custom_tools.general_tools.param_utils import initialize_params
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    buff_small_polygon_segments_parameters,
-    EliminateSmallPolygonsParameters,
+from generalization.n10.arealdekke.parameters.parameter_worker import (
+    get_min_area, get_min_width
 )
 from generalization.n10.arealdekke.overall_tools.overlap_remover import remove_overlaps
 
@@ -58,11 +57,12 @@ def aggregate_areas(input_fc: str, output_fc: str, map_scale: str) -> None:
     )
 
     for feature in features.keys():
-        area, width = fetch_parameters(feature=feature, map_scale=map_scale)
+        min_area = get_min_area(map_scale=map_scale, target=feature)
+        min_width = get_min_width(map_scale=map_scale, target=feature)
 
-        tol = width * features[feature]
+        tol = min_width * features[feature]
 
-        data_selection(files=files, feature=feature, area_tol=area, tol=tol)
+        data_selection(files=files, feature=feature, area_tol=min_area, tol=tol)
         aggregate_small_features(files=files, tol=tol)
         combine_datasets(files=files)
         remove_overlaps(
@@ -123,45 +123,6 @@ def create_wfm_gdbs(wfm: WorkFileManager):
             file_name="processed_features", file_type="gdb"
         ),
     }
-
-
-def fetch_parameters(feature: str, map_scale: str) -> list:
-    """
-    Retrieves relevant minimum criterias for the relevant feature type.
-
-    Args:
-        feature (str): Name of the feature type to investigate
-        map_scale (str): Current map scale
-
-    Returns:
-        list: A list of the relevant parameteres for this specific feature
-    """
-    params_path = Path(__file__).parent.parent / "parameters" / "parameters.yml"
-
-    categories = [
-        ["EliminateSmallPolygons", EliminateSmallPolygonsParameters, "min_area"],
-        [
-            "BuffSmallPolygonSegments",
-            buff_small_polygon_segments_parameters,
-            "min_width",
-        ],
-    ]
-
-    params = []
-
-    for name, param_class, call in categories:
-        scale_parameters = initialize_params(
-            params_path=params_path,
-            class_name=name,
-            map_scale=map_scale,
-            dataclass=param_class,
-        )
-
-        params.append(getattr(scale_parameters, call)[feature])
-
-    print(f"⚙️  Parameters fetched for feature '{feature}' at map scale '{map_scale}'")
-
-    return params
 
 
 def data_selection(files: dict, feature: str, area_tol: int, tol: int) -> None:

--- a/generalization/n10/arealdekke/overall_tools/eliminate_small_polygons.py
+++ b/generalization/n10/arealdekke/overall_tools/eliminate_small_polygons.py
@@ -1,18 +1,17 @@
 import os
-from pathlib import Path
 
 import arcpy
 
 from composition_configs import core_config, logic_config
 from custom_tools.decorators.timing_decorator import timing_decorator
 from custom_tools.general_tools.geometry_tools import GeometryValidator
-from custom_tools.general_tools.param_utils import initialize_params
 from custom_tools.general_tools.partition_iterator import PartitionIterator
 from env_setup import environment_setup
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    EliminateSmallPolygonsParameters,
+from generalization.n10.arealdekke.parameters.parameter_worker import (
+    initialize_parameters,
+    get_min_area,
 )
 
 
@@ -33,13 +32,10 @@ class EliminateSmallPolygons:
         )
 
         self.map_scale = eliminate_small_polygons_config.map_scale
-        params_path = Path(__file__).parent.parent / "parameters" / "parameters.yml"
-        self.scale_parameters = initialize_params(
-            params_path=params_path,
-            class_name="EliminateSmallPolygons",
-            map_scale=self.map_scale,
-            dataclass=EliminateSmallPolygonsParameters,
+        self.eliminate_parameters = initialize_parameters(
+            map_scale=self.map_scale, class_name="EliminateSmallPolygons"
         )
+        self.area_parameters = get_min_area(map_scale=self.map_scale)
 
         self.files = self._create_wfm_gdbs(self.wfm)
 
@@ -126,7 +122,7 @@ class EliminateSmallPolygons:
         """
         include = "layer_include"
         exclude = "layer_exclude"
-        quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.exclude)
+        quoted = ", ".join(f"'{v}'" for v in self.eliminate_parameters.exclude)
         exclusion_sql = f"arealdekke NOT IN ({quoted})"
         not_exclusion_sql = f"arealdekke IN ({quoted})"
 
@@ -205,12 +201,12 @@ class EliminateSmallPolygons:
     def eliminate(self, input_fc, output_fc):
         """Eliminate small polygons based on area times isoperimetric quotient, while excluding rivers and samferdsel."""
         layer = "eliminate_layer"
-        quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.dont_eliminate)
+        quoted = ", ".join(f"'{v}'" for v in self.eliminate_parameters.dont_eliminate)
         exclusion_sql = f"arealdekke NOT IN ({quoted})"
         numeric_clauses = []
-        numeric_clauses.append(f"area < {self.scale_parameters.max_area_b_iq}")
+        numeric_clauses.append(f"area < {self.eliminate_parameters.max_area_b_iq}")
         numeric_clauses.append(
-            f"iq_adjusted_area < {self.scale_parameters.min_iq_area}"
+            f"iq_adjusted_area < {self.eliminate_parameters.min_iq_area}"
         )
 
         # combine all parts into one where clause
@@ -236,11 +232,11 @@ class EliminateSmallPolygons:
         self, input_fc: str, output_fc: str, run: int
     ) -> None:
         layer = "eliminate_layer"
-        quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.dont_eliminate)
+        quoted = ", ".join(f"'{v}'" for v in self.eliminate_parameters.dont_eliminate)
         exclusion_sql = f"arealdekke NOT IN ({quoted})"
 
         temp_in = input_fc
-        for arealdekke, min_area in self.scale_parameters.min_area.items():
+        for arealdekke, min_area in self.area_parameters.features.items():
             print(f"Eliminating: {arealdekke} - {min_area}")
             clauses = []
             clauses.append(f"arealdekke = '{arealdekke}'")
@@ -286,7 +282,9 @@ class EliminateSmallPolygons:
     def _buffer_potential_spikes(self):
         """Buffer all polygons except water and samferdsel to remove spikes"""
         layer = "eliminate_after_elim_layer"
-        quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.dont_remove_spikes)
+        quoted = ", ".join(
+            f"'{v}'" for v in self.eliminate_parameters.dont_remove_spikes
+        )
         exclusion_sql = f"arealdekke NOT IN ({quoted})"
 
         arcpy.management.MakeFeatureLayer(
@@ -297,12 +295,12 @@ class EliminateSmallPolygons:
         arcpy.analysis.Buffer(
             in_features=layer,
             out_feature_class=self.files["eliminate_selected_negative_buffers"],
-            buffer_distance_or_field=f"-{self.scale_parameters.spike_size} Meters",
+            buffer_distance_or_field=f"-{self.eliminate_parameters.spike_size} Meters",
         )
         arcpy.analysis.Buffer(
             in_features=self.files["eliminate_selected_negative_buffers"],
             out_feature_class=self.files["eliminate_selected_positive_buffers"],
-            buffer_distance_or_field=f"{self.scale_parameters.spike_size} Meters",
+            buffer_distance_or_field=f"{self.eliminate_parameters.spike_size} Meters",
         )
 
     def _clip_and_erase(self):
@@ -347,7 +345,9 @@ class EliminateSmallPolygons:
             input_fc=self.files["eliminate_merged_clipped_erased"], max_iterations=5
         )
 
-        quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.dont_remove_spikes)
+        quoted = ", ".join(
+            f"'{v}'" for v in self.eliminate_parameters.dont_remove_spikes
+        )
         exclusion_sql = f"arealdekke NOT IN ({quoted})"
         numeric_clauses = []
         numeric_clauses.append(f"area < 100")
@@ -370,7 +370,7 @@ class EliminateSmallPolygons:
     def _integrate(self, input_fc):
         arcpy.management.Integrate(
             in_features=input_fc,
-            cluster_tolerance=f"{self.scale_parameters.integrate_tolerance} Meters",
+            cluster_tolerance=f"{self.eliminate_parameters.integrate_tolerance} Meters",
         )
 
     @staticmethod
@@ -438,12 +438,12 @@ class EliminateSmallPolygons:
             out_feature_class=potential_holes_polygons,
         )
 
-        quoted = ", ".join(f"'{v}'" for v in self.scale_parameters.dont_eliminate)
+        quoted = ", ".join(f"'{v}'" for v in self.eliminate_parameters.dont_eliminate)
         exclusion_sql = f"arealdekke NOT IN ({quoted})"
         numeric_clauses = []
-        numeric_clauses.append(f"area < {self.scale_parameters.max_area_b_iq}")
+        numeric_clauses.append(f"area < {self.eliminate_parameters.max_area_b_iq}")
         numeric_clauses.append(
-            f"iq_adjusted_area < {self.scale_parameters.min_iq_area}"
+            f"iq_adjusted_area < {self.eliminate_parameters.min_iq_area}"
         )
         where_parts = [exclusion_sql] + numeric_clauses
         where_clause = " AND ".join(where_parts)

--- a/generalization/n10/arealdekke/overall_tools/fill_holes.py
+++ b/generalization/n10/arealdekke/overall_tools/fill_holes.py
@@ -8,6 +8,9 @@ from composition_configs import core_config
 from custom_tools.decorators.timing_decorator import timing_decorator
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
+from generalization.n10.arealdekke.category_tools.buff_small_polygon_segments import (
+    LINE,
+)
 
 # ========================
 # Main function
@@ -108,8 +111,10 @@ def remove_locked_features_from_input(
     )
 
     # Create Polygons of the holes
+    active_line_layers = [key for key in LINE.keys() if arcpy.Exists(key)]
     arcpy.management.FeatureToPolygon(
-        in_features=files["copy_of_input"], out_feature_class=files["complete"]
+        in_features=[files["copy_of_input"]] + active_line_layers,
+        out_feature_class=files["complete"],
     )
 
     land_use_lyr = "land_use_lyr"

--- a/generalization/n10/arealdekke/overall_tools/gangsykkel_dissolver.py
+++ b/generalization/n10/arealdekke/overall_tools/gangsykkel_dissolver.py
@@ -1,12 +1,10 @@
 from collections import defaultdict
-from pathlib import Path
 
 import arcpy
 
 from composition_configs import core_config, logic_config
 from custom_tools.decorators.timing_decorator import timing_decorator
 from custom_tools.general_tools.geometry_tools import GeometryValidator
-from custom_tools.general_tools.param_utils import initialize_params
 from custom_tools.general_tools.partition_iterator import PartitionIterator
 from env_setup import environment_setup
 from file_manager import WorkFileManager
@@ -17,8 +15,8 @@ from generalization.n10.arealdekke.overall_tools.arealdekke_dissolver import (
 from generalization.n10.arealdekke.overall_tools.eliminate_small_polygons import (
     EliminateSmallPolygons,
 )
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    GangSykkelDissolverParameters,
+from generalization.n10.arealdekke.parameters.parameter_worker import (
+    initialize_parameters,
 )
 
 
@@ -43,12 +41,8 @@ class GangSykkelDissolver:
         self.files = self._create_wfm_gdbs(self.wfm)
 
         self.map_scale = gang_sykkel_dissolver_config.map_scale
-        params_path = Path(__file__).parent.parent / "parameters" / "parameters.yml"
-        self.scale_parameters = initialize_params(
-            params_path=params_path,
-            class_name="GangSykkelDissolver",
-            map_scale=self.map_scale,
-            dataclass=GangSykkelDissolverParameters,
+        self.gang_sykkel_parameters = initialize_parameters(
+            map_scale=self.map_scale, class_name="GangSykkelDissolver"
         )
 
         self.geometry_validator = GeometryValidator()
@@ -283,7 +277,7 @@ class GangSykkelDissolver:
         arcpy.management.MakeFeatureLayer(
             in_features=self.files["gangsykkel_final_merge_singlepart"],
             out_layer=gangsykkel_final_merge_singlepart_lyr,
-            where_clause=f"arealbruk_underklasse = 'GangSykkelVeg' AND Shape_Length < {self.scale_parameters.length_divide}",
+            where_clause=f"arealbruk_underklasse = 'GangSykkelVeg' AND Shape_Length < {self.gang_sykkel_parameters.length_divide}",
         )
 
         arcpy.management.Eliminate(
@@ -417,12 +411,12 @@ class GangSykkelDissolver:
         arcpy.management.MakeFeatureLayer(
             in_features=clipped_path,
             out_layer=long_layer,
-            where_clause=f'"Shape_Length" > {self.scale_parameters.length_divide}',
+            where_clause=f'"Shape_Length" > {self.gang_sykkel_parameters.length_divide}',
         )
         arcpy.management.MakeFeatureLayer(
             in_features=clipped_path,
             out_layer=short_layer,
-            where_clause=f'"Shape_Length" <= {self.scale_parameters.length_divide}',
+            where_clause=f'"Shape_Length" <= {self.gang_sykkel_parameters.length_divide}',
         )
 
         arcpy.management.Append(
@@ -486,7 +480,7 @@ class GangSykkelDissolver:
         environment_setup.main()
         self._fetch_data()
         self._dissolve_looping(
-            buffer_distance=f"{self.scale_parameters.buffer_distance} Meters"
+            buffer_distance=f"{self.gang_sykkel_parameters.buffer_distance} Meters"
         )
         e_kwargs = logic_config.EliminateSmallPolygonsInitKwargs(
             input_feature="",

--- a/generalization/n10/arealdekke/overall_tools/overlap_merger.py
+++ b/generalization/n10/arealdekke/overall_tools/overlap_merger.py
@@ -5,7 +5,6 @@ import arcpy
 arcpy.env.overwriteOutput = True
 
 from composition_configs import core_config
-from custom_tools.decorators.timing_decorator import timing_decorator
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 
@@ -14,7 +13,6 @@ from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
 # ========================
 
 
-@timing_decorator
 def create_overlapping_land_use(
     input_fc: str,
     buffered_fc: str,
@@ -36,18 +34,17 @@ def create_overlapping_land_use(
 
     files = create_wfm_gdbs(wfm=wfm)
 
-    print("🔀 Merges buffered features with selected original land use …")
     arcpy.management.Merge(
         inputs=[buffered_fc, input_fc], output=files["temp_merge_fc"]
     )
-
-    print("🧩 Runs dissolve …")
     arcpy.management.Dissolve(
         in_features=files["temp_merge_fc"],
         out_feature_class=output_fc,
         dissolve_field=[],
         multi_part="SINGLE_PART",
     )
+
+    print("🗺️ Overlapping land use created and stored in output feature class")
 
     wfm.delete_created_files()
 

--- a/generalization/n10/arealdekke/overall_tools/small_features_changer.py
+++ b/generalization/n10/arealdekke/overall_tools/small_features_changer.py
@@ -1,7 +1,6 @@
 # Libraries
 
 import os
-from pathlib import Path
 
 import arcpy
 
@@ -9,12 +8,21 @@ arcpy.env.overwriteOutput = True
 
 from composition_configs import core_config
 from custom_tools.decorators.timing_decorator import timing_decorator
-from custom_tools.general_tools.param_utils import initialize_params
 from file_manager import WorkFileManager
 from file_manager.n10.file_manager_arealdekke import Arealdekke_N10
-from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
-    SmallFeatures,
+from generalization.n10.arealdekke.parameters.parameter_worker import (
+    get_min_area,
 )
+
+# ========================
+# Constants
+# ========================
+
+
+PARAMETER_MAPPING = {
+    "Bebygd": ["Snaumark", "Skog"],
+}
+
 
 # ========================
 # Program
@@ -22,16 +30,17 @@ from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
 
 
 @timing_decorator
-def change_attribute_value_main(working_fc: str) -> None:
-    params = fetch_parameters(map_scale="N10")
+def change_attribute_value_main(input_fc: str, map_scale: str, target: str) -> None:
+    min_area = get_min_area(map_scale=map_scale, target=target)
+    new_cat, ex_cat = PARAMETER_MAPPING[target]
 
     change_attribute_value_category(
-        working_fc=working_fc,
+        working_fc=input_fc,
         field="arealdekke",
-        category="Bebygd",
-        new_category="Snaumark",
-        size_limit=params.Bebygd,
-        exception_category="Skog",
+        category=target,
+        new_category=new_cat,
+        size_limit=min_area,
+        exception_category=ex_cat,
     )
 
 
@@ -252,26 +261,6 @@ def change_attribute_value_category(
 # ========================
 # Helper functions
 # ========================
-
-
-def fetch_parameters(map_scale: str) -> dict:
-    """
-    Fetches minimum area parameters for small features from the parameters.yml file for the given map scale.
-
-    Args:
-        map_scale (str): The map scale to fetch parameters for
-
-    Returns:
-        dict: A dictionary of minimum area parameters for small features for the given map scale
-    """
-    params_path = Path(__file__).parent.parent / "parameters" / "parameters.yml"
-    scale_parameters = initialize_params(
-        params_path=params_path,
-        class_name="SmallFeatures",
-        map_scale=map_scale,
-        dataclass=SmallFeatures,
-    )
-    return scale_parameters
 
 
 def create_wfm_gdbs(wfm: WorkFileManager) -> dict:

--- a/generalization/n10/arealdekke/parameters/README.md
+++ b/generalization/n10/arealdekke/parameters/README.md
@@ -9,4 +9,6 @@
 - LandUseParameters
 - buff_small_polygon_segments_parameters
 
+[**Parameter_worker.py**](parameter_worker.py). A collection of functionality to fetch parameters from the YAML file based on specific features and scales.
+
 [**Parameters.yml**](parameters.yml). Description and parameters for each function that needs elaborated parameters.

--- a/generalization/n10/arealdekke/parameters/old_parameters.yml
+++ b/generalization/n10/arealdekke/parameters/old_parameters.yml
@@ -1,0 +1,139 @@
+Description:
+  This is where parameters that can change based on map scale or general rules for the classes are stored.
+  Each object should correspond to a dataclass in parameter_dataclasses.py
+  Read these from class using initialize_params from param_utils.py  
+
+EliminateSmallPolygons:
+  descriptions: 
+    - eliminates all polygons with smaller areas than min_area
+    - eliminates areas smaller than both max_area_b_iq and min_iq_area,
+    - min_iq_area is area * isoperimetric quotient 
+    - max_area_b_iq is max size of polygon that can be eliminated if they have very low iq
+    - exclude is a list of arealdekke values that are not to be eliminated or eliminated into, including spikes
+    - dont_eliminate is list of arealdekke values that wont be eliminated but can still have others eliminated into them
+    - spike_size is size of buffer to detect spikes in meters, buffers from both sides of polygon so spike_size 2 = 4 meters
+    - dont_remove_spikes is list of arealdekke values wont be buffered for spike selection
+    - integrate_tolerance is cluster tolerance in meters on integrate run in the end to fix small holes
+
+  N10:
+    min_area: 
+      Snaumark: 225
+      Grøntområde: 900
+      Skog: 225
+      Jordbruk: 2500
+      Innmarksbeite: 2500
+      GravUrnelund: 900
+      Parkering: 900
+      Park: 900
+      Alpinbakke: 900
+      Golfbane: 900
+      IdrettsOmr: 900
+      Industri: 900
+      Bergverk: 900
+      LufthavnOmr: 2500
+      Tekniskanlegg: 2500
+      Bebygd: 4900
+      Høyblokkbebyggelse: 4900
+      Innsjo: 100
+      InnsjoRegulert: 100
+      Snøisbre: 3600
+      Myr: 225
+      
+
+    min_iq_area: 150   
+    max_area_b_iq: 1500 
+    exclude: 
+      - Samferdsel
+      - Bane
+    dont_eliminate:
+      - Samferdsel
+      - ElvFlate
+      - Kanal
+      - Hav
+      - Bane
+      - Høyblokkbebyggelse
+    spike_size: 3
+    dont_remove_spikes:
+      - Samferdsel
+      - ElvFlate
+      - Kanal
+      - Hav
+      - InnsjoRegulert
+      - Innsjo
+      - Bane
+    integrate_tolerance: 0.09
+
+
+
+  N100:
+    min_area: 0000
+    min_iq_area: 000         
+    dont_eliminate:
+      - Eksempel
+      - Eksempel
+      - Eksempel
+    spike_size: 0
+    dont_remove_spikes:
+      - Eksempel
+      - Eksempel
+      - Eksempel
+      - Eksempel
+      - Eksempel
+    integrate_tolerance: 0.0
+
+
+GangSykkelDissolver:
+  description:
+    - buffer distance is size of buffer that iterates out from roads to absorb gangvei
+    - length divide is length we use to decide if gangvei is adjecent to road or if they move out from road
+  N10:
+    buffer_distance: 5
+    length_divide: 45
+
+
+LandUse:
+  description:
+    - Each variable is the minimum width (in meters) of the land use type that is visible on a printed map
+  N10:
+    elvFlate: {"width": 6, "thin": True}
+
+
+BuffSmallPolygonSegments:
+  description:
+    - Buffs parts of polygons that are below a specified minimum value.
+  N10:
+    min_width: {
+      "Alpinbakke": 6,
+      "Bebygd": 10,
+      "Bergverk": 6,
+      "ElvFlate": 6,
+      "Golfbane": 6,
+      "GravUrnelund": 6,
+      "Grøntområde": 6,
+      "Hav": 6,
+      "Høyblokkbebyggelse": 10,
+      "IdrettsOmr": 6,
+      "Industri": 20,
+      "Innmarksbeite": 6,
+      "Innsjo": 6,
+      "InnsjoRegulert": 6,
+      "Jordbruk": 6,
+      "Kanal": 6,
+      "LufthavnOmr": 10,
+      "Myr": 6,
+      "Park": 6,
+      "Parkering": 6,
+      "Samferdsel": 6,
+      "Skog": 6,
+      "Snaumark": 6,
+      "Snøisbre": 20,
+      "TekniskAnlegg": 6
+    }
+
+
+SmallFeatures:
+  description:
+    - Changes attributes of small features to look more like the actual terrain
+    - Minimum areas for each category
+  N10:
+    Bebygd: 4900

--- a/generalization/n10/arealdekke/parameters/parameter_dataclasses.py
+++ b/generalization/n10/arealdekke/parameters/parameter_dataclasses.py
@@ -2,8 +2,17 @@ from pydantic.dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class MinArea:
+    features: dict[str, int]
+
+
+@dataclass(frozen=True)
+class MinWidth:
+    features: dict[str, int]
+
+
+@dataclass(frozen=True)
 class EliminateSmallPolygonsParameters:
-    min_area: dict[str, int]
     min_iq_area: int
     max_area_b_iq: int
     exclude: list[str]
@@ -17,13 +26,3 @@ class EliminateSmallPolygonsParameters:
 class GangSykkelDissolverParameters:
     buffer_distance: int
     length_divide: int
-
-
-@dataclass(frozen=True)
-class buff_small_polygon_segments_parameters:
-    min_width: dict
-
-
-@dataclass(frozen=True)
-class SmallFeatures:
-    Bebygd: int

--- a/generalization/n10/arealdekke/parameters/parameter_worker.py
+++ b/generalization/n10/arealdekke/parameters/parameter_worker.py
@@ -1,0 +1,71 @@
+# Libraries
+
+from pathlib import Path
+
+from custom_tools.general_tools.param_utils import initialize_params
+from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
+    MinArea,
+    MinWidth,
+)
+
+# ========================
+# Constants
+# ========================
+
+
+PARAMS_PATH = Path(__file__).parent.parent / "parameters" / "parameters.yml"
+AREA_CLASS = "MinArea"
+WIDTH_CLASS = "MinWidth"
+
+
+# ========================
+# Functionality
+# ========================
+
+
+def get_min_width(
+    map_scale: str,
+    target: str,
+) -> int:
+    """
+    Extracts the minimum width for the target land use from the parameters.yml file in the parameters folder.
+
+    Args:
+        map_scale (str): Scale for current map
+        target (str): Name of land use type to consider
+
+    Returns:
+        int: Minimum width for relevant land use type
+    """
+    scale_parameters = initialize_params(
+        params_path=PARAMS_PATH,
+        class_name=WIDTH_CLASS,
+        map_scale=map_scale,
+        dataclass=MinWidth,
+    )
+
+    return scale_parameters.features[target]
+
+
+def get_min_area(
+    map_scale: str,
+    target: str,
+) -> int:
+    """
+    Extracts the minimum area for the target land use from the parameters.yml file in the parameters folder.
+
+    Args:
+        map_scale (str): Scale for current map
+        target (str): Name of land use type to consider
+
+    Returns:
+        int: Minimum area for relevant land use type
+    """
+    scale_parameters = initialize_params(
+        params_path=PARAMS_PATH,
+        class_name=AREA_CLASS,
+        map_scale=map_scale,
+        dataclass=MinArea,
+    )
+
+    return scale_parameters.features[target]

--- a/generalization/n10/arealdekke/parameters/parameter_worker.py
+++ b/generalization/n10/arealdekke/parameters/parameter_worker.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from custom_tools.general_tools.param_utils import initialize_params
 from generalization.n10.arealdekke.parameters.parameter_dataclasses import (
+    EliminateSmallPolygonsParameters,
+    GangSykkelDissolverParameters,
     MinArea,
     MinWidth,
 )
@@ -17,6 +19,13 @@ PARAMS_PATH = Path(__file__).parent.parent / "parameters" / "parameters.yml"
 AREA_CLASS = "MinArea"
 WIDTH_CLASS = "MinWidth"
 
+MAPPING = {
+    "EliminateSmallPolygons": EliminateSmallPolygonsParameters,
+    "GangSykkelDissolver": GangSykkelDissolverParameters,
+}
+
+PARAMETERTYPE = EliminateSmallPolygonsParameters | GangSykkelDissolverParameters
+
 
 # ========================
 # Functionality
@@ -25,17 +34,17 @@ WIDTH_CLASS = "MinWidth"
 
 def get_min_width(
     map_scale: str,
-    target: str,
-) -> int:
+    target: str = None,
+) -> int | MinWidth:
     """
     Extracts the minimum width for the target land use from the parameters.yml file in the parameters folder.
 
     Args:
         map_scale (str): Scale for current map
-        target (str): Name of land use type to consider
+        target (str, optional): Name of land use type to consider. Defaults to None
 
     Returns:
-        int: Minimum width for relevant land use type
+        int | MinWidth: Minimum width for relevant land use type
     """
     scale_parameters = initialize_params(
         params_path=PARAMS_PATH,
@@ -43,23 +52,24 @@ def get_min_width(
         map_scale=map_scale,
         dataclass=MinWidth,
     )
-
-    return scale_parameters.features[target]
+    if target:
+        return scale_parameters.features[target]
+    return scale_parameters
 
 
 def get_min_area(
     map_scale: str,
-    target: str,
-) -> int:
+    target: str = None,
+) -> int | MinArea:
     """
     Extracts the minimum area for the target land use from the parameters.yml file in the parameters folder.
 
     Args:
         map_scale (str): Scale for current map
-        target (str): Name of land use type to consider
+        target (str, optional): Name of land use type to consider. Defaults to None
 
     Returns:
-        int: Minimum area for relevant land use type
+        int | MinArea: Minimum area for relevant land use type
     """
     scale_parameters = initialize_params(
         params_path=PARAMS_PATH,
@@ -67,5 +77,27 @@ def get_min_area(
         map_scale=map_scale,
         dataclass=MinArea,
     )
+    if target:
+        return scale_parameters.features[target]
+    return scale_parameters
 
-    return scale_parameters.features[target]
+
+def initialize_parameters(map_scale: str, class_name: str) -> PARAMETERTYPE:
+    """
+    Initializes parameter objects from the parameters.yml file.
+
+    Args:
+        map_scale (str): Scale for the current map
+        class_name (str): Name of the parameter class to initialize
+
+    Returns:
+        Parameter dataclass instance:
+            Initialized parameter object for the specified class and map scale
+    """
+    scale_parameters = initialize_params(
+        params_path=PARAMS_PATH,
+        class_name=class_name,
+        map_scale=map_scale,
+        dataclass=MAPPING[class_name],
+    )
+    return scale_parameters

--- a/generalization/n10/arealdekke/parameters/parameters.yml
+++ b/generalization/n10/arealdekke/parameters/parameters.yml
@@ -3,106 +3,43 @@ Description:
   Each object should correspond to a dataclass in parameter_dataclasses.py
   Read these from class using initialize_params from param_utils.py  
 
-EliminateSmallPolygons:
-  descriptions: 
-    - eliminates all polygons with smaller areas than min_area
-    - eliminates areas smaller than both max_area_b_iq and min_iq_area,
-    - min_iq_area is area * isoperimetric quotient 
-    - max_area_b_iq is max size of polygon that can be eliminated if they have very low iq
-    - exclude is a list of arealdekke values that are not to be eliminated or eliminated into, including spikes
-    - dont_eliminate is list of arealdekke values that wont be eliminated but can still have others eliminated into them
-    - spike_size is size of buffer to detect spikes in meters, buffers from both sides of polygon so spike_size 2 = 4 meters
-    - dont_remove_spikes is list of arealdekke values wont be buffered for spike selection
-    - integrate_tolerance is cluster tolerance in meters on integrate run in the end to fix small holes
-
+MinArea:
+  Description:
+    - Minimum values for area of polygons in square meters
+    - Polygons smaller than this will be eliminated or changed
+  
   N10:
-    min_area: 
-      Snaumark: 225
-      Grøntområde: 900
-      Skog: 225
-      Jordbruk: 2500
-      Innmarksbeite: 2500
-      GravUrnelund: 900
-      Parkering: 900
-      Park: 900
-      Alpinbakke: 900
-      Golfbane: 900
-      IdrettsOmr: 900
-      Industri: 900
-      Bergverk: 900
-      LufthavnOmr: 2500
-      Tekniskanlegg: 2500
-      Bebygd: 4900
-      Høyblokkbebyggelse: 4900
-      Innsjo: 100
-      InnsjoRegulert: 100
-      Snøisbre: 3600
-      Myr: 225
-      
+    features: {
+      "Snaumark": 225,
+      "Grøntområde": 900,
+      "Skog": 225,
+      "Jordbruk": 2500,
+      "Innmarksbeite": 2500,
+      "GravUrnelund": 900,
+      "Parkering": 900,
+      "Park": 900,
+      "Alpinbakke": 900,
+      "Golfbane": 900,
+      "IdrettsOmr": 900,
+      "Industri": 900,
+      "Bergverk": 900,
+      "LufthavnOmr": 2500,
+      "Tekniskanlegg": 2500,
+      "Bebygd": 4900,
+      "Høyblokkbebyggelse": 4900,
+      "Innsjo": 100,
+      "InnsjoRegulert": 100,
+      "Snøisbre": 3600,
+      "Myr": 225,
+    }
 
-    min_iq_area: 150   
-    max_area_b_iq: 1500 
-    exclude: 
-      - Samferdsel
-      - Bane
-    dont_eliminate:
-      - Samferdsel
-      - ElvFlate
-      - Kanal
-      - Hav
-      - Bane
-      - Høyblokkbebyggelse
-    spike_size: 3
-    dont_remove_spikes:
-      - Samferdsel
-      - ElvFlate
-      - Kanal
-      - Hav
-      - InnsjoRegulert
-      - Innsjo
-      - Bane
-    integrate_tolerance: 0.09
-
-
-
-  N100:
-    min_area: 0000
-    min_iq_area: 000         
-    dont_eliminate:
-      - Eksempel
-      - Eksempel
-      - Eksempel
-    spike_size: 0
-    dont_remove_spikes:
-      - Eksempel
-      - Eksempel
-      - Eksempel
-      - Eksempel
-      - Eksempel
-    integrate_tolerance: 0.0
-
-
-GangSykkelDissolver:
-  description:
-    - buffer distance is size of buffer that iterates out from roads to absorb gangvei
-    - length divide is length we use to decide if gangvei is adjecent to road or if they move out from road
+MinWidth:
+  Description:
+    - Minimum values for width of polygons in meters
+    - Polygon segments smaller than this will be expanded or reduced to line format
+  
   N10:
-    buffer_distance: 5
-    length_divide: 45
-
-
-LandUse:
-  description:
-    - Each variable is the minimum width (in meters) of the land use type that is visible on a printed map
-  N10:
-    elvFlate: {"width": 6, "thin": True}
-
-
-BuffSmallPolygonSegments:
-  description:
-    - Buffs parts of polygons that are below a specified minimum value.
-  N10:
-    min_width: {
+    features: {
       "Alpinbakke": 6,
       "Bebygd": 10,
       "Bergverk": 6,
@@ -127,13 +64,50 @@ BuffSmallPolygonSegments:
       "Skog": 6,
       "Snaumark": 6,
       "Snøisbre": 20,
-      "TekniskAnlegg": 6
+      "TekniskAnlegg": 6,
     }
 
-
-SmallFeatures:
-  description:
-    - Changes attributes of small features to look more like the actual terrain
-    - Minimum areas for each category
+EliminateSmallPolygons:
+  Description: 
+    - Eliminates all polygons with smaller areas than min_area
+    - Eliminates areas smaller than both max_area_b_iq and min_iq_area,
+    - Min_iq_area = area * isoperimetric quotient 
+    - Max_area_b_iq = max size of polygon that can be eliminated if they have very low iq
+    - Exclude is a list of arealdekke values that are not to be eliminated or eliminated into, including spikes
+    - Dont_eliminate is list of arealdekke values that wont be eliminated but can still have others eliminated into them
+    - Spike_size is size of buffer to detect spikes in meters, buffers from both sides of polygon so spike_size 2 = 4 meters
+    - Dont_remove_spikes is list of arealdekke values wont be buffered for spike selection
+    - Integrate_tolerance is cluster tolerance in meters on integrate run in the end to fix small holes
+  
   N10:
-    Bebygd: 4900
+    min_iq_area: 150   
+    max_area_b_iq: 1500 
+    exclude: 
+      - Samferdsel
+      - Bane
+    dont_eliminate:
+      - Samferdsel
+      - ElvFlate
+      - Kanal
+      - Hav
+      - Bane
+      - Høyblokkbebyggelse
+    spike_size: 3
+    dont_remove_spikes:
+      - Samferdsel
+      - ElvFlate
+      - Kanal
+      - Hav
+      - InnsjoRegulert
+      - Innsjo
+      - Bane
+    integrate_tolerance: 0.09
+
+GangSykkelDissolver:
+  Description:
+    - Buffer distance = size of buffer that iterates out from roads to absorb gangvei
+    - Length divide = length we use to decide if gangvei is adjecent to road or if they move out from road
+  
+  N10:
+    buffer_distance: 5
+    length_divide: 45


### PR DESCRIPTION
This PR solves the following:

- The parameter functionality is reorganized
- More functionality is isolated to smaller instances
- Buffer thin areas is adjusted
- Rivers / 'ElvFlate' is now shifting (without cleanup) between polygon and line representation depending on the minimum width criteria
- This functionality can easily be added to more features as well, if needed